### PR TITLE
Generic column data

### DIFF
--- a/src/LuYao.Common/Data/ColumnData.T.cs
+++ b/src/LuYao.Common/Data/ColumnData.T.cs
@@ -2,64 +2,8 @@
 
 namespace LuYao.Data;
 
-
-#region Object
-sealed class ObjectColumnData : ColumnData<Object>
-{
-    public ObjectColumnData(int capacity) : base(capacity)
-    {
-    }
-
-    public override void Set(Boolean value, int index) => _data[index] = value;
-    public override Boolean ToBoolean(int index) => Valid.ToBoolean(this._data[index]);
-
-    public override void Set(Byte value, int index) => _data[index] = value;
-    public override Byte ToByte(int index) => Valid.ToByte(this._data[index]);
-
-    public override void Set(Char value, int index) => _data[index] = value;
-    public override Char ToChar(int index) => Valid.ToChar(this._data[index]);
-
-    public override void Set(DateTime value, int index) => _data[index] = value;
-    public override DateTime ToDateTime(int index) => Valid.ToDateTime(this._data[index]);
-
-    public override void Set(Decimal value, int index) => _data[index] = value;
-    public override Decimal ToDecimal(int index) => Valid.ToDecimal(this._data[index]);
-
-    public override void Set(Double value, int index) => _data[index] = value;
-    public override Double ToDouble(int index) => Valid.ToDouble(this._data[index]);
-
-    public override void Set(Int16 value, int index) => _data[index] = value;
-    public override Int16 ToInt16(int index) => Valid.ToInt16(this._data[index]);
-
-    public override void Set(Int32 value, int index) => _data[index] = value;
-    public override Int32 ToInt32(int index) => Valid.ToInt32(this._data[index]);
-
-    public override void Set(Int64 value, int index) => _data[index] = value;
-    public override Int64 ToInt64(int index) => Valid.ToInt64(this._data[index]);
-
-    public override void Set(SByte value, int index) => _data[index] = value;
-    public override SByte ToSByte(int index) => Valid.ToSByte(this._data[index]);
-
-    public override void Set(Single value, int index) => _data[index] = value;
-    public override Single ToSingle(int index) => Valid.ToSingle(this._data[index]);
-
-    public override void Set(String value, int index) => _data[index] = value;
-    public override String ToString(int index) => Valid.ToString(this._data[index]);
-
-    public override void Set(UInt16 value, int index) => _data[index] = value;
-    public override UInt16 ToUInt16(int index) => Valid.ToUInt16(this._data[index]);
-
-    public override void Set(UInt32 value, int index) => _data[index] = value;
-    public override UInt32 ToUInt32(int index) => Valid.ToUInt32(this._data[index]);
-
-    public override void Set(UInt64 value, int index) => _data[index] = value;
-    public override UInt64 ToUInt64(int index) => Valid.ToUInt64(this._data[index]);
-}
-
-#endregion
-
 #region Boolean
-sealed class BooleanColumnData : ColumnData<Boolean>
+sealed class BooleanColumnData : BaseColumnData<Boolean>
 {
     public BooleanColumnData(int capacity) : base(capacity) { }
 
@@ -111,7 +55,7 @@ sealed class BooleanColumnData : ColumnData<Boolean>
 #endregion
 
 #region Byte
-sealed class ByteColumnData : ColumnData<Byte>
+sealed class ByteColumnData : BaseColumnData<Byte>
 {
     public ByteColumnData(int capacity) : base(capacity) { }
 
@@ -163,7 +107,7 @@ sealed class ByteColumnData : ColumnData<Byte>
 #endregion
 
 #region Char
-sealed class CharColumnData : ColumnData<Char>
+sealed class CharColumnData : BaseColumnData<Char>
 {
     public CharColumnData(int capacity) : base(capacity) { }
 
@@ -215,7 +159,7 @@ sealed class CharColumnData : ColumnData<Char>
 #endregion
 
 #region DateTime
-sealed class DateTimeColumnData : ColumnData<DateTime>
+sealed class DateTimeColumnData : BaseColumnData<DateTime>
 {
     public DateTimeColumnData(int capacity) : base(capacity) { }
 
@@ -267,7 +211,7 @@ sealed class DateTimeColumnData : ColumnData<DateTime>
 #endregion
 
 #region Decimal
-sealed class DecimalColumnData : ColumnData<Decimal>
+sealed class DecimalColumnData : BaseColumnData<Decimal>
 {
     public DecimalColumnData(int capacity) : base(capacity) { }
 
@@ -319,7 +263,7 @@ sealed class DecimalColumnData : ColumnData<Decimal>
 #endregion
 
 #region Double
-sealed class DoubleColumnData : ColumnData<Double>
+sealed class DoubleColumnData : BaseColumnData<Double>
 {
     public DoubleColumnData(int capacity) : base(capacity) { }
 
@@ -371,7 +315,7 @@ sealed class DoubleColumnData : ColumnData<Double>
 #endregion
 
 #region Int16
-sealed class Int16ColumnData : ColumnData<Int16>
+sealed class Int16ColumnData : BaseColumnData<Int16>
 {
     public Int16ColumnData(int capacity) : base(capacity) { }
 
@@ -423,7 +367,7 @@ sealed class Int16ColumnData : ColumnData<Int16>
 #endregion
 
 #region Int32
-sealed class Int32ColumnData : ColumnData<Int32>
+sealed class Int32ColumnData : BaseColumnData<Int32>
 {
     public Int32ColumnData(int capacity) : base(capacity) { }
 
@@ -475,7 +419,7 @@ sealed class Int32ColumnData : ColumnData<Int32>
 #endregion
 
 #region Int64
-sealed class Int64ColumnData : ColumnData<Int64>
+sealed class Int64ColumnData : BaseColumnData<Int64>
 {
     public Int64ColumnData(int capacity) : base(capacity) { }
 
@@ -527,7 +471,7 @@ sealed class Int64ColumnData : ColumnData<Int64>
 #endregion
 
 #region SByte
-sealed class SByteColumnData : ColumnData<SByte>
+sealed class SByteColumnData : BaseColumnData<SByte>
 {
     public SByteColumnData(int capacity) : base(capacity) { }
 
@@ -579,7 +523,7 @@ sealed class SByteColumnData : ColumnData<SByte>
 #endregion
 
 #region Single
-sealed class SingleColumnData : ColumnData<Single>
+sealed class SingleColumnData : BaseColumnData<Single>
 {
     public SingleColumnData(int capacity) : base(capacity) { }
 
@@ -631,7 +575,7 @@ sealed class SingleColumnData : ColumnData<Single>
 #endregion
 
 #region String
-sealed class StringColumnData : ColumnData<String>
+sealed class StringColumnData : BaseColumnData<String>
 {
     public StringColumnData(int capacity) : base(capacity) { }
 
@@ -683,7 +627,7 @@ sealed class StringColumnData : ColumnData<String>
 #endregion
 
 #region UInt16
-sealed class UInt16ColumnData : ColumnData<UInt16>
+sealed class UInt16ColumnData : BaseColumnData<UInt16>
 {
     public UInt16ColumnData(int capacity) : base(capacity) { }
 
@@ -735,7 +679,7 @@ sealed class UInt16ColumnData : ColumnData<UInt16>
 #endregion
 
 #region UInt32
-sealed class UInt32ColumnData : ColumnData<UInt32>
+sealed class UInt32ColumnData : BaseColumnData<UInt32>
 {
     public UInt32ColumnData(int capacity) : base(capacity) { }
 
@@ -787,7 +731,7 @@ sealed class UInt32ColumnData : ColumnData<UInt32>
 #endregion
 
 #region UInt64
-sealed class UInt64ColumnData : ColumnData<UInt64>
+sealed class UInt64ColumnData : BaseColumnData<UInt64>
 {
     public UInt64ColumnData(int capacity) : base(capacity) { }
 

--- a/src/LuYao.Common/Data/ColumnData.cs
+++ b/src/LuYao.Common/Data/ColumnData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace LuYao.Data;
 
@@ -59,10 +60,10 @@ internal abstract class ColumnData
     public abstract TRet To<TRet>(int index);
 }
 
-internal abstract class ColumnData<T> : ColumnData
+internal abstract class BaseColumnData<T> : ColumnData
 {
     protected T[] _data;
-    public ColumnData(int capacity) => _data = new T[capacity];
+    public BaseColumnData(int capacity) => _data = new T[capacity];
 
     public override void Clear() => Array.Clear(_data, 0, _data.Length);
 
@@ -94,29 +95,135 @@ internal abstract class ColumnData<T> : ColumnData
         if (value is null) return default!;
         if (typeof(TRet) == typeof(T)) return (TRet)value;
         if (value is TRet direct) return direct;
-        return (TRet)To(value, typeof(TRet));
+        return (TRet)Valid.To(value, typeof(TRet));
     }
-    private static object To(Object value, Type type)
+}
+
+sealed class GenericColumnData<T> : BaseColumnData<T>
+{
+    private static readonly Type ElementType = typeof(T);
+
+    public GenericColumnData(int capacity) : base(capacity)
     {
-        Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
-        switch (Type.GetTypeCode(underlyingType))
-        {
-            case TypeCode.Boolean: return Valid.ToBoolean(value);
-            case TypeCode.Byte: return Valid.ToByte(value);
-            case TypeCode.Char: return Valid.ToChar(value);
-            case TypeCode.DateTime: return Valid.ToDateTime(value);
-            case TypeCode.Decimal: return Valid.ToDecimal(value);
-            case TypeCode.Double: return Valid.ToDouble(value);
-            case TypeCode.Int16: return Valid.ToInt16(value);
-            case TypeCode.Int32: return Valid.ToInt32(value);
-            case TypeCode.Int64: return Valid.ToInt64(value);
-            case TypeCode.SByte: return Valid.ToSByte(value);
-            case TypeCode.Single: return Valid.ToSingle(value);
-            case TypeCode.String: return Valid.ToString(value);
-            case TypeCode.UInt16: return Valid.ToUInt16(value);
-            case TypeCode.UInt32: return Valid.ToUInt32(value);
-            case TypeCode.UInt64: return Valid.ToUInt64(value);
-        }
-        return Convert.ChangeType(value, underlyingType);
     }
+
+    public override void Set(bool value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(byte value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(char value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(DateTime value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(decimal value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(double value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(short value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(int value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(long value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(sbyte value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(float value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(string value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(ushort value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(uint value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override void Set(ulong value, int index)
+    {
+        if (value is T d) this._data[index] = d;
+        else this._data[index] = (T)Valid.To(value, ElementType);
+    }
+
+    public override bool ToBoolean(int index) => Valid.ToBoolean(this._data[index]);
+
+    public override byte ToByte(int index) => Valid.ToByte(this._data[index]);
+
+    public override char ToChar(int index) => Valid.ToChar(this._data[index]);
+
+    public override DateTime ToDateTime(int index) => Valid.ToDateTime(this._data[index]);
+
+    public override decimal ToDecimal(int index) => Valid.ToDecimal(this._data[index]);
+
+    public override double ToDouble(int index) => Valid.ToDouble(this._data[index]);
+
+    public override short ToInt16(int index) => Valid.ToInt16(this._data[index]);
+
+    public override int ToInt32(int index) => Valid.ToInt32(this._data[index]);
+
+    public override long ToInt64(int index) => Valid.ToInt64(this._data[index]);
+
+    public override sbyte ToSByte(int index) => Valid.ToSByte(this._data[index]);
+
+    public override float ToSingle(int index) => Valid.ToSingle(this._data[index]);
+
+    public override string ToString(int index) => Valid.ToString(this._data[index]);
+
+    public override ushort ToUInt16(int index) => Valid.ToUInt16(this._data[index]);
+
+    public override uint ToUInt32(int index) => Valid.ToUInt32(this._data[index]);
+
+    public override ulong ToUInt64(int index) => Valid.ToUInt64(this._data[index]);
 }

--- a/src/LuYao.Common/Data/Helpers.cs
+++ b/src/LuYao.Common/Data/Helpers.cs
@@ -29,9 +29,9 @@ internal static class Helpers
         };
     }
 
-    public static ColumnData MakeData(RecordDataType type, int capacity)
+    public static ColumnData MakeData(RecordDataType dt, int capacity, Type type)
     {
-        return type switch
+        return dt switch
         {
             RecordDataType.Boolean => new BooleanColumnData(capacity),
             RecordDataType.Byte => new ByteColumnData(capacity),
@@ -48,9 +48,16 @@ internal static class Helpers
             RecordDataType.UInt16 => new UInt16ColumnData(capacity),
             RecordDataType.UInt32 => new UInt32ColumnData(capacity),
             RecordDataType.UInt64 => new UInt64ColumnData(capacity),
-            RecordDataType.Object => new ObjectColumnData(capacity),
+            RecordDataType.Object => MakeData(capacity, type),
             _ => throw new NotSupportedException()
         };
+    }
+
+    private static ColumnData MakeData(int capacity, Type type)
+    {
+        var g = typeof(GenericColumnData<>);
+        var dt = g.MakeGenericType(type);
+        return (ColumnData)Activator.CreateInstance(dt, capacity)!;
     }
 
     public static RecordDataType ReadDataType(BinaryReader reader)

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -34,7 +34,7 @@ public sealed partial class RecordColumn
         this.Code = code;
         if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity), "容量不能小于1");
         this._type = Helpers.ToType(code);
-        this._data = Helpers.MakeData(code, capacity);
+        this._data = Helpers.MakeData(code, capacity, this._type);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public sealed partial class RecordColumn
         this.Code = RecordDataType.Object;
         if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity), "容量不能小于1");
         this._type = type;
-        this._data = Helpers.MakeData(RecordDataType.Object, capacity);
+        this._data = Helpers.MakeData(RecordDataType.Object, capacity, type);
     }
 
     internal void Extend(int length) => this._data.Extend(length);

--- a/src/LuYao.Common/Valid/Valid.Object.cs
+++ b/src/LuYao.Common/Valid/Valid.Object.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LuYao;
+
+partial class Valid
+{
+    /// <summary>
+    /// 将指定的值转换为指定的类型。
+    /// </summary>
+    /// <param name="value">要转换的值。</param>
+    /// <param name="type">目标类型。</param>
+    /// <returns>转换后的对象。</returns>
+    public static object To(Object value, Type type)
+    {
+        Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        switch (Type.GetTypeCode(underlyingType))
+        {
+            case TypeCode.Boolean: return Valid.ToBoolean(value);
+            case TypeCode.Byte: return Valid.ToByte(value);
+            case TypeCode.Char: return Valid.ToChar(value);
+            case TypeCode.DateTime: return Valid.ToDateTime(value);
+            case TypeCode.Decimal: return Valid.ToDecimal(value);
+            case TypeCode.Double: return Valid.ToDouble(value);
+            case TypeCode.Int16: return Valid.ToInt16(value);
+            case TypeCode.Int32: return Valid.ToInt32(value);
+            case TypeCode.Int64: return Valid.ToInt64(value);
+            case TypeCode.SByte: return Valid.ToSByte(value);
+            case TypeCode.Single: return Valid.ToSingle(value);
+            case TypeCode.String: return Valid.ToString(value);
+            case TypeCode.UInt16: return Valid.ToUInt16(value);
+            case TypeCode.UInt32: return Valid.ToUInt32(value);
+            case TypeCode.UInt64: return Valid.ToUInt64(value);
+        }
+        return Convert.ChangeType(value, underlyingType);
+    }
+}

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -1142,4 +1142,42 @@ public class RecordTests
         // Act & Assert
         table.Columns.AddInt32("TestColumn"); // 应该抛出异常
     }
+
+
+    public class Student
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [TestMethod]
+    public void Columns_SetObject_WorksCorrectly()
+    {
+        var re = new Record();
+        var raw = re.Columns.Add<Student>("Raw");
+        var id = re.Columns.AddInt32("Id");
+
+        var row = re.AddRow();
+        row.SetValue(new Student { Id = 1, Name = "John Doe" }, raw);
+        row.Set(1, id);
+
+        // Assert
+
+        var stu = row.To<Student>(raw);
+        Assert.AreEqual(1, stu.Id);
+        Assert.AreEqual("John Doe", stu.Name);
+        Assert.AreEqual(1, row.ToInt32(id));
+    }
+
+    [TestMethod]
+    public void Columns_SetObjectNotMatchType_ThrowsInvalidCastException()
+    {
+        // Arrange
+        var re = new Record();
+        var raw = re.Columns.Add<Student>("Raw");
+        var id = re.Columns.AddInt32("Id");
+        var row = re.AddRow();
+        // Act & Assert
+        Assert.ThrowsException<InvalidCastException>(() => row.SetValue(1, raw));
+    }
 }


### PR DESCRIPTION
This pull request refactors the `ColumnData` hierarchy to improve maintainability and flexibility by introducing a generic `GenericColumnData<T>` implementation and replacing type-specific implementations with a unified base class, `BaseColumnData<T>`. It also enhances the `Helpers` class to dynamically create `ColumnData` instances using reflection and expression trees.

### Refactoring of `ColumnData` hierarchy:

* **Introduction of `BaseColumnData<T>`**: The `ColumnData<T>` abstract class is renamed to `BaseColumnData<T>`, and all type-specific classes (e.g., `BooleanColumnData`, `Int32ColumnData`) now inherit from it instead of the old `ColumnData<T>`. (`src/LuYao.Common/Data/ColumnData.cs`, [src/LuYao.Common/Data/ColumnData.csL62-R66](diffhunk://#diff-bed6399759e6de427dec56ece64238edaa93d773a732fec4447dfad3a384ec85L62-R66))
* **Removal of `ObjectColumnData`**: The `ObjectColumnData` implementation is removed, and its functionality is replaced by the new dynamic `GenericColumnData<T>` class. (`src/LuYao.Common/Data/ColumnData.T.cs`, [src/LuYao.Common/Data/ColumnData.T.csL5-R6](diffhunk://#diff-16d32f8d54db199abc9c2cecc5a4f21ae56aa7c60743cc46a7bdf3c85b5e6d96L5-R6))

### Addition of `GenericColumnData<T>`:

* **Generic implementation**: A new `GenericColumnData<T>` class is introduced to handle type conversions and data storage for generic types, reducing the need for explicit type-specific implementations. (`src/LuYao.Common/Data/ColumnData.cs`, [src/LuYao.Common/Data/ColumnData.csL97-R229](diffhunk://#diff-bed6399759e6de427dec56ece64238edaa93d773a732fec4447dfad3a384ec85L97-R229))

### Enhancements to `Helpers` class:

* **Dynamic factory creation**: The `Helpers` class now includes a `FactoryCache<T>` to dynamically generate `ColumnData` instances using reflection and expression trees, enabling support for arbitrary types. (`src/LuYao.Common/Data/Helpers.cs`, [src/LuYao.Common/Data/Helpers.csR4-R28](diffhunk://#diff-402f0f2737fb187c23b0ea326dc449dbd2bd7c19dec615c1200a6f5abffe6df5R4-R28))
* **Updated `MakeData` method**: The `MakeData` method is updated to support dynamic type creation by passing the type as an additional parameter. (`src/LuYao.Common/Data/Helpers.cs`, [[1]](diffhunk://#diff-402f0f2737fb187c23b0ea326dc449dbd2bd7c19dec615c1200a6f5abffe6df5L32-R54) [[2]](diffhunk://#diff-402f0f2737fb187c23b0ea326dc449dbd2bd7c19dec615c1200a6f5abffe6df5L51-R82)

### Updates to `RecordColumn`:

* **Support for dynamic types**: The constructor of `RecordColumn` is updated to use the enhanced `Helpers.MakeData` method, enabling support for dynamically specified types. (`src/LuYao.Common/Data/RecordColumn.cs`, [[1]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL37-R37) [[2]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL57-R57)