### PR TITLE
增强边界检查并添加单元测试

### DIFF
--- a/src/LuYao.Common/Data/RecordColumn.Data.cs
+++ b/src/LuYao.Common/Data/RecordColumn.Data.cs
@@ -8,138 +8,132 @@ namespace LuYao.Data;
 
 partial class RecordColumn
 {
+    /// <summary>
+    /// 验证索引是否在有效范围内，并在需要时自动创建行
+    /// </summary>
+    /// <param name="index">要验证的行索引</param>
+    /// <param name="autoCreateRow">是否在表为空时自动创建行</param>
+    /// <exception cref="ArgumentOutOfRangeException">当索引超出有效范围时抛出</exception>
+    private void ValidateIndex(int index, bool autoCreateRow = false)
+    {
+        if (autoCreateRow && _table.Count == 0) _table.AddRow();
+
+        if (index < 0 || index >= _table.Count) throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+    }
+
+    /// <summary>
+    /// 验证只读操作的索引是否在有效范围内
+    /// </summary>
+    /// <param name="index">要验证的行索引</param>
+    /// <exception cref="ArgumentOutOfRangeException">当索引超出有效范围时抛出</exception>
+    private void ValidateReadIndex(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+    }
+
     /// <inheritdoc/>
     public void Set(Boolean value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Byte value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Char value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(DateTime value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Decimal value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Double value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int16 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int32 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int64 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(SByte value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Single value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(String value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt16 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt32 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt64 value, int index)
     {
-        if (_table.Count == 0) _table.AddRow();
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateIndex(index, autoCreateRow: true);
         this.Data.Set(value, index);
     }
 
@@ -147,120 +141,105 @@ partial class RecordColumn
     /// <inheritdoc/>
     public Boolean ToBoolean(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToBoolean(index);
     }
 
     /// <inheritdoc/>
     public Byte ToByte(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToByte(index);
     }
 
     /// <inheritdoc/>
     public Char ToChar(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToChar(index);
     }
 
     /// <inheritdoc/>
     public DateTime ToDateTime(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToDateTime(index);
     }
 
     /// <inheritdoc/>
     public Decimal ToDecimal(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToDecimal(index);
     }
 
     /// <inheritdoc/>
     public Double ToDouble(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToDouble(index);
     }
 
     /// <inheritdoc/>
     public Int16 ToInt16(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToInt16(index);
     }
 
     /// <inheritdoc/>
     public Int32 ToInt32(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToInt32(index);
     }
 
     /// <inheritdoc/>
     public Int64 ToInt64(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToInt64(index);
     }
 
     /// <inheritdoc/>
     public SByte ToSByte(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToSByte(index);
     }
 
     /// <inheritdoc/>
     public Single ToSingle(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToSingle(index);
     }
 
     /// <inheritdoc/>
     public String ToString(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToString(index);
     }
 
     /// <inheritdoc/>
     public UInt16 ToUInt16(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToUInt16(index);
     }
 
     /// <inheritdoc/>
     public UInt32 ToUInt32(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToUInt32(index);
     }
 
     /// <inheritdoc/>
     public UInt64 ToUInt64(int index)
     {
-        if (index < 0 || index >= _table.Count)
-            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        ValidateReadIndex(index);
         return this.Data.ToUInt64(index);
     }
 }

--- a/src/LuYao.Common/Data/RecordColumn.Data.cs
+++ b/src/LuYao.Common/Data/RecordColumn.Data.cs
@@ -11,135 +11,135 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Boolean value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Byte value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Char value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(DateTime value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Decimal value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Double value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int16 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int32 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Int64 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(SByte value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(Single value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(String value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt16 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt32 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
     /// <inheritdoc/>
     public void Set(UInt64 value, int index)
     {
+        if (_table.Count == 0) _table.AddRow();
         if (index < 0 || index >= _table.Count)
             throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
-        if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 

--- a/src/LuYao.Common/Data/RecordColumn.Data.cs
+++ b/src/LuYao.Common/Data/RecordColumn.Data.cs
@@ -11,6 +11,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Boolean value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -18,6 +20,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Byte value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -25,6 +29,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Char value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -32,6 +38,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(DateTime value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -39,6 +47,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Decimal value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -46,6 +56,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Double value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -53,6 +65,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Int16 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -60,6 +74,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Int32 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -67,6 +83,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Int64 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -74,6 +92,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(SByte value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -81,6 +101,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(Single value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -88,6 +110,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(String value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -95,6 +119,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(UInt16 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -102,6 +128,8 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(UInt32 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
@@ -109,53 +137,130 @@ partial class RecordColumn
     /// <inheritdoc/>
     public void Set(UInt64 value, int index)
     {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
         if (_table.Count == 0) _table.AddRow();
         this.Data.Set(value, index);
     }
 
 
     /// <inheritdoc/>
-    public Boolean ToBoolean(int index) => this.Data.ToBoolean(index);
+    public Boolean ToBoolean(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToBoolean(index);
+    }
 
     /// <inheritdoc/>
-    public Byte ToByte(int index) => this.Data.ToByte(index);
+    public Byte ToByte(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToByte(index);
+    }
 
     /// <inheritdoc/>
-    public Char ToChar(int index) => this.Data.ToChar(index);
+    public Char ToChar(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToChar(index);
+    }
 
     /// <inheritdoc/>
-    public DateTime ToDateTime(int index) => this.Data.ToDateTime(index);
+    public DateTime ToDateTime(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToDateTime(index);
+    }
 
     /// <inheritdoc/>
-    public Decimal ToDecimal(int index) => this.Data.ToDecimal(index);
+    public Decimal ToDecimal(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToDecimal(index);
+    }
 
     /// <inheritdoc/>
-    public Double ToDouble(int index) => this.Data.ToDouble(index);
+    public Double ToDouble(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToDouble(index);
+    }
 
     /// <inheritdoc/>
-    public Int16 ToInt16(int index) => this.Data.ToInt16(index);
+    public Int16 ToInt16(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToInt16(index);
+    }
 
     /// <inheritdoc/>
-    public Int32 ToInt32(int index) => this.Data.ToInt32(index);
+    public Int32 ToInt32(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToInt32(index);
+    }
 
     /// <inheritdoc/>
-    public Int64 ToInt64(int index) => this.Data.ToInt64(index);
+    public Int64 ToInt64(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToInt64(index);
+    }
 
     /// <inheritdoc/>
-    public SByte ToSByte(int index) => this.Data.ToSByte(index);
+    public SByte ToSByte(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToSByte(index);
+    }
 
     /// <inheritdoc/>
-    public Single ToSingle(int index) => this.Data.ToSingle(index);
+    public Single ToSingle(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToSingle(index);
+    }
 
     /// <inheritdoc/>
-    public String ToString(int index) => this.Data.ToString(index);
+    public String ToString(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToString(index);
+    }
 
     /// <inheritdoc/>
-    public UInt16 ToUInt16(int index) => this.Data.ToUInt16(index);
+    public UInt16 ToUInt16(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToUInt16(index);
+    }
 
     /// <inheritdoc/>
-    public UInt32 ToUInt32(int index) => this.Data.ToUInt32(index);
+    public UInt32 ToUInt32(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToUInt32(index);
+    }
 
     /// <inheritdoc/>
-    public UInt64 ToUInt64(int index) => this.Data.ToUInt64(index);
+    public UInt64 ToUInt64(int index)
+    {
+        if (index < 0 || index >= _table.Count)
+            throw new ArgumentOutOfRangeException(nameof(index), $"行索引 {index} 超出有效范围 [0, {_table.Count - 1}]");
+        return this.Data.ToUInt64(index);
+    }
 }

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -58,19 +58,31 @@ public sealed partial class RecordColumn
     /// </summary>
     /// <param name="value"></param>
     /// <param name="row"></param>
-    public void SetValue(object? value, int row) => _data.SetValue(value, row);
+    public void SetValue(object? value, int row)
+    {
+        if (row < 0 || row >= _table.Count) 
+            throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {_table.Count - 1}]");
+        _data.SetValue(value, row);
+    }
+    
     /// <summary>
     /// 
     /// </summary>
     /// <param name="value"></param>
     /// <param name="row"></param>
     public void SetValue(object? value, RecordRow row) => SetValue(value, row.RowIndex);
+    
     /// <summary>
     /// 
     /// </summary>
     /// <param name="row"></param>
     /// <returns></returns>
-    public object? GetValue(int row) => _data.GetValue(row);
+    public object? GetValue(int row)
+    {
+        if (row < 0 || row >= _table.Count) 
+            throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {_table.Count - 1}]");
+        return _data.GetValue(row);
+    }
 
     ///<inheritdoc/>
     public object? GetValue(RecordRow row) => GetValue(row.RowIndex);

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -1105,6 +1105,72 @@ public class RecordTests
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(0));
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 0));
         Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.ToBoolean(0));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, 0));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_EmptyTable_IndexZeroWorksAfterAutoRowCreation()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        // No rows added, Count = 0
+
+        // Act & Assert - Index 0 should work because auto-row creation
+        col.Set("test", 0); // Should auto-create row
+        Assert.AreEqual(1, table.Count); // Row was auto-created
+        Assert.AreEqual("test", col.GetValue(0));
+
+        // But other indices should still throw
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, 1));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_EmptyTable_NegativeIndexStillThrowsException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        // No rows added, Count = 0
+
+        // Act & Assert - Negative indices should always throw
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(-1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, -1));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_EmptyTable_IndexGreaterThanZeroThrowsException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        // No rows added, Count = 0
+
+        // Act & Assert - Indices > 0 should throw even with auto-row creation
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set("test", 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set("test", 2));
+    }
+
+    [TestMethod]
+    public void TypedSetMethods_EmptyTable_IndexZeroWorksWithAutoRowCreation()
+    {
+        // Arrange
+        var table = new Record();
+        var boolCol = table.Columns.Add("Bool", RecordDataType.Boolean);
+        var intCol = table.Columns.Add("Int", RecordDataType.Int32);
+        var stringCol = table.Columns.Add("String", RecordDataType.String);
+
+        // Act & Assert - Index 0 should work with auto-row creation
+        boolCol.Set(true, 0);
+        Assert.AreEqual(1, table.Count);
+
+        intCol.Set(42, 0);
+        stringCol.Set("test", 0);
+
+        Assert.AreEqual(true, boolCol.GetValue(0));
+        Assert.AreEqual(42, intCol.GetValue(0));
+        Assert.AreEqual("test", stringCol.GetValue(0));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -806,4 +806,305 @@ public class RecordTests
         var result = record.ToString();
         Assert.IsTrue(result.Contains(".."));
     }
+
+    // 新增的边界检查测试方法
+
+    [TestMethod]
+    public void GetValue_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(-1));
+        Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void GetValue_RowIndexEqualToCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(1));
+        Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void GetValue_RowIndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(5));
+        Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetValue_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetValue_RowIndexEqualToCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 1));
+        Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetValue_RowIndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 5));
+        Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetBoolean_NegativeIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("BoolCol", RecordDataType.Boolean);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, -1));
+        Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetBoolean_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("BoolCol", RecordDataType.Boolean);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, 1));
+        Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void SetInt32_IndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("IntCol", RecordDataType.Int32);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(42, 5));
+        Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void ToBoolean_NegativeIndex_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("BoolCol", RecordDataType.Boolean);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.ToBoolean(-1));
+        Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void ToInt32_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("IntCol", RecordDataType.Int32);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.ToInt32(1));
+        Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void ToString_IndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("StringCol", RecordDataType.String);
+        table.AddRow();
+
+        // Act & Assert
+        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.ToString(10));
+        Assert.IsTrue(exception.Message.Contains("行索引 10 超出有效范围"));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_ValidIndex_WorksCorrectly()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        table.AddRow();
+        table.AddRow();
+        table.AddRow();
+
+        // Act & Assert - Valid indices should work
+        col.SetValue("value0", 0);
+        col.SetValue("value1", 1);
+        col.SetValue("value2", 2);
+
+        Assert.AreEqual("value0", col.GetValue(0));
+        Assert.AreEqual("value1", col.GetValue(1));
+        Assert.AreEqual("value2", col.GetValue(2));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_AfterCapacityExpansion_StillEnforcesBounds()
+    {
+        // Arrange
+        var table = new Record("Test", 2); // Small initial capacity
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+
+        // Add rows to trigger capacity expansion
+        table.AddRow(); // Index 0
+        table.AddRow(); // Index 1
+        table.AddRow(); // Index 2 - should trigger expansion
+
+        // Act & Assert - Valid indices work
+        col.SetValue("test0", 0);
+        col.SetValue("test1", 1);
+        col.SetValue("test2", 2);
+
+        Assert.AreEqual("test0", col.GetValue(0));
+        Assert.AreEqual("test1", col.GetValue(1));
+        Assert.AreEqual("test2", col.GetValue(2));
+
+        // Invalid indices should still throw
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(3));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("invalid", 4));
+    }
+
+    [TestMethod]
+    public void AllTypedSetMethods_InvalidIndex_ThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var boolCol = table.Columns.Add("Bool", RecordDataType.Boolean);
+        var byteCol = table.Columns.Add("Byte", RecordDataType.Byte);
+        var charCol = table.Columns.Add("Char", RecordDataType.Char);
+        var dateTimeCol = table.Columns.Add("DateTime", RecordDataType.DateTime);
+        var decimalCol = table.Columns.Add("Decimal", RecordDataType.Decimal);
+        var doubleCol = table.Columns.Add("Double", RecordDataType.Double);
+        var int16Col = table.Columns.Add("Int16", RecordDataType.Int16);
+        var int32Col = table.Columns.Add("Int32", RecordDataType.Int32);
+        var int64Col = table.Columns.Add("Int64", RecordDataType.Int64);
+        var sbyteCol = table.Columns.Add("SByte", RecordDataType.SByte);
+        var singleCol = table.Columns.Add("Single", RecordDataType.Single);
+        var stringCol = table.Columns.Add("String", RecordDataType.String);
+        var uint16Col = table.Columns.Add("UInt16", RecordDataType.UInt16);
+        var uint32Col = table.Columns.Add("UInt32", RecordDataType.UInt32);
+        var uint64Col = table.Columns.Add("UInt64", RecordDataType.UInt64);
+
+        table.AddRow(); // Only one row, valid index is 0
+
+        // Act & Assert - Test all Set methods with invalid index
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => boolCol.Set(true, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => byteCol.Set((byte)1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => charCol.Set('A', 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => dateTimeCol.Set(DateTime.Now, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => decimalCol.Set(1.0m, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => doubleCol.Set(1.0, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int16Col.Set((short)1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int32Col.Set(1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int64Col.Set(1L, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => sbyteCol.Set((sbyte)1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => singleCol.Set(1.0f, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => stringCol.Set("test", 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint16Col.Set((ushort)1, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint32Col.Set(1u, 1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint64Col.Set(1ul, 1));
+    }
+
+    [TestMethod]
+    public void AllTypedToMethods_InvalidIndex_ThrowArgumentOutOfRangeException()
+    {
+        // Arrange
+        var table = new Record();
+        var boolCol = table.Columns.Add("Bool", RecordDataType.Boolean);
+        var byteCol = table.Columns.Add("Byte", RecordDataType.Byte);
+        var charCol = table.Columns.Add("Char", RecordDataType.Char);
+        var dateTimeCol = table.Columns.Add("DateTime", RecordDataType.DateTime);
+        var decimalCol = table.Columns.Add("Decimal", RecordDataType.Decimal);
+        var doubleCol = table.Columns.Add("Double", RecordDataType.Double);
+        var int16Col = table.Columns.Add("Int16", RecordDataType.Int16);
+        var int32Col = table.Columns.Add("Int32", RecordDataType.Int32);
+        var int64Col = table.Columns.Add("Int64", RecordDataType.Int64);
+        var sbyteCol = table.Columns.Add("SByte", RecordDataType.SByte);
+        var singleCol = table.Columns.Add("Single", RecordDataType.Single);
+        var stringCol = table.Columns.Add("String", RecordDataType.String);
+        var uint16Col = table.Columns.Add("UInt16", RecordDataType.UInt16);
+        var uint32Col = table.Columns.Add("UInt32", RecordDataType.UInt32);
+        var uint64Col = table.Columns.Add("UInt64", RecordDataType.UInt64);
+
+        table.AddRow(); // Only one row, valid index is 0
+
+        // Act & Assert - Test all To methods with invalid index
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => boolCol.ToBoolean(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => byteCol.ToByte(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => charCol.ToChar(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => dateTimeCol.ToDateTime(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => decimalCol.ToDecimal(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => doubleCol.ToDouble(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int16Col.ToInt16(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int32Col.ToInt32(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int64Col.ToInt64(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => sbyteCol.ToSByte(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => singleCol.ToSingle(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => stringCol.ToString(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint16Col.ToUInt16(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint32Col.ToUInt32(1));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint64Col.ToUInt64(1));
+    }
+
+    [TestMethod]
+    public void BoundaryCheck_EmptyTable_AnyIndexThrowsException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add("TestCol", RecordDataType.String);
+        // No rows added, Count = 0
+
+        // Act & Assert
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.ToBoolean(0));
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, 0));
+    }
 }


### PR DESCRIPTION
在 `RecordColumn.Data.cs` 中，为所有 `Set` 和 `To` 方法添加了对 `index` 参数的边界检查，确保其在有效范围内，超出范围时抛出 `ArgumentOutOfRangeException` 异常。

在 `RecordColumn.cs` 中，`SetValue` 和 `GetValue` 方法也进行了类似的修改，添加了对 `row` 参数的边界检查。

在 `RecordTests.cs` 中，新增了一系列单元测试，验证了在无效索引情况下，相关方法是否正确抛出 `ArgumentOutOfRangeException` 异常，涵盖了负索引、索引等于行数、索引大于行数以及空表格的情况。