### PR TITLE
Json reader writer

### DIFF
--- a/src/LuYao.Common/Text/Json/JsonReader.cs
+++ b/src/LuYao.Common/Text/Json/JsonReader.cs
@@ -7,7 +7,7 @@ using System.Text;
 namespace LuYao.Text.Json;
 
 /// <summary>
-/// ¸ßĞÔÄÜ JSON ¶ÁÈ¡Æ÷£¬Ê¹ÓÃ¹Ì¶¨´óĞ¡»º³åÇøÓÅ»¯ĞÔÄÜ
+/// é«˜æ€§èƒ½ JSON è¯»å–å™¨ï¼Œä½¿ç”¨å›ºå®šå¤§å°ç¼“å†²åŒºä¼˜åŒ–æ€§èƒ½
 /// </summary>
 public sealed class JsonReader : IDisposable
 {
@@ -35,29 +35,29 @@ public sealed class JsonReader : IDisposable
     }
 
     /// <summary>
-    /// µ±Ç°±ê¼ÇÀàĞÍ
+    /// å½“å‰æ ‡è®°ç±»å‹
     /// </summary>
     public JsonTokenType TokenType { get; private set; } = JsonTokenType.None;
 
     /// <summary>
-    /// µ±Ç°±ê¼ÇÖµ
+    /// å½“å‰æ ‡è®°å€¼
     /// </summary>
     public object? Value { get; private set; }
 
     /// <summary>
-    /// µ±Ç°ĞĞºÅ
+    /// å½“å‰è¡Œå·
     /// </summary>
     public int Line => _line;
 
     /// <summary>
-    /// µ±Ç°ÁĞºÅ
+    /// å½“å‰åˆ—å·
     /// </summary>
     public int Column => _column;
 
     /// <summary>
-    /// ¶ÁÈ¡ÏÂÒ»¸ö±ê¼Ç
+    /// è¯»å–ä¸‹ä¸€ä¸ªæ ‡è®°
     /// </summary>
-    /// <returns>Èç¹û³É¹¦¶ÁÈ¡µ½±ê¼ÇÔò·µ»Ø true£¬·ñÔò·µ»Ø false</returns>
+    /// <returns>å¦‚æœæˆåŠŸè¯»å–åˆ°æ ‡è®°åˆ™è¿”å› trueï¼Œå¦åˆ™è¿”å› false</returns>
     public bool Read()
     {
         if (_disposed) throw new ObjectDisposedException(nameof(JsonReader));
@@ -112,7 +112,7 @@ public sealed class JsonReader : IDisposable
             case ',':
             case ':':
                 ConsumeChar();
-                return Read(); // Ìø¹ı·Ö¸ô·û£¬¶ÁÈ¡ÏÂÒ»¸ö±ê¼Ç
+                return Read(); // è·³è¿‡åˆ†éš”ç¬¦ï¼Œè¯»å–ä¸‹ä¸€ä¸ªæ ‡è®°
 
             default:
                 if (IsDigit(c) || c == '-' || c == '+')
@@ -171,7 +171,7 @@ public sealed class JsonReader : IDisposable
 
     private bool ReadString()
     {
-        ConsumeChar(); // Ïû·Ñ¿ªÊ¼µÄÒıºÅ
+        ConsumeChar(); // æ¶ˆè´¹å¼€å§‹çš„å¼•å·
 
         var sb = new StringBuilder();
 
@@ -181,9 +181,9 @@ public sealed class JsonReader : IDisposable
 
             if (c == '"')
             {
-                ConsumeChar(); // Ïû·Ñ½áÊøµÄÒıºÅ
+                ConsumeChar(); // æ¶ˆè´¹ç»“æŸçš„å¼•å·
 
-                // ÅĞ¶ÏÊÇ·ñÎªÊôĞÔÃû£¨¼ò»¯ÅĞ¶Ï£º²é¿´ÏÂÒ»¸ö·Ç¿Õ°××Ö·ûÊÇ·ñÎªÃ°ºÅ£©
+                // åˆ¤æ–­æ˜¯å¦ä¸ºå±æ€§åï¼ˆç®€åŒ–åˆ¤æ–­ï¼šæŸ¥çœ‹ä¸‹ä¸€ä¸ªéç©ºç™½å­—ç¬¦æ˜¯å¦ä¸ºå†’å·ï¼‰
                 int savedPos = _bufferPosition;
                 int savedLine = _line;
                 int savedColumn = _column;
@@ -191,7 +191,7 @@ public sealed class JsonReader : IDisposable
                 SkipWhitespace();
                 bool isPropertyName = EnsureBuffer() && _buffer[_bufferPosition] == ':';
 
-                // »Ö¸´Î»ÖÃºÍĞĞÁĞºÅ
+                // æ¢å¤ä½ç½®å’Œè¡Œåˆ—å·
                 _bufferPosition = savedPos;
                 _line = savedLine;
                 _column = savedColumn;
@@ -220,7 +220,7 @@ public sealed class JsonReader : IDisposable
                     case 'r': sb.Append('\r'); break;
                     case 't': sb.Append('\t'); break;
                     case 'u':
-                        // Unicode ×ªÒåĞòÁĞ \uXXXX
+                        // Unicode è½¬ä¹‰åºåˆ— \uXXXX
                         string hexDigits = ReadHexDigits(4);
                         if (int.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int unicode))
                         {
@@ -273,14 +273,14 @@ public sealed class JsonReader : IDisposable
         bool hasDecimalPoint = false;
         bool hasExponent = false;
 
-        // ´¦Àí¸ººÅ
+        // å¤„ç†è´Ÿå·
         if (EnsureBuffer() && (_buffer[_bufferPosition] == '-' || _buffer[_bufferPosition] == '+'))
         {
             sb.Append(_buffer[_bufferPosition]);
             ConsumeChar();
         }
 
-        // ¶ÁÈ¡Êı×Ö²¿·Ö
+        // è¯»å–æ•°å­—éƒ¨åˆ†
         bool hasDigits = false;
         while (EnsureBuffer())
         {
@@ -304,7 +304,7 @@ public sealed class JsonReader : IDisposable
                 sb.Append(c);
                 ConsumeChar();
 
-                // Ö¸Êı²¿·Ö¿ÉÄÜÓĞ·ûºÅ
+                // æŒ‡æ•°éƒ¨åˆ†å¯èƒ½æœ‰ç¬¦å·
                 if (EnsureBuffer() && (_buffer[_bufferPosition] == '+' || _buffer[_bufferPosition] == '-'))
                 {
                     sb.Append(_buffer[_bufferPosition]);
@@ -323,7 +323,7 @@ public sealed class JsonReader : IDisposable
         string numberStr = sb.ToString();
         TokenType = JsonTokenType.Number;
 
-        // ³¢ÊÔ½âÎöÎª²»Í¬µÄÊı×ÖÀàĞÍ
+        // å°è¯•è§£æä¸ºä¸åŒçš„æ•°å­—ç±»å‹
         if (!hasDecimalPoint && !hasExponent)
         {
             if (long.TryParse(numberStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue))
@@ -410,7 +410,7 @@ public sealed class JsonReader : IDisposable
 }
 
 /// <summary>
-/// JSON ½âÎöÒì³£
+/// JSON è§£æå¼‚å¸¸
 /// </summary>
 public class JsonException : Exception
 {

--- a/src/LuYao.Common/Text/Json/JsonReader.cs
+++ b/src/LuYao.Common/Text/Json/JsonReader.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace LuYao.Text.Json
+{
+    /// <summary>
+    /// 高性能 JSON 读取器，使用固定大小缓冲区优化性能
+    /// </summary>
+    public sealed class JsonReader : IDisposable
+    {
+        private readonly TextReader _reader;
+        private readonly bool _ownsReader;
+        private char[] _buffer;
+        private int _bufferPosition;
+        private int _bufferLength;
+        private int _currentIndex;
+        private int _line = 1;
+        private int _column = 1;
+        private bool _disposed;
+
+        private const int DefaultBufferSize = 4096;
+
+        public JsonReader(TextReader reader, bool ownsReader = false, int bufferSize = DefaultBufferSize)
+        {
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            _ownsReader = ownsReader;
+            _buffer = new char[Math.Max(bufferSize, 64)];
+        }
+
+        public JsonReader(string json) : this(new StringReader(json), true)
+        {
+        }
+
+        /// <summary>
+        /// 当前标记类型
+        /// </summary>
+        public JsonTokenType TokenType { get; private set; } = JsonTokenType.None;
+
+        /// <summary>
+        /// 当前标记值
+        /// </summary>
+        public object? Value { get; private set; }
+
+        /// <summary>
+        /// 当前行号
+        /// </summary>
+        public int Line => _line;
+
+        /// <summary>
+        /// 当前列号
+        /// </summary>
+        public int Column => _column;
+
+        /// <summary>
+        /// 读取下一个标记
+        /// </summary>
+        /// <returns>如果成功读取到标记则返回 true，否则返回 false</returns>
+        public bool Read()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(JsonReader));
+
+            SkipWhitespace();
+
+            if (!EnsureBuffer())
+            {
+                TokenType = JsonTokenType.None;
+                Value = null;
+                return false;
+            }
+
+            char c = _buffer[_bufferPosition];
+
+            switch (c)
+            {
+                case '{':
+                    TokenType = JsonTokenType.StartObject;
+                    Value = null;
+                    ConsumeChar();
+                    return true;
+
+                case '}':
+                    TokenType = JsonTokenType.EndObject;
+                    Value = null;
+                    ConsumeChar();
+                    return true;
+
+                case '[':
+                    TokenType = JsonTokenType.StartArray;
+                    Value = null;
+                    ConsumeChar();
+                    return true;
+
+                case ']':
+                    TokenType = JsonTokenType.EndArray;
+                    Value = null;
+                    ConsumeChar();
+                    return true;
+
+                case '"':
+                    return ReadString();
+
+                case 't':
+                case 'f':
+                    return ReadBoolean();
+
+                case 'n':
+                    return ReadNull();
+
+                case ',':
+                case ':':
+                    ConsumeChar();
+                    return Read(); // 跳过分隔符，读取下一个标记
+
+                default:
+                    if (IsDigit(c) || c == '-' || c == '+')
+                        return ReadNumber();
+
+                    throw new JsonException($"Unexpected character '{c}' at line {_line}, column {_column}");
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void SkipWhitespace()
+        {
+            while (EnsureBuffer())
+            {
+                char c = _buffer[_bufferPosition];
+                if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
+                {
+                    ConsumeChar();
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ConsumeChar()
+        {
+            if (_buffer[_bufferPosition] == '\n')
+            {
+                _line++;
+                _column = 1;
+            }
+            else
+            {
+                _column++;
+            }
+
+            _bufferPosition++;
+            _currentIndex++;
+        }
+
+        private bool EnsureBuffer()
+        {
+            if (_bufferPosition >= _bufferLength)
+            {
+                _bufferLength = _reader.Read(_buffer, 0, _buffer.Length);
+                _bufferPosition = 0;
+
+                if (_bufferLength == 0)
+                    return false;
+            }
+            return true;
+        }
+
+        private bool ReadString()
+        {
+            ConsumeChar(); // 消费开始的引号
+
+            var sb = new StringBuilder();
+
+            while (EnsureBuffer())
+            {
+                char c = _buffer[_bufferPosition];
+
+                if (c == '"')
+                {
+                    ConsumeChar(); // 消费结束的引号
+
+                    // 判断是否为属性名（简化判断：查看下一个非空白字符是否为冒号）
+                    int savedPos = _bufferPosition;
+                    SkipWhitespace();
+                    bool isPropertyName = EnsureBuffer() && _buffer[_bufferPosition] == ':';
+                    _bufferPosition = savedPos; // 恢复位置
+
+                    TokenType = isPropertyName ? JsonTokenType.PropertyName : JsonTokenType.String;
+                    Value = sb.ToString();
+                    return true;
+                }
+                else if (c == '\\')
+                {
+                    ConsumeChar();
+                    if (!EnsureBuffer())
+                        throw new JsonException("Unexpected end of input while reading string escape sequence");
+
+                    char escaped = _buffer[_bufferPosition];
+                    ConsumeChar();
+
+                    switch (escaped)
+                    {
+                        case '"': sb.Append('"'); break;
+                        case '\\': sb.Append('\\'); break;
+                        case '/': sb.Append('/'); break;
+                        case 'b': sb.Append('\b'); break;
+                        case 'f': sb.Append('\f'); break;
+                        case 'n': sb.Append('\n'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'u':
+                            // Unicode 转义序列 \uXXXX
+                            string hexDigits = ReadHexDigits(4);
+                            if (int.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int unicode))
+                            {
+                                sb.Append((char)unicode);
+                            }
+                            else
+                            {
+                                throw new JsonException($"Invalid unicode escape sequence \\u{hexDigits}");
+                            }
+                            break;
+                        default:
+                            throw new JsonException($"Invalid escape sequence \\{escaped}");
+                    }
+                }
+                else if (char.IsControl(c))
+                {
+                    throw new JsonException($"Unescaped control character in string at line {_line}, column {_column}");
+                }
+                else
+                {
+                    sb.Append(c);
+                    ConsumeChar();
+                }
+            }
+
+            throw new JsonException("Unexpected end of input while reading string");
+        }
+
+        private string ReadHexDigits(int count)
+        {
+            var sb = new StringBuilder(count);
+            for (int i = 0; i < count; i++)
+            {
+                if (!EnsureBuffer())
+                    throw new JsonException("Unexpected end of input while reading unicode escape sequence");
+
+                char c = _buffer[_bufferPosition];
+                if (!IsHexDigit(c))
+                    throw new JsonException($"Invalid hex digit '{c}' in unicode escape sequence");
+
+                sb.Append(c);
+                ConsumeChar();
+            }
+            return sb.ToString();
+        }
+
+        private bool ReadNumber()
+        {
+            var sb = new StringBuilder();
+            bool hasDecimalPoint = false;
+            bool hasExponent = false;
+
+            // 处理负号
+            if (EnsureBuffer() && (_buffer[_bufferPosition] == '-' || _buffer[_bufferPosition] == '+'))
+            {
+                sb.Append(_buffer[_bufferPosition]);
+                ConsumeChar();
+            }
+
+            // 读取数字部分
+            bool hasDigits = false;
+            while (EnsureBuffer())
+            {
+                char c = _buffer[_bufferPosition];
+
+                if (IsDigit(c))
+                {
+                    sb.Append(c);
+                    hasDigits = true;
+                    ConsumeChar();
+                }
+                else if (c == '.' && !hasDecimalPoint && !hasExponent)
+                {
+                    hasDecimalPoint = true;
+                    sb.Append(c);
+                    ConsumeChar();
+                }
+                else if ((c == 'e' || c == 'E') && !hasExponent && hasDigits)
+                {
+                    hasExponent = true;
+                    sb.Append(c);
+                    ConsumeChar();
+
+                    // 指数部分可能有符号
+                    if (EnsureBuffer() && (_buffer[_bufferPosition] == '+' || _buffer[_bufferPosition] == '-'))
+                    {
+                        sb.Append(_buffer[_bufferPosition]);
+                        ConsumeChar();
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (!hasDigits)
+                throw new JsonException($"Invalid number format at line {_line}, column {_column}");
+
+            string numberStr = sb.ToString();
+            TokenType = JsonTokenType.Number;
+
+            // 尝试解析为不同的数字类型
+            if (!hasDecimalPoint && !hasExponent)
+            {
+                if (long.TryParse(numberStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue))
+                {
+                    Value = longValue;
+                    return true;
+                }
+            }
+
+            if (double.TryParse(numberStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue))
+            {
+                Value = doubleValue;
+                return true;
+            }
+
+            throw new JsonException($"Invalid number format '{numberStr}' at line {_line}, column {_column}");
+        }
+
+        private bool ReadBoolean()
+        {
+            if (ReadLiteral("true"))
+            {
+                TokenType = JsonTokenType.Boolean;
+                Value = true;
+                return true;
+            }
+
+            if (ReadLiteral("false"))
+            {
+                TokenType = JsonTokenType.Boolean;
+                Value = false;
+                return true;
+            }
+
+            throw new JsonException($"Invalid boolean value at line {_line}, column {_column}");
+        }
+
+        private bool ReadNull()
+        {
+            if (ReadLiteral("null"))
+            {
+                TokenType = JsonTokenType.Null;
+                Value = null;
+                return true;
+            }
+
+            throw new JsonException($"Invalid null value at line {_line}, column {_column}");
+        }
+
+        private bool ReadLiteral(string literal)
+        {
+            for (int i = 0; i < literal.Length; i++)
+            {
+                if (!EnsureBuffer() || _buffer[_bufferPosition] != literal[i])
+                    return false;
+                ConsumeChar();
+            }
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsDigit(char c) => c >= '0' && c <= '9';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsHexDigit(char c) =>
+            (c >= '0' && c <= '9') ||
+            (c >= 'A' && c <= 'F') ||
+            (c >= 'a' && c <= 'f');
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _buffer = null!;
+
+                if (_ownsReader)
+                {
+                    _reader?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// JSON 解析异常
+    /// </summary>
+    public class JsonException : Exception
+    {
+        public JsonException(string message) : base(message) { }
+        public JsonException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/LuYao.Common/Text/Json/JsonReader.cs
+++ b/src/LuYao.Common/Text/Json/JsonReader.cs
@@ -4,411 +4,416 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace LuYao.Text.Json
+namespace LuYao.Text.Json;
+
+/// <summary>
+/// 高性能 JSON 读取器，使用固定大小缓冲区优化性能
+/// </summary>
+public sealed class JsonReader : IDisposable
 {
-    /// <summary>
-    /// 高性能 JSON 读取器，使用固定大小缓冲区优化性能
-    /// </summary>
-    public sealed class JsonReader : IDisposable
+    private readonly TextReader _reader;
+    private readonly bool _ownsReader;
+    private char[] _buffer;
+    private int _bufferPosition;
+    private int _bufferLength;
+    private int _currentIndex;
+    private int _line = 1;
+    private int _column = 1;
+    private bool _disposed;
+
+    private const int DefaultBufferSize = 4096;
+
+    public JsonReader(TextReader reader, bool ownsReader = false, int bufferSize = DefaultBufferSize)
     {
-        private readonly TextReader _reader;
-        private readonly bool _ownsReader;
-        private char[] _buffer;
-        private int _bufferPosition;
-        private int _bufferLength;
-        private int _currentIndex;
-        private int _line = 1;
-        private int _column = 1;
-        private bool _disposed;
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _ownsReader = ownsReader;
+        _buffer = new char[Math.Max(bufferSize, 64)];
+    }
 
-        private const int DefaultBufferSize = 4096;
+    public JsonReader(string json) : this(new StringReader(json), true)
+    {
+    }
 
-        public JsonReader(TextReader reader, bool ownsReader = false, int bufferSize = DefaultBufferSize)
+    /// <summary>
+    /// 当前标记类型
+    /// </summary>
+    public JsonTokenType TokenType { get; private set; } = JsonTokenType.None;
+
+    /// <summary>
+    /// 当前标记值
+    /// </summary>
+    public object? Value { get; private set; }
+
+    /// <summary>
+    /// 当前行号
+    /// </summary>
+    public int Line => _line;
+
+    /// <summary>
+    /// 当前列号
+    /// </summary>
+    public int Column => _column;
+
+    /// <summary>
+    /// 读取下一个标记
+    /// </summary>
+    /// <returns>如果成功读取到标记则返回 true，否则返回 false</returns>
+    public bool Read()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(JsonReader));
+
+        SkipWhitespace();
+
+        if (!EnsureBuffer())
         {
-            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
-            _ownsReader = ownsReader;
-            _buffer = new char[Math.Max(bufferSize, 64)];
+            TokenType = JsonTokenType.None;
+            Value = null;
+            return false;
         }
 
-        public JsonReader(string json) : this(new StringReader(json), true)
+        char c = _buffer[_bufferPosition];
+
+        switch (c)
         {
-        }
-
-        /// <summary>
-        /// 当前标记类型
-        /// </summary>
-        public JsonTokenType TokenType { get; private set; } = JsonTokenType.None;
-
-        /// <summary>
-        /// 当前标记值
-        /// </summary>
-        public object? Value { get; private set; }
-
-        /// <summary>
-        /// 当前行号
-        /// </summary>
-        public int Line => _line;
-
-        /// <summary>
-        /// 当前列号
-        /// </summary>
-        public int Column => _column;
-
-        /// <summary>
-        /// 读取下一个标记
-        /// </summary>
-        /// <returns>如果成功读取到标记则返回 true，否则返回 false</returns>
-        public bool Read()
-        {
-            if (_disposed)
-                throw new ObjectDisposedException(nameof(JsonReader));
-
-            SkipWhitespace();
-
-            if (!EnsureBuffer())
-            {
-                TokenType = JsonTokenType.None;
+            case '{':
+                TokenType = JsonTokenType.StartObject;
                 Value = null;
-                return false;
-            }
+                ConsumeChar();
+                return true;
 
+            case '}':
+                TokenType = JsonTokenType.EndObject;
+                Value = null;
+                ConsumeChar();
+                return true;
+
+            case '[':
+                TokenType = JsonTokenType.StartArray;
+                Value = null;
+                ConsumeChar();
+                return true;
+
+            case ']':
+                TokenType = JsonTokenType.EndArray;
+                Value = null;
+                ConsumeChar();
+                return true;
+
+            case '"':
+                return ReadString();
+
+            case 't':
+            case 'f':
+                return ReadBoolean();
+
+            case 'n':
+                return ReadNull();
+
+            case ',':
+            case ':':
+                ConsumeChar();
+                return Read(); // 跳过分隔符，读取下一个标记
+
+            default:
+                if (IsDigit(c) || c == '-' || c == '+')
+                    return ReadNumber();
+
+                throw new JsonException($"Unexpected character '{c}' at line {_line}, column {_column}");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void SkipWhitespace()
+    {
+        while (EnsureBuffer())
+        {
             char c = _buffer[_bufferPosition];
-
-            switch (c)
+            if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
             {
-                case '{':
-                    TokenType = JsonTokenType.StartObject;
-                    Value = null;
-                    ConsumeChar();
-                    return true;
-
-                case '}':
-                    TokenType = JsonTokenType.EndObject;
-                    Value = null;
-                    ConsumeChar();
-                    return true;
-
-                case '[':
-                    TokenType = JsonTokenType.StartArray;
-                    Value = null;
-                    ConsumeChar();
-                    return true;
-
-                case ']':
-                    TokenType = JsonTokenType.EndArray;
-                    Value = null;
-                    ConsumeChar();
-                    return true;
-
-                case '"':
-                    return ReadString();
-
-                case 't':
-                case 'f':
-                    return ReadBoolean();
-
-                case 'n':
-                    return ReadNull();
-
-                case ',':
-                case ':':
-                    ConsumeChar();
-                    return Read(); // 跳过分隔符，读取下一个标记
-
-                default:
-                    if (IsDigit(c) || c == '-' || c == '+')
-                        return ReadNumber();
-
-                    throw new JsonException($"Unexpected character '{c}' at line {_line}, column {_column}");
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SkipWhitespace()
-        {
-            while (EnsureBuffer())
-            {
-                char c = _buffer[_bufferPosition];
-                if (c == ' ' || c == '\t' || c == '\r' || c == '\n')
-                {
-                    ConsumeChar();
-                }
-                else
-                {
-                    break;
-                }
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void ConsumeChar()
-        {
-            if (_buffer[_bufferPosition] == '\n')
-            {
-                _line++;
-                _column = 1;
+                ConsumeChar();
             }
             else
             {
-                _column++;
+                break;
             }
+        }
+    }
 
-            _bufferPosition++;
-            _currentIndex++;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void ConsumeChar()
+    {
+        if (_buffer[_bufferPosition] == '\n')
+        {
+            _line++;
+            _column = 1;
+        }
+        else
+        {
+            _column++;
         }
 
-        private bool EnsureBuffer()
-        {
-            if (_bufferPosition >= _bufferLength)
-            {
-                _bufferLength = _reader.Read(_buffer, 0, _buffer.Length);
-                _bufferPosition = 0;
+        _bufferPosition++;
+        _currentIndex++;
+    }
 
-                if (_bufferLength == 0)
-                    return false;
-            }
-            return true;
+    private bool EnsureBuffer()
+    {
+        if (_bufferPosition >= _bufferLength)
+        {
+            _bufferLength = _reader.Read(_buffer, 0, _buffer.Length);
+            _bufferPosition = 0;
+
+            if (_bufferLength == 0)
+                return false;
         }
+        return true;
+    }
 
-        private bool ReadString()
+    private bool ReadString()
+    {
+        ConsumeChar(); // 消费开始的引号
+
+        var sb = new StringBuilder();
+
+        while (EnsureBuffer())
         {
-            ConsumeChar(); // 消费开始的引号
+            char c = _buffer[_bufferPosition];
 
-            var sb = new StringBuilder();
-
-            while (EnsureBuffer())
+            if (c == '"')
             {
-                char c = _buffer[_bufferPosition];
+                ConsumeChar(); // 消费结束的引号
 
-                if (c == '"')
-                {
-                    ConsumeChar(); // 消费结束的引号
+                // 判断是否为属性名（简化判断：查看下一个非空白字符是否为冒号）
+                int savedPos = _bufferPosition;
+                int savedLine = _line;
+                int savedColumn = _column;
 
-                    // 判断是否为属性名（简化判断：查看下一个非空白字符是否为冒号）
-                    int savedPos = _bufferPosition;
-                    SkipWhitespace();
-                    bool isPropertyName = EnsureBuffer() && _buffer[_bufferPosition] == ':';
-                    _bufferPosition = savedPos; // 恢复位置
+                SkipWhitespace();
+                bool isPropertyName = EnsureBuffer() && _buffer[_bufferPosition] == ':';
 
-                    TokenType = isPropertyName ? JsonTokenType.PropertyName : JsonTokenType.String;
-                    Value = sb.ToString();
-                    return true;
-                }
-                else if (c == '\\')
-                {
-                    ConsumeChar();
-                    if (!EnsureBuffer())
-                        throw new JsonException("Unexpected end of input while reading string escape sequence");
+                // 恢复位置和行列号
+                _bufferPosition = savedPos;
+                _line = savedLine;
+                _column = savedColumn;
 
-                    char escaped = _buffer[_bufferPosition];
-                    ConsumeChar();
-
-                    switch (escaped)
-                    {
-                        case '"': sb.Append('"'); break;
-                        case '\\': sb.Append('\\'); break;
-                        case '/': sb.Append('/'); break;
-                        case 'b': sb.Append('\b'); break;
-                        case 'f': sb.Append('\f'); break;
-                        case 'n': sb.Append('\n'); break;
-                        case 'r': sb.Append('\r'); break;
-                        case 't': sb.Append('\t'); break;
-                        case 'u':
-                            // Unicode 转义序列 \uXXXX
-                            string hexDigits = ReadHexDigits(4);
-                            if (int.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int unicode))
-                            {
-                                sb.Append((char)unicode);
-                            }
-                            else
-                            {
-                                throw new JsonException($"Invalid unicode escape sequence \\u{hexDigits}");
-                            }
-                            break;
-                        default:
-                            throw new JsonException($"Invalid escape sequence \\{escaped}");
-                    }
-                }
-                else if (char.IsControl(c))
-                {
-                    throw new JsonException($"Unescaped control character in string at line {_line}, column {_column}");
-                }
-                else
-                {
-                    sb.Append(c);
-                    ConsumeChar();
-                }
+                TokenType = isPropertyName ? JsonTokenType.PropertyName : JsonTokenType.String;
+                Value = sb.ToString();
+                return true;
             }
-
-            throw new JsonException("Unexpected end of input while reading string");
-        }
-
-        private string ReadHexDigits(int count)
-        {
-            var sb = new StringBuilder(count);
-            for (int i = 0; i < count; i++)
+            else if (c == '\\')
             {
+                ConsumeChar();
                 if (!EnsureBuffer())
-                    throw new JsonException("Unexpected end of input while reading unicode escape sequence");
+                    throw new JsonException("Unexpected end of input while reading string escape sequence");
 
-                char c = _buffer[_bufferPosition];
-                if (!IsHexDigit(c))
-                    throw new JsonException($"Invalid hex digit '{c}' in unicode escape sequence");
+                char escaped = _buffer[_bufferPosition];
+                ConsumeChar();
 
+                switch (escaped)
+                {
+                    case '"': sb.Append('"'); break;
+                    case '\\': sb.Append('\\'); break;
+                    case '/': sb.Append('/'); break;
+                    case 'b': sb.Append('\b'); break;
+                    case 'f': sb.Append('\f'); break;
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 't': sb.Append('\t'); break;
+                    case 'u':
+                        // Unicode 转义序列 \uXXXX
+                        string hexDigits = ReadHexDigits(4);
+                        if (int.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int unicode))
+                        {
+                            sb.Append((char)unicode);
+                        }
+                        else
+                        {
+                            throw new JsonException($"Invalid unicode escape sequence \\u{hexDigits}");
+                        }
+                        break;
+                    default:
+                        throw new JsonException($"Invalid escape sequence \\{escaped}");
+                }
+            }
+            else if (char.IsControl(c))
+            {
+                throw new JsonException($"Unescaped control character in string at line {_line}, column {_column}");
+            }
+            else
+            {
                 sb.Append(c);
                 ConsumeChar();
             }
-            return sb.ToString();
         }
 
-        private bool ReadNumber()
-        {
-            var sb = new StringBuilder();
-            bool hasDecimalPoint = false;
-            bool hasExponent = false;
+        throw new JsonException("Unexpected end of input while reading string");
+    }
 
-            // 处理负号
-            if (EnsureBuffer() && (_buffer[_bufferPosition] == '-' || _buffer[_bufferPosition] == '+'))
+    private string ReadHexDigits(int count)
+    {
+        var sb = new StringBuilder(count);
+        for (int i = 0; i < count; i++)
+        {
+            if (!EnsureBuffer())
+                throw new JsonException("Unexpected end of input while reading unicode escape sequence");
+
+            char c = _buffer[_bufferPosition];
+            if (!IsHexDigit(c))
+                throw new JsonException($"Invalid hex digit '{c}' in unicode escape sequence");
+
+            sb.Append(c);
+            ConsumeChar();
+        }
+        return sb.ToString();
+    }
+
+    private bool ReadNumber()
+    {
+        var sb = new StringBuilder();
+        bool hasDecimalPoint = false;
+        bool hasExponent = false;
+
+        // 处理负号
+        if (EnsureBuffer() && (_buffer[_bufferPosition] == '-' || _buffer[_bufferPosition] == '+'))
+        {
+            sb.Append(_buffer[_bufferPosition]);
+            ConsumeChar();
+        }
+
+        // 读取数字部分
+        bool hasDigits = false;
+        while (EnsureBuffer())
+        {
+            char c = _buffer[_bufferPosition];
+
+            if (IsDigit(c))
             {
-                sb.Append(_buffer[_bufferPosition]);
+                sb.Append(c);
+                hasDigits = true;
                 ConsumeChar();
             }
-
-            // 读取数字部分
-            bool hasDigits = false;
-            while (EnsureBuffer())
+            else if (c == '.' && !hasDecimalPoint && !hasExponent)
             {
-                char c = _buffer[_bufferPosition];
-
-                if (IsDigit(c))
-                {
-                    sb.Append(c);
-                    hasDigits = true;
-                    ConsumeChar();
-                }
-                else if (c == '.' && !hasDecimalPoint && !hasExponent)
-                {
-                    hasDecimalPoint = true;
-                    sb.Append(c);
-                    ConsumeChar();
-                }
-                else if ((c == 'e' || c == 'E') && !hasExponent && hasDigits)
-                {
-                    hasExponent = true;
-                    sb.Append(c);
-                    ConsumeChar();
-
-                    // 指数部分可能有符号
-                    if (EnsureBuffer() && (_buffer[_bufferPosition] == '+' || _buffer[_bufferPosition] == '-'))
-                    {
-                        sb.Append(_buffer[_bufferPosition]);
-                        ConsumeChar();
-                    }
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            if (!hasDigits)
-                throw new JsonException($"Invalid number format at line {_line}, column {_column}");
-
-            string numberStr = sb.ToString();
-            TokenType = JsonTokenType.Number;
-
-            // 尝试解析为不同的数字类型
-            if (!hasDecimalPoint && !hasExponent)
-            {
-                if (long.TryParse(numberStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue))
-                {
-                    Value = longValue;
-                    return true;
-                }
-            }
-
-            if (double.TryParse(numberStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue))
-            {
-                Value = doubleValue;
-                return true;
-            }
-
-            throw new JsonException($"Invalid number format '{numberStr}' at line {_line}, column {_column}");
-        }
-
-        private bool ReadBoolean()
-        {
-            if (ReadLiteral("true"))
-            {
-                TokenType = JsonTokenType.Boolean;
-                Value = true;
-                return true;
-            }
-
-            if (ReadLiteral("false"))
-            {
-                TokenType = JsonTokenType.Boolean;
-                Value = false;
-                return true;
-            }
-
-            throw new JsonException($"Invalid boolean value at line {_line}, column {_column}");
-        }
-
-        private bool ReadNull()
-        {
-            if (ReadLiteral("null"))
-            {
-                TokenType = JsonTokenType.Null;
-                Value = null;
-                return true;
-            }
-
-            throw new JsonException($"Invalid null value at line {_line}, column {_column}");
-        }
-
-        private bool ReadLiteral(string literal)
-        {
-            for (int i = 0; i < literal.Length; i++)
-            {
-                if (!EnsureBuffer() || _buffer[_bufferPosition] != literal[i])
-                    return false;
+                hasDecimalPoint = true;
+                sb.Append(c);
                 ConsumeChar();
             }
+            else if ((c == 'e' || c == 'E') && !hasExponent && hasDigits)
+            {
+                hasExponent = true;
+                sb.Append(c);
+                ConsumeChar();
+
+                // 指数部分可能有符号
+                if (EnsureBuffer() && (_buffer[_bufferPosition] == '+' || _buffer[_bufferPosition] == '-'))
+                {
+                    sb.Append(_buffer[_bufferPosition]);
+                    ConsumeChar();
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (!hasDigits)
+            throw new JsonException($"Invalid number format at line {_line}, column {_column}");
+
+        string numberStr = sb.ToString();
+        TokenType = JsonTokenType.Number;
+
+        // 尝试解析为不同的数字类型
+        if (!hasDecimalPoint && !hasExponent)
+        {
+            if (long.TryParse(numberStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out long longValue))
+            {
+                Value = longValue;
+                return true;
+            }
+        }
+
+        if (double.TryParse(numberStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double doubleValue))
+        {
+            Value = doubleValue;
             return true;
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsDigit(char c) => c >= '0' && c <= '9';
+        throw new JsonException($"Invalid number format '{numberStr}' at line {_line}, column {_column}");
+    }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsHexDigit(char c) =>
-            (c >= '0' && c <= '9') ||
-            (c >= 'A' && c <= 'F') ||
-            (c >= 'a' && c <= 'f');
-
-        public void Dispose()
+    private bool ReadBoolean()
+    {
+        if (ReadLiteral("true"))
         {
-            if (!_disposed)
+            TokenType = JsonTokenType.Boolean;
+            Value = true;
+            return true;
+        }
+
+        if (ReadLiteral("false"))
+        {
+            TokenType = JsonTokenType.Boolean;
+            Value = false;
+            return true;
+        }
+
+        throw new JsonException($"Invalid boolean value at line {_line}, column {_column}");
+    }
+
+    private bool ReadNull()
+    {
+        if (ReadLiteral("null"))
+        {
+            TokenType = JsonTokenType.Null;
+            Value = null;
+            return true;
+        }
+
+        throw new JsonException($"Invalid null value at line {_line}, column {_column}");
+    }
+
+    private bool ReadLiteral(string literal)
+    {
+        for (int i = 0; i < literal.Length; i++)
+        {
+            if (!EnsureBuffer() || _buffer[_bufferPosition] != literal[i])
+                return false;
+            ConsumeChar();
+        }
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsDigit(char c) => c >= '0' && c <= '9';
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsHexDigit(char c) =>
+        (c >= '0' && c <= '9') ||
+        (c >= 'A' && c <= 'F') ||
+        (c >= 'a' && c <= 'f');
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _buffer = null!;
+
+            if (_ownsReader)
             {
-                _buffer = null!;
-
-                if (_ownsReader)
-                {
-                    _reader?.Dispose();
-                }
-
-                _disposed = true;
+                _reader?.Dispose();
             }
+
+            _disposed = true;
         }
     }
+}
 
-    /// <summary>
-    /// JSON 解析异常
-    /// </summary>
-    public class JsonException : Exception
-    {
-        public JsonException(string message) : base(message) { }
-        public JsonException(string message, Exception innerException) : base(message, innerException) { }
-    }
+/// <summary>
+/// JSON 解析异常
+/// </summary>
+public class JsonException : Exception
+{
+    public JsonException(string message) : base(message) { }
+    public JsonException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/LuYao.Common/Text/Json/JsonToken.cs
+++ b/src/LuYao.Common/Text/Json/JsonToken.cs
@@ -1,73 +1,73 @@
 namespace LuYao.Text.Json;
 
 /// <summary>
-/// JSON ±ê¼ÇÀàĞÍÃ¶¾Ù
+/// JSON æ ‡è®°ç±»å‹æšä¸¾
 /// </summary>
 public enum JsonTokenType
 {
     /// <summary>
-    /// ÎŞĞ§»òÎ´³õÊ¼»¯µÄ±ê¼Ç
+    /// æ— æ•ˆæˆ–æœªåˆå§‹åŒ–çš„æ ‡è®°
     /// </summary>
     None = 0,
 
     /// <summary>
-    /// ¶ÔÏó¿ªÊ¼ {
+    /// å¯¹è±¡å¼€å§‹ {
     /// </summary>
     StartObject = 1,
 
     /// <summary>
-    /// ¶ÔÏó½áÊø }
+    /// å¯¹è±¡ç»“æŸ }
     /// </summary>
     EndObject = 2,
 
     /// <summary>
-    /// Êı×é¿ªÊ¼ [
+    /// æ•°ç»„å¼€å§‹ [
     /// </summary>
     StartArray = 3,
 
     /// <summary>
-    /// Êı×é½áÊø ]
+    /// æ•°ç»„ç»“æŸ ]
     /// </summary>
     EndArray = 4,
 
     /// <summary>
-    /// ÊôĞÔÃû
+    /// å±æ€§å
     /// </summary>
     PropertyName = 5,
 
     /// <summary>
-    /// ×Ö·û´®Öµ
+    /// å­—ç¬¦ä¸²å€¼
     /// </summary>
     String = 6,
 
     /// <summary>
-    /// Êı×ÖÖµ
+    /// æ•°å­—å€¼
     /// </summary>
     Number = 7,
 
     /// <summary>
-    /// ²¼¶ûÖµ
+    /// å¸ƒå°”å€¼
     /// </summary>
     Boolean = 8,
 
     /// <summary>
-    /// null Öµ
+    /// null å€¼
     /// </summary>
     Null = 9,
 
     /// <summary>
-    /// ×¢ÊÍ
+    /// æ³¨é‡Š
     /// </summary>
     Comment = 10,
 
     /// <summary>
-    /// Ô­Ê¼ JSON
+    /// åŸå§‹ JSON
     /// </summary>
     Raw = 11
 }
 
 /// <summary>
-/// JSON ±ê¼Ç½á¹¹
+/// JSON æ ‡è®°ç»“æ„
 /// </summary>
 public readonly struct JsonToken
 {
@@ -80,22 +80,22 @@ public readonly struct JsonToken
     }
 
     /// <summary>
-    /// ±ê¼ÇÀàĞÍ
+    /// æ ‡è®°ç±»å‹
     /// </summary>
     public JsonTokenType Type { get; }
 
     /// <summary>
-    /// ±ê¼ÇÖµ
+    /// æ ‡è®°å€¼
     /// </summary>
     public object? Value { get; }
 
     /// <summary>
-    /// ÔÚÔ´×Ö·û´®ÖĞµÄÆğÊ¼Î»ÖÃ
+    /// åœ¨æºå­—ç¬¦ä¸²ä¸­çš„èµ·å§‹ä½ç½®
     /// </summary>
     public int StartIndex { get; }
 
     /// <summary>
-    /// ±ê¼Ç³¤¶È
+    /// æ ‡è®°é•¿åº¦
     /// </summary>
     public int Length { get; }
 }

--- a/src/LuYao.Common/Text/Json/JsonToken.cs
+++ b/src/LuYao.Common/Text/Json/JsonToken.cs
@@ -1,0 +1,101 @@
+namespace LuYao.Text.Json;
+
+/// <summary>
+/// JSON 标记类型枚举
+/// </summary>
+public enum JsonTokenType
+{
+    /// <summary>
+    /// 无效或未初始化的标记
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// 对象开始 {
+    /// </summary>
+    StartObject = 1,
+
+    /// <summary>
+    /// 对象结束 }
+    /// </summary>
+    EndObject = 2,
+
+    /// <summary>
+    /// 数组开始 [
+    /// </summary>
+    StartArray = 3,
+
+    /// <summary>
+    /// 数组结束 ]
+    /// </summary>
+    EndArray = 4,
+
+    /// <summary>
+    /// 属性名
+    /// </summary>
+    PropertyName = 5,
+
+    /// <summary>
+    /// 字符串值
+    /// </summary>
+    String = 6,
+
+    /// <summary>
+    /// 数字值
+    /// </summary>
+    Number = 7,
+
+    /// <summary>
+    /// 布尔值
+    /// </summary>
+    Boolean = 8,
+
+    /// <summary>
+    /// null 值
+    /// </summary>
+    Null = 9,
+
+    /// <summary>
+    /// 注释
+    /// </summary>
+    Comment = 10,
+
+    /// <summary>
+    /// 原始 JSON
+    /// </summary>
+    Raw = 11
+}
+
+/// <summary>
+/// JSON 标记结构
+/// </summary>
+public readonly struct JsonToken
+{
+    public JsonToken(JsonTokenType type, object? value = null, int startIndex = 0, int length = 0)
+    {
+        Type = type;
+        Value = value;
+        StartIndex = startIndex;
+        Length = length;
+    }
+
+    /// <summary>
+    /// 标记类型
+    /// </summary>
+    public JsonTokenType Type { get; }
+
+    /// <summary>
+    /// 标记值
+    /// </summary>
+    public object? Value { get; }
+
+    /// <summary>
+    /// 在源字符串中的起始位置
+    /// </summary>
+    public int StartIndex { get; }
+
+    /// <summary>
+    /// 标记长度
+    /// </summary>
+    public int Length { get; }
+}

--- a/src/LuYao.Common/Text/Json/JsonWriter.cs
+++ b/src/LuYao.Common/Text/Json/JsonWriter.cs
@@ -4,8 +4,10 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 
+namespace LuYao.Text.Json;
+
 /// <summary>
-/// ¸ßĞÔÄÜ JSON Ğ´ÈëÆ÷£¬Ê¹ÓÃ¹Ì¶¨´óĞ¡»º³åÇøºÍ Span ÓÅ»¯
+/// é«˜æ€§èƒ½ JSON å†™å…¥å™¨ï¼Œä½¿ç”¨å›ºå®šå¤§å°ç¼“å†²åŒºå’Œ Span ä¼˜åŒ–
 /// </summary>
 public sealed class JsonWriter : IDisposable
 {
@@ -17,23 +19,23 @@ public sealed class JsonWriter : IDisposable
 
     private const int DefaultBufferSize = 4096;
 
-    // JSON ×´Ì¬Õ»£¬ÓÃÓÚ¹ÜÀíÇ¶Ì×½á¹¹
+    // JSON çŠ¶æ€æ ˆï¼Œç”¨äºç®¡ç†åµŒå¥—ç»“æ„
     private JsonWriteState[] _stateStack;
     private int _stackDepth;
 
-    // ¸ñÊ½»¯Ñ¡Ïî
+    // æ ¼å¼åŒ–é€‰é¡¹
     private readonly bool _indented;
     private readonly string _indentString;
     private int _currentIndentLevel;
 
     /// <summary>
-    /// ³õÊ¼»¯ JsonWriter ÊµÀı
+    /// åˆå§‹åŒ– JsonWriter å®ä¾‹
     /// </summary>
-    /// <param name="writer">ÒªĞ´ÈëµÄ TextWriter</param>
-    /// <param name="ownsWriter">ÊÇ·ñÓµÓĞ²¢ÊÍ·Å TextWriter</param>
-    /// <param name="indented">ÊÇ·ñÆôÓÃËõ½ø¸ñÊ½»¯</param>
-    /// <param name="indentString">Ëõ½ø×Ö·û´®</param>
-    /// <param name="bufferSize">»º³åÇø´óĞ¡</param>
+    /// <param name="writer">è¦å†™å…¥çš„ TextWriter</param>
+    /// <param name="ownsWriter">æ˜¯å¦æ‹¥æœ‰å¹¶é‡Šæ”¾ TextWriter</param>
+    /// <param name="indented">æ˜¯å¦å¯ç”¨ç¼©è¿›æ ¼å¼åŒ–</param>
+    /// <param name="indentString">ç¼©è¿›å­—ç¬¦ä¸²</param>
+    /// <param name="bufferSize">ç¼“å†²åŒºå¤§å°</param>
     public JsonWriter(TextWriter writer, bool ownsWriter = false, bool indented = false,
                      string indentString = "  ", int bufferSize = DefaultBufferSize)
     {
@@ -42,15 +44,15 @@ public sealed class JsonWriter : IDisposable
         _indented = indented;
         _indentString = indentString ?? "  ";
         _buffer = new char[Math.Max(bufferSize, 64)];
-        _stateStack = new JsonWriteState[8]; // ³õÊ¼Õ»´óĞ¡
+        _stateStack = new JsonWriteState[8]; // åˆå§‹æ ˆå¤§å°
     }
 
     /// <summary>
-    /// Ê¹ÓÃ StringBuilder ³õÊ¼»¯ JsonWriter ÊµÀı
+    /// ä½¿ç”¨ StringBuilder åˆå§‹åŒ– JsonWriter å®ä¾‹
     /// </summary>
-    /// <param name="sb">ÒªĞ´ÈëµÄ StringBuilder</param>
-    /// <param name="indented">ÊÇ·ñÆôÓÃËõ½ø¸ñÊ½»¯</param>
-    /// <param name="indentString">Ëõ½ø×Ö·û´®</param>
+    /// <param name="sb">è¦å†™å…¥çš„ StringBuilder</param>
+    /// <param name="indented">æ˜¯å¦å¯ç”¨ç¼©è¿›æ ¼å¼åŒ–</param>
+    /// <param name="indentString">ç¼©è¿›å­—ç¬¦ä¸²</param>
     public JsonWriter(StringBuilder sb, bool indented = false, string indentString = "  ")
         : this(new StringWriter(sb), true, indented, indentString)
     {
@@ -66,7 +68,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë¶ÔÏó¿ªÊ¼·û {
+    /// å†™å…¥å¯¹è±¡å¼€å§‹ç¬¦ {
     /// </summary>
     public void WriteStartObject()
     {
@@ -75,23 +77,23 @@ public sealed class JsonWriter : IDisposable
         WriteChar('{');
         PushState(JsonWriteState.Object);
         IncreaseIndent();
-        if (_indented) WriteNewLine(); // ÔÚÔö¼ÓËõ½ø¼¶±ğºóÔÙ»»ĞĞ
+        if (_indented) WriteNewLine(); // åœ¨å¢åŠ ç¼©è¿›çº§åˆ«åå†æ¢è¡Œ
     }
 
     /// <summary>
-    /// Ğ´Èë¶ÔÏó½áÊø·û }
+    /// å†™å…¥å¯¹è±¡ç»“æŸç¬¦ }
     /// </summary>
     public void WriteEndObject()
     {
         PopState(JsonWriteState.Object);
         DecreaseIndent();
-        if (_indented) WriteNewLine(); // ÏÈ»»ĞĞÔÙĞ´Ëõ½ø
+        if (_indented) WriteNewLine(); // å…ˆæ¢è¡Œå†å†™ç¼©è¿›
         WriteIndentIfNeeded();
         WriteChar('}');
     }
 
     /// <summary>
-    /// Ğ´ÈëÊı×é¿ªÊ¼·û [
+    /// å†™å…¥æ•°ç»„å¼€å§‹ç¬¦ [
     /// </summary>
     public void WriteStartArray()
     {
@@ -99,23 +101,23 @@ public sealed class JsonWriter : IDisposable
         WriteChar('[');
         PushState(JsonWriteState.Array);
         IncreaseIndent();
-        if (_indented) WriteNewLine(); // ÔÚÔö¼ÓËõ½ø¼¶±ğºóÔÙ»»ĞĞ
+        if (_indented) WriteNewLine(); // åœ¨å¢åŠ ç¼©è¿›çº§åˆ«åå†æ¢è¡Œ
     }
 
     /// <summary>
-    /// Ğ´ÈëÊı×é½áÊø·û ]
+    /// å†™å…¥æ•°ç»„ç»“æŸç¬¦ ]
     /// </summary>
     public void WriteEndArray()
     {
         PopState(JsonWriteState.Array);
         DecreaseIndent();
-        if (_indented) WriteNewLine(); // ÏÈ»»ĞĞÔÙĞ´Ëõ½ø
+        if (_indented) WriteNewLine(); // å…ˆæ¢è¡Œå†å†™ç¼©è¿›
         WriteIndentIfNeeded();
         WriteChar(']');
     }
 
     /// <summary>
-    /// Ğ´ÈëÊôĞÔÃû
+    /// å†™å…¥å±æ€§å
     /// </summary>
     public void WritePropertyName(string? name)
     {
@@ -132,7 +134,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë×Ö·û´®Öµ
+    /// å†™å…¥å­—ç¬¦ä¸²å€¼
     /// </summary>
     public void WriteValue(string? value)
     {
@@ -151,7 +153,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´ÈëÕûÊıÖµ
+    /// å†™å…¥æ•´æ•°å€¼
     /// </summary>
     public void WriteValue(long value)
     {
@@ -162,7 +164,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë¸¡µãÖµ
+    /// å†™å…¥æµ®ç‚¹å€¼
     /// </summary>
     public void WriteValue(double value)
     {
@@ -182,7 +184,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë²¼¶ûÖµ
+    /// å†™å…¥å¸ƒå°”å€¼
     /// </summary>
     public void WriteValue(bool value)
     {
@@ -193,7 +195,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë null Öµ
+    /// å†™å…¥ null å€¼
     /// </summary>
     public void WriteNull()
     {
@@ -204,7 +206,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´ÈëÔ­Ê¼ JSON
+    /// å†™å…¥åŸå§‹ JSON
     /// </summary>
     public void WriteRaw(string? json)
     {
@@ -218,7 +220,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ë¢ĞÂ»º³åÇø
+    /// åˆ·æ–°ç¼“å†²åŒº
     /// </summary>
     public void Flush()
     {
@@ -238,7 +240,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´ÈëÔ­Ê¼×Ö·û´®£¬²»½øĞĞ×ªÒå
+    /// å†™å…¥åŸå§‹å­—ç¬¦ä¸²ï¼Œä¸è¿›è¡Œè½¬ä¹‰
     /// </summary>
     private void WriteString(string? str)
     {
@@ -252,7 +254,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// Ğ´Èë×Ö·û´®£¬½øĞĞJSON×ªÒå
+    /// å†™å…¥å­—ç¬¦ä¸²ï¼Œè¿›è¡ŒJSONè½¬ä¹‰
     /// </summary>
     private void WriteStringEscaped(string value)
     {
@@ -316,7 +318,7 @@ public sealed class JsonWriter : IDisposable
             var currentState = _stateStack[_stackDepth - 1];
             if (currentState == JsonWriteState.Array || currentState == JsonWriteState.Object)
             {
-                // µÚÒ»¸öÔªËØ²»ĞèÒª¶ººÅ
+                // ç¬¬ä¸€ä¸ªå…ƒç´ ä¸éœ€è¦é€—å·
                 _stateStack[_stackDepth - 1] = JsonWriteState.Value;
             }
             else if (currentState == JsonWriteState.Value)
@@ -324,10 +326,10 @@ public sealed class JsonWriter : IDisposable
                 WriteChar(',');
                 if (_indented) WriteNewLine();
             }
-            // Property ×´Ì¬²»ĞèÒª¶ººÅ£¬Ö»ĞèÒªÉèÖÃÎª Value
+            // Property çŠ¶æ€ä¸éœ€è¦é€—å·ï¼Œåªéœ€è¦è®¾ç½®ä¸º Value
             else if (currentState == JsonWriteState.Property)
             {
-                // ÊôĞÔÃûºóÃæ¸úÖµ£¬²»ĞèÒª¶ººÅ
+                // å±æ€§ååé¢è·Ÿå€¼ï¼Œä¸éœ€è¦é€—å·
             }
         }
     }
@@ -363,7 +365,7 @@ public sealed class JsonWriter : IDisposable
             throw new InvalidOperationException("Invalid JSON structure: unexpected end marker");
 
         var currentState = _stateStack[--_stackDepth];
-        // ÔÊĞí´Ó Value »ò Property ×´Ì¬ÍË³ö Object/Array£¬ÒòÎªÕâĞ©¶¼ÊÇÓĞĞ§µÄ×´Ì¬
+        // å…è®¸ä» Value æˆ– Property çŠ¶æ€é€€å‡º Object/Arrayï¼Œå› ä¸ºè¿™äº›éƒ½æ˜¯æœ‰æ•ˆçš„çŠ¶æ€
         if (currentState != expectedState && currentState != JsonWriteState.Value &&
             !(expectedState == JsonWriteState.Object && currentState == JsonWriteState.Property))
             throw new InvalidOperationException($"Invalid JSON structure: expected {expectedState}, got {currentState}");
@@ -394,7 +396,7 @@ public sealed class JsonWriter : IDisposable
     }
 
     /// <summary>
-    /// ÊÍ·Å×ÊÔ´
+    /// é‡Šæ”¾èµ„æº
     /// </summary>
     public void Dispose()
     {

--- a/src/LuYao.Common/Text/Json/JsonWriter.cs
+++ b/src/LuYao.Common/Text/Json/JsonWriter.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+/// <summary>
+/// 高性能 JSON 写入器，使用固定大小缓冲区和 Span 优化
+/// </summary>
+public sealed class JsonWriter : IDisposable
+{
+    private readonly TextWriter _writer;
+    private readonly bool _ownsWriter;
+    private char[]? _buffer;
+    private int _bufferPosition;
+    private bool _disposed;
+
+    private const int DefaultBufferSize = 4096;
+
+    // JSON 状态栈，用于管理嵌套结构
+    private JsonWriteState[] _stateStack;
+    private int _stackDepth;
+
+    // 格式化选项
+    private readonly bool _indented;
+    private readonly string _indentString;
+    private int _currentIndentLevel;
+
+    /// <summary>
+    /// 初始化 JsonWriter 实例
+    /// </summary>
+    /// <param name="writer">要写入的 TextWriter</param>
+    /// <param name="ownsWriter">是否拥有并释放 TextWriter</param>
+    /// <param name="indented">是否启用缩进格式化</param>
+    /// <param name="indentString">缩进字符串</param>
+    /// <param name="bufferSize">缓冲区大小</param>
+    public JsonWriter(TextWriter writer, bool ownsWriter = false, bool indented = false,
+                     string indentString = "  ", int bufferSize = DefaultBufferSize)
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _ownsWriter = ownsWriter;
+        _indented = indented;
+        _indentString = indentString ?? "  ";
+        _buffer = new char[Math.Max(bufferSize, 64)];
+        _stateStack = new JsonWriteState[8]; // 初始栈大小
+    }
+
+    /// <summary>
+    /// 使用 StringBuilder 初始化 JsonWriter 实例
+    /// </summary>
+    /// <param name="sb">要写入的 StringBuilder</param>
+    /// <param name="indented">是否启用缩进格式化</param>
+    /// <param name="indentString">缩进字符串</param>
+    public JsonWriter(StringBuilder sb, bool indented = false, string indentString = "  ")
+        : this(new StringWriter(sb), true, indented, indentString)
+    {
+    }
+
+    private enum JsonWriteState
+    {
+        Start,
+        Object,
+        Array,
+        Property,
+        Value
+    }
+
+    /// <summary>
+    /// 写入对象开始符 {
+    /// </summary>
+    public void WriteStartObject()
+    {
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteChar('{');
+        PushState(JsonWriteState.Object);
+        IncreaseIndent();
+        if (_indented) WriteNewLine(); // 在增加缩进级别后再换行
+    }
+
+    /// <summary>
+    /// 写入对象结束符 }
+    /// </summary>
+    public void WriteEndObject()
+    {
+        PopState(JsonWriteState.Object);
+        DecreaseIndent();
+        if (_indented) WriteNewLine(); // 先换行再写缩进
+        WriteIndentIfNeeded();
+        WriteChar('}');
+    }
+
+    /// <summary>
+    /// 写入数组开始符 [
+    /// </summary>
+    public void WriteStartArray()
+    {
+        WriteValueSeparator();
+        WriteChar('[');
+        PushState(JsonWriteState.Array);
+        IncreaseIndent();
+        if (_indented) WriteNewLine(); // 在增加缩进级别后再换行
+    }
+
+    /// <summary>
+    /// 写入数组结束符 ]
+    /// </summary>
+    public void WriteEndArray()
+    {
+        PopState(JsonWriteState.Array);
+        DecreaseIndent();
+        if (_indented) WriteNewLine(); // 先换行再写缩进
+        WriteIndentIfNeeded();
+        WriteChar(']');
+    }
+
+    /// <summary>
+    /// 写入属性名
+    /// </summary>
+    public void WritePropertyName(string? name)
+    {
+        if (name == null)
+            throw new ArgumentNullException(nameof(name));
+
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteStringEscaped(name);
+        WriteChar(':');
+        if (_indented) WriteChar(' ');
+
+        SetState(JsonWriteState.Property);
+    }
+
+    /// <summary>
+    /// 写入字符串值
+    /// </summary>
+    public void WriteValue(string? value)
+    {
+        WriteValueSeparator();
+
+        if (value == null)
+        {
+            WriteNull();
+        }
+        else
+        {
+            WriteStringEscaped(value);
+        }
+
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 写入整数值
+    /// </summary>
+    public void WriteValue(long value)
+    {
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteString(value.ToString(CultureInfo.InvariantCulture));
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 写入浮点值
+    /// </summary>
+    public void WriteValue(double value)
+    {
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            WriteNull();
+        }
+        else
+        {
+            WriteString(value.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 写入布尔值
+    /// </summary>
+    public void WriteValue(bool value)
+    {
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteString(value ? "true" : "false");
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 写入 null 值
+    /// </summary>
+    public void WriteNull()
+    {
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteString("null");
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 写入原始 JSON
+    /// </summary>
+    public void WriteRaw(string? json)
+    {
+        if (json == null)
+            throw new ArgumentNullException(nameof(json));
+
+        WriteValueSeparator();
+        WriteIndentIfNeeded();
+        WriteString(json);
+        SetState(JsonWriteState.Value);
+    }
+
+    /// <summary>
+    /// 刷新缓冲区
+    /// </summary>
+    public void Flush()
+    {
+        if (_bufferPosition > 0)
+        {
+            _writer.Write(_buffer, 0, _bufferPosition);
+            _bufferPosition = 0;
+        }
+        _writer.Flush();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void WriteChar(char c)
+    {
+        EnsureCapacity(1);
+        _buffer![_bufferPosition++] = c;
+    }
+
+    /// <summary>
+    /// 写入原始字符串，不进行转义
+    /// </summary>
+    private void WriteString(string? str)
+    {
+        if (str == null) return;
+
+        EnsureCapacity(str.Length);
+        for (int i = 0; i < str.Length; i++)
+        {
+            _buffer![_bufferPosition++] = str[i];
+        }
+    }
+
+    /// <summary>
+    /// 写入字符串，进行JSON转义
+    /// </summary>
+    private void WriteStringEscaped(string value)
+    {
+        if (value == null) return;
+
+        WriteChar('"');
+
+        foreach (char c in value)
+        {
+            switch (c)
+            {
+                case '"':
+                    WriteString("\\\"");
+                    break;
+                case '\\':
+                    WriteString("\\\\");
+                    break;
+                case '\b':
+                    WriteString("\\b");
+                    break;
+                case '\f':
+                    WriteString("\\f");
+                    break;
+                case '\n':
+                    WriteString("\\n");
+                    break;
+                case '\r':
+                    WriteString("\\r");
+                    break;
+                case '\t':
+                    WriteString("\\t");
+                    break;
+                default:
+                    if (char.IsControl(c))
+                    {
+                        WriteString($"\\u{(int)c:x4}");
+                    }
+                    else
+                    {
+                        WriteChar(c);
+                    }
+                    break;
+            }
+        }
+
+        WriteChar('"');
+    }
+
+    private void EnsureCapacity(int count)
+    {
+        if (_bufferPosition + count >= _buffer!.Length)
+        {
+            Flush();
+        }
+    }
+
+    private void WriteValueSeparator()
+    {
+        if (_stackDepth > 0)
+        {
+            var currentState = _stateStack[_stackDepth - 1];
+            if (currentState == JsonWriteState.Array || currentState == JsonWriteState.Object)
+            {
+                // 第一个元素不需要逗号
+                _stateStack[_stackDepth - 1] = JsonWriteState.Value;
+            }
+            else if (currentState == JsonWriteState.Value)
+            {
+                WriteChar(',');
+                if (_indented) WriteNewLine();
+            }
+            // Property 状态不需要逗号，只需要设置为 Value
+            else if (currentState == JsonWriteState.Property)
+            {
+                // 属性名后面跟值，不需要逗号
+            }
+        }
+    }
+
+    private void WriteIndentIfNeeded()
+    {
+        if (_indented && _currentIndentLevel > 0)
+        {
+            for (int i = 0; i < _currentIndentLevel; i++)
+            {
+                WriteString(_indentString);
+            }
+        }
+    }
+
+    private void WriteNewLine()
+    {
+        WriteChar('\n');
+    }
+
+    private void PushState(JsonWriteState state)
+    {
+        if (_stackDepth >= _stateStack.Length)
+        {
+            Array.Resize(ref _stateStack, _stateStack.Length * 2);
+        }
+        _stateStack[_stackDepth++] = state;
+    }
+
+    private void PopState(JsonWriteState expectedState)
+    {
+        if (_stackDepth == 0)
+            throw new InvalidOperationException("Invalid JSON structure: unexpected end marker");
+
+        var currentState = _stateStack[--_stackDepth];
+        // 允许从 Value 或 Property 状态退出 Object/Array，因为这些都是有效的状态
+        if (currentState != expectedState && currentState != JsonWriteState.Value &&
+            !(expectedState == JsonWriteState.Object && currentState == JsonWriteState.Property))
+            throw new InvalidOperationException($"Invalid JSON structure: expected {expectedState}, got {currentState}");
+    }
+
+    private void SetState(JsonWriteState state)
+    {
+        if (_stackDepth > 0)
+        {
+            _stateStack[_stackDepth - 1] = state;
+        }
+    }
+
+    private void IncreaseIndent()
+    {
+        if (_indented)
+        {
+            _currentIndentLevel++;
+        }
+    }
+
+    private void DecreaseIndent()
+    {
+        if (_indented)
+        {
+            _currentIndentLevel--;
+        }
+    }
+
+    /// <summary>
+    /// 释放资源
+    /// </summary>
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            Flush();
+
+            _buffer = null;
+
+            if (_ownsWriter)
+            {
+                _writer?.Dispose();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/tests/LuYao.Common.UnitTests/Text/Json/JsonReaderTest.cs
+++ b/tests/LuYao.Common.UnitTests/Text/Json/JsonReaderTest.cs
@@ -1,0 +1,577 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LuYao.Text.Json;
+
+[TestClass]
+public class JsonReaderTest
+{
+    [TestMethod]
+    public void Constructor_WithTextReader_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var textReader = new StringReader("{}");
+
+        // Act
+        using var jsonReader = new JsonReader(textReader);
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.None, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+        Assert.AreEqual(1, jsonReader.Line);
+        Assert.AreEqual(1, jsonReader.Column);
+    }
+
+    [TestMethod]
+    public void Constructor_WithString_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        string json = "{}";
+
+        // Act
+        using var jsonReader = new JsonReader(json);
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.None, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+        Assert.AreEqual(1, jsonReader.Line);
+        Assert.AreEqual(1, jsonReader.Column);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void Constructor_WithNullTextReader_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        new JsonReader((TextReader)null);
+    }
+
+    [TestMethod]
+    public void Read_EmptyObject_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("{}");
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.StartObject, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.EndObject, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+
+        Assert.IsFalse(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.None, jsonReader.TokenType);
+    }
+
+    [TestMethod]
+    public void Read_EmptyArray_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("[]");
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.StartArray, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.EndArray, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+
+        Assert.IsFalse(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.None, jsonReader.TokenType);
+    }
+
+    [TestMethod]
+    public void Read_SimpleString_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"hello\"");
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("hello", jsonReader.Value);
+
+        Assert.IsFalse(jsonReader.Read());
+    }
+
+    [TestMethod]
+    public void Read_PropertyName_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("{\"name\":\"value\"}");
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read()); // {
+        Assert.AreEqual(JsonTokenType.StartObject, jsonReader.TokenType);
+
+        Assert.IsTrue(jsonReader.Read()); // "name"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("name", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // "value"
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("value", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // }
+        Assert.AreEqual(JsonTokenType.EndObject, jsonReader.TokenType);
+    }
+
+    [TestMethod]
+    public void Read_StringWithEscapes_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"hello\\nworld\\t\\\"test\\\"\"");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("hello\nworld\t\"test\"", jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_StringWithUnicodeEscape_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"\\u0048\\u0065\\u006C\\u006C\\u006F\""); // "Hello"
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("Hello", jsonReader.Value);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_StringWithInvalidUnicodeEscape_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"\\uGGGG\"");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_StringWithInvalidEscape_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"\\x\"");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_UnterminatedString_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"unterminated");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Read_PositiveInteger_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("123");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(123L, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_NegativeInteger_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("-456");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(-456L, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_PositiveDecimal_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("123.45");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(123.45, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_NegativeDecimal_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("-123.45");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(-123.45, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_NumberWithExponent_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("1.23e4");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(12300.0, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_NumberWithNegativeExponent_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("1.23e-4");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(0.000123, jsonReader.Value);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_InvalidNumber_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("-");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Read_BooleanTrue_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("true");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Boolean, jsonReader.TokenType);
+        Assert.AreEqual(true, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_BooleanFalse_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("false");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Boolean, jsonReader.TokenType);
+        Assert.AreEqual(false, jsonReader.Value);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_InvalidBoolean_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("tru");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Read_Null_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("null");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Null, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_InvalidNull_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("nul");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Read_ComplexObject_ShouldReadCorrectly()
+    {
+        // Arrange
+        string json = "{\"name\":\"John\",\"age\":30,\"active\":true,\"scores\":[85,92,78],\"address\":null}";
+        using var jsonReader = new JsonReader(json);
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read()); // {
+        Assert.AreEqual(JsonTokenType.StartObject, jsonReader.TokenType);
+
+        Assert.IsTrue(jsonReader.Read()); // "name"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("name", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // "John"
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("John", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // "age"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("age", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // 30
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(30L, jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // "active"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("active", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // true
+        Assert.AreEqual(JsonTokenType.Boolean, jsonReader.TokenType);
+        Assert.AreEqual(true, jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // "scores"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("scores", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // [
+        Assert.AreEqual(JsonTokenType.StartArray, jsonReader.TokenType);
+
+        Assert.IsTrue(jsonReader.Read()); // 85
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(85L, jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // 92
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(92L, jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // 78
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(78L, jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // ]
+        Assert.AreEqual(JsonTokenType.EndArray, jsonReader.TokenType);
+
+        Assert.IsTrue(jsonReader.Read()); // "address"
+        Assert.AreEqual(JsonTokenType.PropertyName, jsonReader.TokenType);
+        Assert.AreEqual("address", jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // null
+        Assert.AreEqual(JsonTokenType.Null, jsonReader.TokenType);
+        Assert.IsNull(jsonReader.Value);
+
+        Assert.IsTrue(jsonReader.Read()); // }
+        Assert.AreEqual(JsonTokenType.EndObject, jsonReader.TokenType);
+
+        Assert.IsFalse(jsonReader.Read()); // EOF
+        Assert.AreEqual(JsonTokenType.None, jsonReader.TokenType);
+    }
+
+    [TestMethod]
+    public void Read_WithWhitespace_ShouldSkipWhitespace()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("  \t\r\n  {  \t\r\n  }  \t\r\n  ");
+
+        // Act & Assert
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.StartObject, jsonReader.TokenType);
+
+        Assert.IsTrue(jsonReader.Read());
+        Assert.AreEqual(JsonTokenType.EndObject, jsonReader.TokenType);
+
+        Assert.IsFalse(jsonReader.Read());
+    }
+
+    [TestMethod]
+    public void LineAndColumn_ShouldUpdateCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("{\n  \"name\": \"value\"\n}");
+
+        // Act & Assert
+        Assert.AreEqual(1, jsonReader.Line);
+        Assert.AreEqual(1, jsonReader.Column);
+
+        Assert.IsTrue(jsonReader.Read()); // {
+        Assert.AreEqual(1, jsonReader.Line);
+        Assert.AreEqual(2, jsonReader.Column);
+
+        Assert.IsTrue(jsonReader.Read()); // "name"
+        Assert.AreEqual(2, jsonReader.Line);
+
+        Assert.IsTrue(jsonReader.Read()); // "value"
+
+        Assert.IsTrue(jsonReader.Read()); // }
+        Assert.AreEqual(3, jsonReader.Line);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_UnexpectedCharacter_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("@");
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ObjectDisposedException))]
+    public void Read_AfterDispose_ShouldThrowObjectDisposedException()
+    {
+        // Arrange
+        var jsonReader = new JsonReader("{}");
+        jsonReader.Dispose();
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Dispose_ShouldDisposeCorrectly()
+    {
+        // Arrange
+        var textReader = new StringReader("{}");
+        var jsonReader = new JsonReader(textReader, ownsReader: true);
+
+        // Act
+        jsonReader.Dispose();
+
+        // Assert - 第二次调用不应该抛出异常
+        jsonReader.Dispose();
+    }
+
+    [TestMethod]
+    public void Dispose_WithoutOwningReader_ShouldNotDisposeReader()
+    {
+        // Arrange
+        var textReader = new StringReader("{}");
+        var jsonReader = new JsonReader(textReader, ownsReader: false);
+
+        // Act
+        jsonReader.Dispose();
+
+        // Assert - Reader 应该仍然可用
+        // 注意：这里我们无法直接验证 TextReader 未被释放，因为 StringReader 没有公共的 IsDisposed 属性
+        // 但我们可以确保 JsonReader 正确处理了 ownsReader 参数
+    }
+
+    [TestMethod]
+    public void Read_LargeNumber_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("9223372036854775807"); // long.MaxValue
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(long.MaxValue, jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_VeryLargeNumber_ShouldReadAsDouble()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("1.7976931348623157e308"); // 接近 double.MaxValue
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.IsInstanceOfType(jsonReader.Value, typeof(double));
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Read_StringWithUnescapedControlCharacter_ShouldThrowException()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"\u0001\""); // 未转义的控制字符
+
+        // Act
+        jsonReader.Read();
+    }
+
+    [TestMethod]
+    public void Read_EmptyString_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("\"\"");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.String, jsonReader.TokenType);
+        Assert.AreEqual("", jsonReader.Value);
+    }
+
+    [TestMethod]
+    public void Read_Zero_ShouldReadCorrectly()
+    {
+        // Arrange
+        using var jsonReader = new JsonReader("0");
+
+        // Act
+        Assert.IsTrue(jsonReader.Read());
+
+        // Assert
+        Assert.AreEqual(JsonTokenType.Number, jsonReader.TokenType);
+        Assert.AreEqual(0L, jsonReader.Value);
+    }
+}

--- a/tests/LuYao.Common.UnitTests/Text/Json/JsonWriterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Text/Json/JsonWriterTests.cs
@@ -1,0 +1,715 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace LuYao.Text.Json;
+
+[TestClass]
+public class JsonWriterTests
+{
+    private StringBuilder _stringBuilder;
+    private JsonWriter _writer;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _stringBuilder = new StringBuilder();
+        _writer = new JsonWriter(_stringBuilder);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _writer?.Dispose();
+    }
+
+    #region Constructor Tests
+
+    [TestMethod]
+    public void Constructor_WithTextWriter_ShouldCreateWriter()
+    {
+        // Arrange
+        using var stringWriter = new StringWriter();
+
+        // Act
+        using var writer = new JsonWriter(stringWriter);
+
+        // Assert
+        Assert.IsNotNull(writer);
+    }
+
+    [TestMethod]
+    public void Constructor_WithStringBuilder_ShouldCreateWriter()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+
+        // Act
+        using var writer = new JsonWriter(sb);
+
+        // Assert
+        Assert.IsNotNull(writer);
+    }
+
+    [TestMethod]
+    public void Constructor_WithNullTextWriter_ShouldThrowArgumentNullException()
+    {
+        // Arrange & Act & Assert
+        Assert.ThrowsException<ArgumentNullException>(() => new JsonWriter((TextWriter)null));
+    }
+
+    [TestMethod]
+    public void Constructor_WithIndentation_ShouldCreateIndentedWriter()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+
+        // Act
+        using var writer = new JsonWriter(sb, indented: true, indentString: "    ");
+
+        // Assert
+        Assert.IsNotNull(writer);
+    }
+
+    #endregion
+
+    #region Object Tests
+
+    [TestMethod]
+    public void WriteStartObject_ShouldWriteOpeningBrace()
+    {
+        // Act
+        _writer.WriteStartObject();
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("{", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteEndObject_ShouldWriteClosingBrace()
+    {
+        // Act
+        _writer.WriteStartObject();
+        _writer.WriteEndObject();
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("{}", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteObject_WithIndentation_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new JsonWriter(sb, indented: true);
+
+        // Act
+        writer.WriteStartObject();
+        writer.WritePropertyName("test");
+        writer.WriteValue("value");
+        writer.WriteEndObject();
+        writer.Flush();
+
+        // Assert
+        var result = sb.ToString();
+        Assert.IsTrue(result.Contains("{\n"));
+        Assert.IsTrue(result.Contains("  \"test\": \"value\"\n"));
+        Assert.IsTrue(result.Contains("}"));
+    }
+
+    [TestMethod]
+    public void WriteEndObject_WithoutStartObject_ShouldThrowInvalidOperationException()
+    {
+        // Act & Assert
+        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndObject());
+    }
+
+    #endregion
+
+    #region Array Tests
+
+    [TestMethod]
+    public void WriteStartArray_ShouldWriteOpeningBracket()
+    {
+        // Act
+        _writer.WriteStartArray();
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("[", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteEndArray_ShouldWriteClosingBracket()
+    {
+        // Act
+        _writer.WriteStartArray();
+        _writer.WriteEndArray();
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("[]", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteArray_WithIndentation_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new JsonWriter(sb, indented: true);
+
+        // Act
+        writer.WriteStartArray();
+        writer.WriteValue(1);
+        writer.WriteValue(2);
+        writer.WriteEndArray();
+        writer.Flush();
+
+        // Assert
+        var result = sb.ToString();
+        Assert.IsTrue(result.Contains("[\n"));
+        Assert.IsTrue(result.Contains("1,\n"));
+        Assert.IsTrue(result.Contains("2\n"));
+        Assert.IsTrue(result.Contains("]"));
+    }
+
+    [TestMethod]
+    public void WriteEndArray_WithoutStartArray_ShouldThrowInvalidOperationException()
+    {
+        // Act & Assert
+        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndArray());
+    }
+
+    #endregion
+
+    #region Property Tests
+
+    [TestMethod]
+    public void WritePropertyName_ValidName_ShouldWriteQuotedName()
+    {
+        // Act
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("test");
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("{\"test\":", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WritePropertyName_WithIndentation_ShouldIncludeSpace()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new JsonWriter(sb, indented: true);
+
+        // Act
+        writer.WriteStartObject();
+        writer.WritePropertyName("test");
+        writer.Flush();
+
+        // Assert
+        var result = sb.ToString();
+        Assert.IsTrue(result.Contains("\"test\": "));
+    }
+
+    [TestMethod]
+    public void WritePropertyName_NullName_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.ThrowsException<ArgumentNullException>(() => _writer.WritePropertyName(null));
+    }
+
+    #endregion
+
+    #region String Value Tests
+
+    [TestMethod]
+    public void WriteValue_String_ShouldWriteQuotedString()
+    {
+        // Act
+        _writer.WriteValue("test");
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("\"test\"", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_NullString_ShouldWriteNull()
+    {
+        // Act
+        _writer.WriteValue((string)null);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("null", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_StringWithEscapeCharacters_ShouldEscapeCorrectly()
+    {
+        // Arrange
+        var testCases = new[]
+        {
+            ("\"", "\\\""),
+            ("\\", "\\\\"),
+            ("\b", "\\b"),
+            ("\f", "\\f"),
+            ("\n", "\\n"),
+            ("\r", "\\r"),
+            ("\t", "\\t")
+        };
+
+        foreach (var (input, expected) in testCases)
+        {
+            // Arrange
+            var sb = new StringBuilder();
+            using var writer = new JsonWriter(sb);
+
+            // Act
+            writer.WriteValue(input);
+            writer.Flush();
+
+            // Assert
+            Assert.AreEqual($"\"{expected}\"", sb.ToString(), $"Failed for input: {input}");
+        }
+    }
+
+    [TestMethod]
+    public void WriteValue_StringWithControlCharacters_ShouldUnicodeEscape()
+    {
+        // Act
+        _writer.WriteValue("\u0001");
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("\"\\u0001\"", _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Numeric Value Tests
+
+    [TestMethod]
+    public void WriteValue_Long_ShouldWriteNumber()
+    {
+        // Act
+        _writer.WriteValue(12345L);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("12345", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_NegativeLong_ShouldWriteNegativeNumber()
+    {
+        // Act
+        _writer.WriteValue(-12345L);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("-12345", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_Double_ShouldWriteNumber()
+    {
+        // Act
+        _writer.WriteValue(123.45);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("123.45", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_DoubleNaN_ShouldWriteNull()
+    {
+        // Act
+        _writer.WriteValue(double.NaN);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("null", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_DoubleInfinity_ShouldWriteNull()
+    {
+        // Act
+        _writer.WriteValue(double.PositiveInfinity);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("null", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_DoubleNegativeInfinity_ShouldWriteNull()
+    {
+        // Act
+        _writer.WriteValue(double.NegativeInfinity);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("null", _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Boolean Value Tests
+
+    [TestMethod]
+    public void WriteValue_BooleanTrue_ShouldWriteTrue()
+    {
+        // Act
+        _writer.WriteValue(true);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("true", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteValue_BooleanFalse_ShouldWriteFalse()
+    {
+        // Act
+        _writer.WriteValue(false);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("false", _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Null Value Tests
+
+    [TestMethod]
+    public void WriteNull_ShouldWriteNull()
+    {
+        // Act
+        _writer.WriteNull();
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("null", _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Raw Value Tests
+
+    [TestMethod]
+    public void WriteRaw_ValidJson_ShouldWriteRawValue()
+    {
+        // Act
+        _writer.WriteRaw("{\"key\":\"value\"}");
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("{\"key\":\"value\"}", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteRaw_NullValue_ShouldThrowArgumentNullException()
+    {
+        // Act & Assert
+        Assert.ThrowsException<ArgumentNullException>(() => _writer.WriteRaw(null));
+    }
+
+    #endregion
+
+    #region Complex JSON Tests
+
+    [TestMethod]
+    public void WriteComplexObject_ShouldProduceValidJson()
+    {
+        // Act
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("name");
+        _writer.WriteValue("John");
+        _writer.WritePropertyName("age");
+        _writer.WriteValue(30L);
+        _writer.WritePropertyName("active");
+        _writer.WriteValue(true);
+        _writer.WritePropertyName("address");
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("city");
+        _writer.WriteValue("New York");
+        _writer.WriteEndObject();
+        _writer.WriteEndObject();
+        _writer.Flush();
+
+        // Assert
+        var expected = "{\"name\":\"John\",\"age\":30,\"active\":true,\"address\":{\"city\":\"New York\"}}";
+        Assert.AreEqual(expected, _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteComplexArray_ShouldProduceValidJson()
+    {
+        // Act
+        _writer.WriteStartArray();
+        _writer.WriteValue("item1");
+        _writer.WriteValue(42L);
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("nested");
+        _writer.WriteValue("value");
+        _writer.WriteEndObject();
+        _writer.WriteEndArray();
+        _writer.Flush();
+
+        // Assert
+        var expected = "[\"item1\",42,{\"nested\":\"value\"}]";
+        Assert.AreEqual(expected, _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteNestedArraysAndObjects_ShouldProduceValidJson()
+    {
+        // Act
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("data");
+        _writer.WriteStartArray();
+        _writer.WriteStartObject();
+        _writer.WritePropertyName("id");
+        _writer.WriteValue(1L);
+        _writer.WritePropertyName("tags");
+        _writer.WriteStartArray();
+        _writer.WriteValue("tag1");
+        _writer.WriteValue("tag2");
+        _writer.WriteEndArray();
+        _writer.WriteEndObject();
+        _writer.WriteEndArray();
+        _writer.WriteEndObject();
+        _writer.Flush();
+
+        // Assert
+        var expected = "{\"data\":[{\"id\":1,\"tags\":[\"tag1\",\"tag2\"]}]}";
+        Assert.AreEqual(expected, _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Indentation Tests
+
+    [TestMethod]
+    public void WriteIndentedJson_ShouldFormatWithNewlinesAndIndentation()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new JsonWriter(sb, indented: true, indentString: "  ");
+
+        // Act
+        writer.WriteStartObject();
+        writer.WritePropertyName("name");
+        writer.WriteValue("John");
+        writer.WritePropertyName("items");
+        writer.WriteStartArray();
+        writer.WriteValue(1L);
+        writer.WriteValue(2L);
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.Flush();
+
+        // Assert
+        var result = sb.ToString();
+        Assert.IsTrue(result.Contains("{\n"));
+        Assert.IsTrue(result.Contains("  \"name\": \"John\",\n"));
+        Assert.IsTrue(result.Contains("  \"items\": [\n"));
+        Assert.IsTrue(result.Contains("    1,\n"));
+        Assert.IsTrue(result.Contains("    2\n"));
+        Assert.IsTrue(result.Contains("  ]\n"));
+        Assert.IsTrue(result.Contains("}"));
+    }
+
+    [TestMethod]
+    public void WriteIndentedJson_CustomIndentString_ShouldUseCustomIndentation()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        using var writer = new JsonWriter(sb, indented: true, indentString: "\t");
+
+        // Act
+        writer.WriteStartObject();
+        writer.WritePropertyName("key");
+        writer.WriteValue("value");
+        writer.WriteEndObject();
+        writer.Flush();
+
+        // Assert
+        var result = sb.ToString();
+        Assert.IsTrue(result.Contains("\t\"key\": \"value\""));
+    }
+
+    #endregion
+
+    #region Buffer Management Tests
+
+    [TestMethod]
+    public void WriteValue_LongString_ShouldHandleBuffering()
+    {
+        // Arrange
+        var longString = new string('a', 10000);
+
+        // Act
+        _writer.WriteValue(longString);
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual($"\"{longString}\"", _stringBuilder.ToString());
+    }
+
+    [TestMethod]
+    public void WriteMultipleValues_ShouldHandleBufferFlushes()
+    {
+        // Act
+        for (int i = 0; i < 1000; i++)
+        {
+            if (i == 0)
+                _writer.WriteStartArray();
+
+            _writer.WriteValue($"item{i}");
+
+            if (i == 999)
+                _writer.WriteEndArray();
+        }
+        _writer.Flush();
+
+        // Assert
+        var result = _stringBuilder.ToString();
+        Assert.IsTrue(result.StartsWith("["));
+        Assert.IsTrue(result.EndsWith("]"));
+        Assert.IsTrue(result.Contains("\"item0\""));
+        Assert.IsTrue(result.Contains("\"item999\""));
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [TestMethod]
+    public void WriteInvalidStructure_ShouldThrowInvalidOperationException()
+    {
+        // Act & Assert
+        _writer.WriteStartObject();
+        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndArray());
+    }
+
+    [TestMethod]
+    public void WritePropertyNameOutsideObject_ShouldNotThrow()
+    {
+        // This test verifies current behavior - property names can be written at root level
+        // Act
+        _writer.WritePropertyName("test");
+        _writer.WriteValue("value");
+        _writer.Flush();
+
+        // Assert
+        Assert.AreEqual("\"test\":\"value\"", _stringBuilder.ToString());
+    }
+
+    #endregion
+
+    #region Disposal Tests
+
+    [TestMethod]
+    public void Dispose_ShouldFlushAndCleanup()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        var writer = new JsonWriter(sb);
+
+        // Act
+        writer.WriteValue("test");
+        writer.Dispose();
+
+        // Assert
+        Assert.AreEqual("\"test\"", sb.ToString());
+    }
+
+    [TestMethod]
+    public void Dispose_CalledTwice_ShouldNotThrow()
+    {
+        // Arrange
+        var sb = new StringBuilder();
+        var writer = new JsonWriter(sb);
+
+        // Act & Assert
+        writer.Dispose();
+        writer.Dispose(); // Should not throw
+    }
+
+    [TestMethod]
+    public void Dispose_WithOwnedWriter_ShouldDisposeUnderlyingWriter()
+    {
+        // Arrange
+        var stringWriter = new StringWriter();
+        var writer = new JsonWriter(stringWriter, ownsWriter: true);
+
+        // Act
+        writer.WriteValue("test");
+        writer.Dispose();
+
+        // Assert
+        Assert.AreEqual("\"test\"", stringWriter.ToString());
+        // Note: We can't easily verify that stringWriter is disposed without reflection
+    }
+
+    #endregion
+
+    #region Culture Tests
+
+    [TestMethod]
+    public void WriteValue_DoubleWithDifferentCulture_ShouldUseInvariantCulture()
+    {
+        // Arrange
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE"); // Uses comma as decimal separator
+
+            // Act
+            _writer.WriteValue(123.45);
+            _writer.Flush();
+
+            // Assert
+            Assert.AreEqual("123.45", _stringBuilder.ToString()); // Should use dot, not comma
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [TestMethod]
+    public void WriteValue_LongWithDifferentCulture_ShouldUseInvariantCulture()
+    {
+        // Arrange
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("en-IN"); // Uses different number formatting
+
+            // Act
+            _writer.WriteValue(1234567L);
+            _writer.Flush();
+
+            // Assert
+            Assert.AreEqual("1234567", _stringBuilder.ToString()); // No thousand separators
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
This pull request introduces a new `JsonToken` struct and `JsonTokenType` enum to the codebase, providing foundational types for representing and working with JSON tokens. These additions will help standardize how JSON structures are parsed and handled across the project.

JSON token infrastructure:

* Added the `JsonTokenType` enum to define various types of JSON tokens, such as objects, arrays, property names, values, and comments. (`src/LuYao.Common/Text/Json/JsonToken.cs`)
* Introduced the `JsonToken` readonly struct to encapsulate the type, value, start index, and length of a JSON token, supporting precise parsing and manipulation. (`src/LuYao.Common/Text/Json/JsonToken.cs`)