### PR TITLE
替换 TypeCode 为 RecordDataType

### DIFF
--- a/src/LuYao.Common/Data/Helpers.cs
+++ b/src/LuYao.Common/Data/Helpers.cs
@@ -5,89 +5,67 @@ namespace LuYao.Data;
 
 internal static class Helpers
 {
-    public static IEnumerable<TypeCode> ListTypeCode()
+    public static IEnumerable<RecordDataType> ListTypeCode()
     {
-        yield return TypeCode.Boolean;
-        yield return TypeCode.Byte;
-        yield return TypeCode.Char;
-        yield return TypeCode.DateTime;
-        yield return TypeCode.Decimal;
-        yield return TypeCode.Double;
-        yield return TypeCode.Int16;
-        yield return TypeCode.Int32;
-        yield return TypeCode.Int64;
-        yield return TypeCode.SByte;
-        yield return TypeCode.Single;
-        yield return TypeCode.String;
-        yield return TypeCode.UInt16;
-        yield return TypeCode.UInt32;
-        yield return TypeCode.UInt64;
-    }
-    public static bool IsExists(TypeCode type)
-    {
-        return type switch
-        {
-            TypeCode.Boolean => true,
-            TypeCode.Byte => true,
-            TypeCode.Char => true,
-            TypeCode.DateTime => true,
-            TypeCode.Decimal => true,
-            TypeCode.Double => true,
-            TypeCode.Int16 => true,
-            TypeCode.Int32 => true,
-            TypeCode.Int64 => true,
-            TypeCode.SByte => true,
-            TypeCode.Single => true,
-            TypeCode.String => true,
-            TypeCode.UInt16 => true,
-            TypeCode.UInt32 => true,
-            TypeCode.UInt64 => true,
-            _ => false
-        };
+        yield return RecordDataType.Boolean;
+        yield return RecordDataType.Byte;
+        yield return RecordDataType.Char;
+        yield return RecordDataType.DateTime;
+        yield return RecordDataType.Decimal;
+        yield return RecordDataType.Double;
+        yield return RecordDataType.Int16;
+        yield return RecordDataType.Int32;
+        yield return RecordDataType.Int64;
+        yield return RecordDataType.SByte;
+        yield return RecordDataType.Single;
+        yield return RecordDataType.String;
+        yield return RecordDataType.UInt16;
+        yield return RecordDataType.UInt32;
+        yield return RecordDataType.UInt64;
     }
 
-    public static Type ToType(TypeCode type)
+    public static Type ToType(RecordDataType type)
     {
         return type switch
         {
-            TypeCode.Boolean => typeof(bool),
-            TypeCode.Byte => typeof(byte),
-            TypeCode.Char => typeof(char),
-            TypeCode.DateTime => typeof(DateTime),
-            TypeCode.Decimal => typeof(decimal),
-            TypeCode.Double => typeof(double),
-            TypeCode.Int16 => typeof(short),
-            TypeCode.Int32 => typeof(int),
-            TypeCode.Int64 => typeof(long),
-            TypeCode.SByte => typeof(sbyte),
-            TypeCode.Single => typeof(float),
-            TypeCode.String => typeof(string),
-            TypeCode.UInt16 => typeof(ushort),
-            TypeCode.UInt32 => typeof(uint),
-            TypeCode.UInt64 => typeof(ulong),
+            RecordDataType.Boolean => typeof(bool),
+            RecordDataType.Byte => typeof(byte),
+            RecordDataType.Char => typeof(char),
+            RecordDataType.DateTime => typeof(DateTime),
+            RecordDataType.Decimal => typeof(decimal),
+            RecordDataType.Double => typeof(double),
+            RecordDataType.Int16 => typeof(short),
+            RecordDataType.Int32 => typeof(int),
+            RecordDataType.Int64 => typeof(long),
+            RecordDataType.SByte => typeof(sbyte),
+            RecordDataType.Single => typeof(float),
+            RecordDataType.String => typeof(string),
+            RecordDataType.UInt16 => typeof(ushort),
+            RecordDataType.UInt32 => typeof(uint),
+            RecordDataType.UInt64 => typeof(ulong),
             _ => throw new NotSupportedException()
         };
     }
 
-    public static ColumnData MakeData(TypeCode type, int capacity)
+    public static ColumnData MakeData(RecordDataType type, int capacity)
     {
         return type switch
         {
-            TypeCode.Boolean => new BooleanColumnData(capacity),
-            TypeCode.Byte => new ByteColumnData(capacity),
-            TypeCode.Char => new CharColumnData(capacity),
-            TypeCode.DateTime => new DateTimeColumnData(capacity),
-            TypeCode.Decimal => new DecimalColumnData(capacity),
-            TypeCode.Double => new DoubleColumnData(capacity),
-            TypeCode.Int16 => new Int16ColumnData(capacity),
-            TypeCode.Int32 => new Int32ColumnData(capacity),
-            TypeCode.Int64 => new Int64ColumnData(capacity),
-            TypeCode.SByte => new SByteColumnData(capacity),
-            TypeCode.Single => new SingleColumnData(capacity),
-            TypeCode.String => new StringColumnData(capacity),
-            TypeCode.UInt16 => new UInt16ColumnData(capacity),
-            TypeCode.UInt32 => new UInt32ColumnData(capacity),
-            TypeCode.UInt64 => new UInt64ColumnData(capacity),
+            RecordDataType.Boolean => new BooleanColumnData(capacity),
+            RecordDataType.Byte => new ByteColumnData(capacity),
+            RecordDataType.Char => new CharColumnData(capacity),
+            RecordDataType.DateTime => new DateTimeColumnData(capacity),
+            RecordDataType.Decimal => new DecimalColumnData(capacity),
+            RecordDataType.Double => new DoubleColumnData(capacity),
+            RecordDataType.Int16 => new Int16ColumnData(capacity),
+            RecordDataType.Int32 => new Int32ColumnData(capacity),
+            RecordDataType.Int64 => new Int64ColumnData(capacity),
+            RecordDataType.SByte => new SByteColumnData(capacity),
+            RecordDataType.Single => new SingleColumnData(capacity),
+            RecordDataType.String => new StringColumnData(capacity),
+            RecordDataType.UInt16 => new UInt16ColumnData(capacity),
+            RecordDataType.UInt32 => new UInt32ColumnData(capacity),
+            RecordDataType.UInt64 => new UInt64ColumnData(capacity),
             _ => throw new NotSupportedException()
         };
     }

--- a/src/LuYao.Common/Data/Helpers.cs
+++ b/src/LuYao.Common/Data/Helpers.cs
@@ -5,25 +5,6 @@ namespace LuYao.Data;
 
 internal static class Helpers
 {
-    public static IEnumerable<RecordDataType> ListTypeCode()
-    {
-        yield return RecordDataType.Boolean;
-        yield return RecordDataType.Byte;
-        yield return RecordDataType.Char;
-        yield return RecordDataType.DateTime;
-        yield return RecordDataType.Decimal;
-        yield return RecordDataType.Double;
-        yield return RecordDataType.Int16;
-        yield return RecordDataType.Int32;
-        yield return RecordDataType.Int64;
-        yield return RecordDataType.SByte;
-        yield return RecordDataType.Single;
-        yield return RecordDataType.String;
-        yield return RecordDataType.UInt16;
-        yield return RecordDataType.UInt32;
-        yield return RecordDataType.UInt64;
-    }
-
     public static Type ToType(RecordDataType type)
     {
         return type switch

--- a/src/LuYao.Common/Data/Record.ReadWrite.cs
+++ b/src/LuYao.Common/Data/Record.ReadWrite.cs
@@ -32,21 +32,21 @@ partial class Record
             {
                 switch (col.Code)
                 {
-                    case TypeCode.Boolean: writer.Write(col.Data.ToBoolean(r)); break;
-                    case TypeCode.Byte: writer.Write(col.Data.ToByte(r)); break;
-                    case TypeCode.Char: writer.Write(col.Data.ToChar(r)); break;
-                    case TypeCode.DateTime: writer.Write(col.Data.ToInt64(r)); break;
-                    case TypeCode.Decimal: writer.Write(col.Data.ToDecimal(r)); break;
-                    case TypeCode.Double: writer.Write(col.Data.ToDouble(r)); break;
-                    case TypeCode.Int16: writer.Write(col.Data.ToInt16(r)); break;
-                    case TypeCode.Int32: writer.Write(col.Data.ToInt32(r)); break;
-                    case TypeCode.Int64: writer.Write(col.Data.ToInt64(r)); break;
-                    case TypeCode.SByte: writer.Write(col.Data.ToSByte(r)); break;
-                    case TypeCode.Single: writer.Write(col.Data.ToSingle(r)); break;
-                    case TypeCode.String: writer.Write(col.Data.ToString(r)); break;
-                    case TypeCode.UInt16: writer.Write(col.Data.ToUInt16(r)); break;
-                    case TypeCode.UInt32: writer.Write(col.Data.ToUInt32(r)); break;
-                    case TypeCode.UInt64: writer.Write(col.Data.ToUInt64(r)); break;
+                    case RecordDataType.Boolean: writer.Write(col.Data.ToBoolean(r)); break;
+                    case RecordDataType.Byte: writer.Write(col.Data.ToByte(r)); break;
+                    case RecordDataType.Char: writer.Write(col.Data.ToChar(r)); break;
+                    case RecordDataType.DateTime: writer.Write(col.Data.ToInt64(r)); break;
+                    case RecordDataType.Decimal: writer.Write(col.Data.ToDecimal(r)); break;
+                    case RecordDataType.Double: writer.Write(col.Data.ToDouble(r)); break;
+                    case RecordDataType.Int16: writer.Write(col.Data.ToInt16(r)); break;
+                    case RecordDataType.Int32: writer.Write(col.Data.ToInt32(r)); break;
+                    case RecordDataType.Int64: writer.Write(col.Data.ToInt64(r)); break;
+                    case RecordDataType.SByte: writer.Write(col.Data.ToSByte(r)); break;
+                    case RecordDataType.Single: writer.Write(col.Data.ToSingle(r)); break;
+                    case RecordDataType.String: writer.Write(col.Data.ToString(r)); break;
+                    case RecordDataType.UInt16: writer.Write(col.Data.ToUInt16(r)); break;
+                    case RecordDataType.UInt32: writer.Write(col.Data.ToUInt32(r)); break;
+                    case RecordDataType.UInt64: writer.Write(col.Data.ToUInt64(r)); break;
                 }
             }
         }
@@ -69,7 +69,7 @@ partial class Record
         for (int i = 0; i < header.Columns; i++)
         {
             string n = reader.ReadString();
-            TypeCode code = (TypeCode)reader.ReadByte();
+            RecordDataType code = (RecordDataType)reader.ReadByte();
             string ext = reader.ReadString(); //读取扩展信息（目前为空）
             this.Columns.Add(n, code);
         }
@@ -81,75 +81,21 @@ partial class Record
             {
                 switch (col.Code)
                 {
-                    case TypeCode.Boolean: col.Data.Set(reader.ReadBoolean(), r); break;
-                    case TypeCode.Byte: col.Data.Set(reader.ReadByte(), r); break;
-                    case TypeCode.Char: col.Data.Set(reader.ReadChar(), r); break;
-                    case TypeCode.DateTime: col.Data.Set(reader.ReadInt64(), r); break;
-                    case TypeCode.Decimal: col.Data.Set(reader.ReadDecimal(), r); break;
-                    case TypeCode.Double: col.Data.Set(reader.ReadDouble(), r); break;
-                    case TypeCode.Int16: col.Data.Set(reader.ReadInt16(), r); break;
-                    case TypeCode.Int32: col.Data.Set(reader.ReadInt32(), r); break;
-                    case TypeCode.Int64: col.Data.Set(reader.ReadInt64(), r); break;
-                    case TypeCode.SByte: col.Data.Set(reader.ReadSByte(), r); break;
-                    case TypeCode.Single: col.Data.Set(reader.ReadSingle(), r); break;
-                    case TypeCode.String: col.Data.Set(reader.ReadString(), r); break;
-                    case TypeCode.UInt16: col.Data.Set(reader.ReadUInt16(), r); break;
-                    case TypeCode.UInt32: col.Data.Set(reader.ReadUInt32(), r); break;
-                    case TypeCode.UInt64: col.Data.Set(reader.ReadUInt64(), r); break;
-                }
-            }
-        }
-    }
-
-
-
-    /// <summary>
-    /// 从指定的 <see cref="DbDataReader"/> 读取数据并填充到当前 <see cref="Record"/> 实例。
-    /// </summary>
-    /// <param name="reader">用于读取数据的 <see cref="DbDataReader"/> 实例。</param>
-    public void Read(DbDataReader reader)
-    {
-        RecordColumn[] columns = new RecordColumn[reader.FieldCount];
-        for (int i = 0; i < reader.FieldCount; i++)
-        {
-            string name = reader.GetName(i);
-            Type type = reader.GetFieldType(i);
-            TypeCode code = Type.GetTypeCode(type);
-            if (Helpers.IsExists(code)) continue;
-            int idx = this.Columns.IndexOf(name);
-            if (idx >= 0)
-            {
-                columns[i] = this.Columns[idx];
-            }
-            else
-            {
-                columns[i] = this.Columns.Add(name, code);
-            }
-        }
-        while (reader.Read())
-        {
-            var row = this.AddRow();
-            for (int i = 0; i < columns.Length; i++)
-            {
-                RecordColumn? col = columns[i];
-                if (col == null) continue;
-                switch (col.Code)
-                {
-                    case TypeCode.Boolean: row.Set(reader.GetBoolean(i), col); break;
-                    case TypeCode.Byte: row.Set(reader.GetByte(i), col); break;
-                    case TypeCode.Char: row.Set(reader.GetChar(i), col); break;
-                    case TypeCode.DateTime: row.Set(reader.GetDateTime(i), col); break;
-                    case TypeCode.Decimal: row.Set(reader.GetDecimal(i), col); break;
-                    case TypeCode.Double: row.Set(reader.GetDouble(i), col); break;
-                    case TypeCode.Int16: row.Set(reader.GetInt16(i), col); break;
-                    case TypeCode.Int32: row.Set(reader.GetInt32(i), col); break;
-                    case TypeCode.Int64: row.Set(reader.GetInt64(i), col); break;
-                    case TypeCode.SByte: row.SetValue(reader.GetValue(i), col); break;
-                    case TypeCode.Single: row.Set(reader.GetFloat(i), col); break;
-                    case TypeCode.String: row.Set(reader.GetString(i), col); break;
-                    case TypeCode.UInt16: row.SetValue(reader.GetValue(i), col); break;
-                    case TypeCode.UInt32: row.SetValue(reader.GetValue(i), col); break;
-                    case TypeCode.UInt64: row.SetValue(reader.GetValue(i), col); break;
+                    case RecordDataType.Boolean: col.Data.Set(reader.ReadBoolean(), r); break;
+                    case RecordDataType.Byte: col.Data.Set(reader.ReadByte(), r); break;
+                    case RecordDataType.Char: col.Data.Set(reader.ReadChar(), r); break;
+                    case RecordDataType.DateTime: col.Data.Set(reader.ReadInt64(), r); break;
+                    case RecordDataType.Decimal: col.Data.Set(reader.ReadDecimal(), r); break;
+                    case RecordDataType.Double: col.Data.Set(reader.ReadDouble(), r); break;
+                    case RecordDataType.Int16: col.Data.Set(reader.ReadInt16(), r); break;
+                    case RecordDataType.Int32: col.Data.Set(reader.ReadInt32(), r); break;
+                    case RecordDataType.Int64: col.Data.Set(reader.ReadInt64(), r); break;
+                    case RecordDataType.SByte: col.Data.Set(reader.ReadSByte(), r); break;
+                    case RecordDataType.Single: col.Data.Set(reader.ReadSingle(), r); break;
+                    case RecordDataType.String: col.Data.Set(reader.ReadString(), r); break;
+                    case RecordDataType.UInt16: col.Data.Set(reader.ReadUInt16(), r); break;
+                    case RecordDataType.UInt32: col.Data.Set(reader.ReadUInt32(), r); break;
+                    case RecordDataType.UInt64: col.Data.Set(reader.ReadUInt64(), r); break;
                 }
             }
         }

--- a/src/LuYao.Common/Data/Record.ReadWrite.cs
+++ b/src/LuYao.Common/Data/Record.ReadWrite.cs
@@ -69,7 +69,9 @@ partial class Record
         for (int i = 0; i < header.Columns; i++)
         {
             string n = reader.ReadString();
-            RecordDataType code = (RecordDataType)reader.ReadByte();
+            byte codeValue = reader.ReadByte();
+            if (!Enum.IsDefined(typeof(RecordDataType), codeValue)) throw new InvalidDataException($"Invalid RecordDataType value: {codeValue}");
+            RecordDataType code = (RecordDataType)codeValue;
             string ext = reader.ReadString(); //读取扩展信息（目前为空）
             this.Columns.Add(n, code);
         }

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -24,7 +24,7 @@ public sealed partial class RecordColumn
     /// <param name="code">列的数据类型。</param>
     /// <param name="capacity">列的初始容量，默认为 60。</param>
     /// <exception cref="ArgumentNullException">当 <paramref name="name"/> 为 null 时抛出。</exception>
-    public RecordColumn(Record table, string name, TypeCode code, int capacity)
+    public RecordColumn(Record table, string name, RecordDataType code, int capacity)
     {
         if (table == null) throw new ArgumentNullException(nameof(table), "表不能为空");
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name), "列的名称不能为空或空白");
@@ -46,7 +46,7 @@ public sealed partial class RecordColumn
     /// <summary>
     /// 获取列的数据类型。
     /// </summary>
-    public TypeCode Code { get; }
+    public RecordDataType Code { get; }
 
     /// <summary>
     /// 获取列的实际数据类型。

--- a/src/LuYao.Common/Data/RecordColumnCollection.cs
+++ b/src/LuYao.Common/Data/RecordColumnCollection.cs
@@ -76,7 +76,7 @@ public class RecordColumnCollection : IReadOnlyList<RecordColumn>
     /// <param name="type"></param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
-    public RecordColumn Add(string name, TypeCode type)
+    public RecordColumn Add(string name, RecordDataType type)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name), "列名不能为空");
         RecordColumn? col = this.Find(name);
@@ -87,49 +87,49 @@ public class RecordColumnCollection : IReadOnlyList<RecordColumn>
     }
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddBoolean(string name) => this.Add(name, TypeCode.Boolean);
+    public RecordColumn AddBoolean(string name) => this.Add(name, RecordDataType.Boolean);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddByte(string name) => this.Add(name, TypeCode.Byte);
+    public RecordColumn AddByte(string name) => this.Add(name, RecordDataType.Byte);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddChar(string name) => this.Add(name, TypeCode.Char);
+    public RecordColumn AddChar(string name) => this.Add(name, RecordDataType.Char);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddDateTime(string name) => this.Add(name, TypeCode.DateTime);
+    public RecordColumn AddDateTime(string name) => this.Add(name, RecordDataType.DateTime);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddDecimal(string name) => this.Add(name, TypeCode.Decimal);
+    public RecordColumn AddDecimal(string name) => this.Add(name, RecordDataType.Decimal);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddDouble(string name) => this.Add(name, TypeCode.Double);
+    public RecordColumn AddDouble(string name) => this.Add(name, RecordDataType.Double);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddInt16(string name) => this.Add(name, TypeCode.Int16);
+    public RecordColumn AddInt16(string name) => this.Add(name, RecordDataType.Int16);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddInt32(string name) => this.Add(name, TypeCode.Int32);
+    public RecordColumn AddInt32(string name) => this.Add(name, RecordDataType.Int32);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddInt64(string name) => this.Add(name, TypeCode.Int64);
+    public RecordColumn AddInt64(string name) => this.Add(name, RecordDataType.Int64);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddSByte(string name) => this.Add(name, TypeCode.SByte);
+    public RecordColumn AddSByte(string name) => this.Add(name, RecordDataType.SByte);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddSingle(string name) => this.Add(name, TypeCode.Single);
+    public RecordColumn AddSingle(string name) => this.Add(name, RecordDataType.Single);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddString(string name) => this.Add(name, TypeCode.String);
+    public RecordColumn AddString(string name) => this.Add(name, RecordDataType.String);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddUInt16(string name) => this.Add(name, TypeCode.UInt16);
+    public RecordColumn AddUInt16(string name) => this.Add(name, RecordDataType.UInt16);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddUInt32(string name) => this.Add(name, TypeCode.UInt32);
+    public RecordColumn AddUInt32(string name) => this.Add(name, RecordDataType.UInt32);
 
     /// <summary>添加数据列</summary>
-    public RecordColumn AddUInt64(string name) => this.Add(name, TypeCode.UInt64);
+    public RecordColumn AddUInt64(string name) => this.Add(name, RecordDataType.UInt64);
     #endregion
 
     /// <summary>

--- a/src/LuYao.Common/Data/RecordDataType.cs
+++ b/src/LuYao.Common/Data/RecordDataType.cs
@@ -5,7 +5,7 @@ namespace LuYao.Data;
 /// <summary>
 /// 表示记录数据类型的代码，映射到 <see cref="TypeCode"/> 枚举。
 /// </summary>
-public enum RecordDataTypeCode
+public enum RecordDataType
 {
     /// <summary>
     /// 布尔类型。对应 <see cref="TypeCode.Boolean"/>

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -27,8 +27,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add("Id", TypeCode.Int32);
-        var colName = table.Columns.Add("Name", TypeCode.String);
+        var colId = table.Columns.Add("Id", RecordDataType.Int32);
+        var colName = table.Columns.Add("Name", RecordDataType.String);
 
         // Act
         var row = table.AddRow();
@@ -60,9 +60,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add("Id", TypeCode.Int32);
-        var colName = table.Columns.Add("Name", TypeCode.String);
-        var colAge = table.Columns.Add("Age", TypeCode.Int32);
+        var colId = table.Columns.Add("Id", RecordDataType.Int32);
+        var colName = table.Columns.Add("Name", RecordDataType.String);
+        var colAge = table.Columns.Add("Age", RecordDataType.Int32);
 
         // Act
         var row1 = table.AddRow();
@@ -93,8 +93,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        table.Columns.Add("Id", TypeCode.Int32);
-        table.Columns.Add("Name", TypeCode.String);
+        table.Columns.Add("Id", RecordDataType.Int32);
+        table.Columns.Add("Name", RecordDataType.String);
         table.AddRow();
 
         // Act
@@ -111,8 +111,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add("Id", TypeCode.Int32);
-        var colName = table.Columns.Add("Name", TypeCode.String);
+        var colId = table.Columns.Add("Id", RecordDataType.Int32);
+        var colName = table.Columns.Add("Name", RecordDataType.String);
         var row = table.AddRow();
         row.Set(123, colId);
         row.Set("TestValue", colName);
@@ -127,8 +127,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        table.Columns.Add("Id", TypeCode.Int32);
-        table.Columns.Add("Name", TypeCode.String);
+        table.Columns.Add("Id", RecordDataType.Int32);
+        table.Columns.Add("Name", RecordDataType.String);
 
         // Act & Assert
         Assert.IsTrue(table.Contains("Id"));
@@ -163,7 +163,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add("Id", TypeCode.Int32);
+        var colId = table.Columns.Add("Id", RecordDataType.Int32);
         table.AddRow();
         table.AddRow();
         table.SetValue("Id", 0, 10);
@@ -197,7 +197,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add("Id", TypeCode.Int32);
+        var colId = table.Columns.Add("Id", RecordDataType.Int32);
         table.AddRow();
         table.AddRow();
         table.AddRow();
@@ -227,15 +227,15 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colBool = table.Columns.Add("Bool", TypeCode.Boolean);
-        var colByte = table.Columns.Add("Byte", TypeCode.Byte);
-        var colDateTime = table.Columns.Add("DateTime", TypeCode.DateTime);
-        var colDecimal = table.Columns.Add("Decimal", TypeCode.Decimal);
-        var colDouble = table.Columns.Add("Double", TypeCode.Double);
-        var colInt16 = table.Columns.Add("Int16", TypeCode.Int16);
-        var colInt32 = table.Columns.Add("Int32", TypeCode.Int32);
-        var colInt64 = table.Columns.Add("Int64", TypeCode.Int64);
-        var colString = table.Columns.Add("String", TypeCode.String);
+        var colBool = table.Columns.Add("Bool", RecordDataType.Boolean);
+        var colByte = table.Columns.Add("Byte", RecordDataType.Byte);
+        var colDateTime = table.Columns.Add("DateTime", RecordDataType.DateTime);
+        var colDecimal = table.Columns.Add("Decimal", RecordDataType.Decimal);
+        var colDouble = table.Columns.Add("Double", RecordDataType.Double);
+        var colInt16 = table.Columns.Add("Int16", RecordDataType.Int16);
+        var colInt32 = table.Columns.Add("Int32", RecordDataType.Int32);
+        var colInt64 = table.Columns.Add("Int64", RecordDataType.Int64);
+        var colString = table.Columns.Add("String", RecordDataType.String);
 
         var row = table.AddRow();
         var testDate = new DateTime(2023, 12, 25);
@@ -284,9 +284,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colInt = table.Columns.Add("Int", TypeCode.Int32);
-        var colString = table.Columns.Add("String", TypeCode.String);
-        var colBool = table.Columns.Add("Bool", TypeCode.Boolean);
+        var colInt = table.Columns.Add("Int", RecordDataType.Int32);
+        var colString = table.Columns.Add("String", RecordDataType.String);
+        var colBool = table.Columns.Add("Bool", RecordDataType.Boolean);
         var row = table.AddRow();
 
         // Act & Assert
@@ -326,8 +326,8 @@ public class RecordTests
         var table = new Record();
 
         // Act
-        var col1 = table.Columns.Add("TestColumn", TypeCode.String);
-        var col2 = table.Columns.Add("TestColumn", TypeCode.String);
+        var col1 = table.Columns.Add("TestColumn", RecordDataType.String);
+        var col2 = table.Columns.Add("TestColumn", RecordDataType.String);
 
         // Assert
         Assert.AreSame(col1, col2);
@@ -339,7 +339,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var originalCol = table.Columns.Add("TestColumn", TypeCode.Int32);
+        var originalCol = table.Columns.Add("TestColumn", RecordDataType.Int32);
 
         // Act
         var foundCol = table.Columns.Find("TestColumn");
@@ -354,7 +354,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        table.Columns.Add("TestColumn", TypeCode.Int32);
+        table.Columns.Add("TestColumn", RecordDataType.Int32);
 
         // Act
         var foundCol = table.Columns.Find("NonExistent");
@@ -387,21 +387,21 @@ public class RecordTests
         var colUInt64 = table.Columns.AddUInt64("UInt64Col");
 
         // Assert
-        Assert.AreEqual(TypeCode.Boolean, colBool.Code);
-        Assert.AreEqual(TypeCode.Byte, colByte.Code);
-        Assert.AreEqual(TypeCode.Char, colChar.Code);
-        Assert.AreEqual(TypeCode.DateTime, colDateTime.Code);
-        Assert.AreEqual(TypeCode.Decimal, colDecimal.Code);
-        Assert.AreEqual(TypeCode.Double, colDouble.Code);
-        Assert.AreEqual(TypeCode.Int16, colInt16.Code);
-        Assert.AreEqual(TypeCode.Int32, colInt32.Code);
-        Assert.AreEqual(TypeCode.Int64, colInt64.Code);
-        Assert.AreEqual(TypeCode.SByte, colSByte.Code);
-        Assert.AreEqual(TypeCode.Single, colSingle.Code);
-        Assert.AreEqual(TypeCode.String, colString.Code);
-        Assert.AreEqual(TypeCode.UInt16, colUInt16.Code);
-        Assert.AreEqual(TypeCode.UInt32, colUInt32.Code);
-        Assert.AreEqual(TypeCode.UInt64, colUInt64.Code);
+        Assert.AreEqual(RecordDataType.Boolean, colBool.Code);
+        Assert.AreEqual(RecordDataType.Byte, colByte.Code);
+        Assert.AreEqual(RecordDataType.Char, colChar.Code);
+        Assert.AreEqual(RecordDataType.DateTime, colDateTime.Code);
+        Assert.AreEqual(RecordDataType.Decimal, colDecimal.Code);
+        Assert.AreEqual(RecordDataType.Double, colDouble.Code);
+        Assert.AreEqual(RecordDataType.Int16, colInt16.Code);
+        Assert.AreEqual(RecordDataType.Int32, colInt32.Code);
+        Assert.AreEqual(RecordDataType.Int64, colInt64.Code);
+        Assert.AreEqual(RecordDataType.SByte, colSByte.Code);
+        Assert.AreEqual(RecordDataType.Single, colSingle.Code);
+        Assert.AreEqual(RecordDataType.String, colString.Code);
+        Assert.AreEqual(RecordDataType.UInt16, colUInt16.Code);
+        Assert.AreEqual(RecordDataType.UInt32, colUInt32.Code);
+        Assert.AreEqual(RecordDataType.UInt64, colUInt64.Code);
         Assert.AreEqual(15, table.Columns.Count);
     }
 
@@ -410,7 +410,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col = table.Columns.Add("TestCol", TypeCode.String);
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
         var row = table.AddRow();
         row.Set("TestValue", col);
 
@@ -430,7 +430,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col = table.Columns.Add("TestColumn", TypeCode.String);
+        var col = table.Columns.Add("TestColumn", RecordDataType.String);
 
         // Act
         var result = col.ToString();
@@ -444,7 +444,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col = table.Columns.Add("TestCol", TypeCode.Int32);
+        var col = table.Columns.Add("TestCol", RecordDataType.Int32);
         var row1 = table.AddRow();
         var row2 = table.AddRow();
 
@@ -472,12 +472,12 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colChar = table.Columns.Add("Char", TypeCode.Char);
-        var colSByte = table.Columns.Add("SByte", TypeCode.SByte);
-        var colSingle = table.Columns.Add("Single", TypeCode.Single);
-        var colUInt16 = table.Columns.Add("UInt16", TypeCode.UInt16);
-        var colUInt32 = table.Columns.Add("UInt32", TypeCode.UInt32);
-        var colUInt64 = table.Columns.Add("UInt64", TypeCode.UInt64);
+        var colChar = table.Columns.Add("Char", RecordDataType.Char);
+        var colSByte = table.Columns.Add("SByte", RecordDataType.SByte);
+        var colSingle = table.Columns.Add("Single", RecordDataType.Single);
+        var colUInt16 = table.Columns.Add("UInt16", RecordDataType.UInt16);
+        var colUInt32 = table.Columns.Add("UInt32", RecordDataType.UInt32);
+        var colUInt64 = table.Columns.Add("UInt64", RecordDataType.UInt64);
 
         var row = table.AddRow();
 
@@ -506,9 +506,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        table.Columns.Add("First", TypeCode.String);
-        table.Columns.Add("Second", TypeCode.Int32);
-        table.Columns.Add("Third", TypeCode.Boolean);
+        table.Columns.Add("First", RecordDataType.String);
+        table.Columns.Add("Second", RecordDataType.Int32);
+        table.Columns.Add("Third", RecordDataType.Boolean);
 
         // Act & Assert
         Assert.AreEqual(0, table.Columns.IndexOf("First"));
@@ -522,8 +522,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col1 = table.Columns.Add("Col1", TypeCode.String);
-        var col2 = table.Columns.Add("Col2", TypeCode.Int32);
+        var col1 = table.Columns.Add("Col1", RecordDataType.String);
+        var col2 = table.Columns.Add("Col2", RecordDataType.Int32);
 
         // Act
         var removed = table.Columns.Remove(col1);
@@ -539,9 +539,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        table.Columns.Add("Col1", TypeCode.String);
-        table.Columns.Add("Col2", TypeCode.Int32);
-        table.Columns.Add("Col3", TypeCode.Boolean);
+        table.Columns.Add("Col1", RecordDataType.String);
+        table.Columns.Add("Col2", RecordDataType.Int32);
+        table.Columns.Add("Col3", RecordDataType.Boolean);
 
         // Act
         table.Columns.Clear();
@@ -555,7 +555,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col = table.Columns.Add("TestCol", TypeCode.String);
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
         var row = table.AddRow();
 
         // Act & Assert - Test null value
@@ -568,7 +568,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var intCol = table.Columns.Add("IntCol", TypeCode.Int32);
+        var intCol = table.Columns.Add("IntCol", RecordDataType.Int32);
         var row = table.AddRow();
 
         // Act - Set string value that can be converted to int
@@ -596,8 +596,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record("TestTable", 10);
-        table.Columns.Add("Col1", TypeCode.String);
-        table.Columns.Add("Col2", TypeCode.Int32);
+        table.Columns.Add("Col1", RecordDataType.String);
+        table.Columns.Add("Col2", RecordDataType.Int32);
         table.AddRow();
         table.AddRow();
 
@@ -648,7 +648,7 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col = table.Columns.Add("TestColumnName", TypeCode.String);
+        var col = table.Columns.Add("TestColumnName", RecordDataType.String);
 
         // Act & Assert
         Assert.AreEqual("TestColumnName", col.Name);
@@ -659,9 +659,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var stringCol = table.Columns.Add("StringCol", TypeCode.String);
-        var intCol = table.Columns.Add("IntCol", TypeCode.Int32);
-        var boolCol = table.Columns.Add("BoolCol", TypeCode.Boolean);
+        var stringCol = table.Columns.Add("StringCol", RecordDataType.String);
+        var intCol = table.Columns.Add("IntCol", RecordDataType.Int32);
+        var boolCol = table.Columns.Add("BoolCol", RecordDataType.Boolean);
 
         // Act & Assert
         Assert.AreEqual(typeof(string), stringCol.Type);
@@ -687,8 +687,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var col1 = table.Columns.Add("First", TypeCode.String);
-        var col2 = table.Columns.Add("Second", TypeCode.Int32);
+        var col1 = table.Columns.Add("First", RecordDataType.String);
+        var col2 = table.Columns.Add("Second", RecordDataType.Int32);
 
         // Act & Assert
         Assert.AreSame(col1, table.Columns[0]);


### PR DESCRIPTION
在多个文件中将 TypeCode 枚举替换为新的 RecordDataType 枚举，更新相关方法的参数和返回类型。涉及的文件包括 Helpers.cs、Record.ReadWrite.cs、RecordColumn.cs 和 RecordColumnCollection.cs。此外，新增了 RecordDataType 枚举以提供更清晰的类型表示，并更新了所有相关的测试用例以确保兼容性。