### PR TITLE
新增 JSON 记录加载和保存适配器

### DIFF
--- a/src/LuYao.Common/Data/Json/JsonRecordLoadAdapter.cs
+++ b/src/LuYao.Common/Data/Json/JsonRecordLoadAdapter.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using LuYao.Data.Models;
+using LuYao.Text.Json;
+
+namespace LuYao.Data.Json;
+
+/// <summary>
+/// 提供从JSON格式流中读取记录数据的适配器实现。
+/// </summary>
+/// <remarks>
+/// 该类继承自 <see cref="RecordLoadAdapter"/>，专门用于从JSON格式反序列化记录数据。
+/// 它使用 <see cref="JsonReader"/> 从底层流中读取各种数据类型。
+/// JSON结构包含header、columns和rows等部分。
+/// </remarks>
+public class JsonRecordLoadAdapter : RecordLoadAdapter
+{
+    private RecordSection _section = RecordSection.Head;
+    private string _name = string.Empty;
+    private readonly Dictionary<string, object?> _currentRowData = new();
+    private readonly List<string> _currentRowKeys = new();
+    private int _currentFieldIndex = -1;
+
+    /// <summary>
+    /// 获取用于读取JSON数据的 <see cref="JsonReader"/> 实例。
+    /// </summary>
+    /// <value>用于执行JSON读取操作的 <see cref="JsonReader"/> 对象。</value>
+    public JsonReader Reader { get; }
+
+    /// <inheritdoc/>
+    public override RecordLoadKeyKind KeyKind => RecordLoadKeyKind.Name;
+
+    /// <inheritdoc/>
+    public override RecordSection Section => _section;
+
+    /// <inheritdoc/>
+    public override int Index => -1;
+
+    /// <inheritdoc/>
+    public override string Name => _name;
+
+    /// <summary>
+    /// 使用指定的JSON读取器初始化 <see cref="JsonRecordLoadAdapter"/> 类的新实例。
+    /// </summary>
+    /// <param name="reader">用于读取JSON数据的 <see cref="JsonReader"/> 实例。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="reader"/> 为 null 时抛出。</exception>
+    public JsonRecordLoadAdapter(JsonReader reader)
+    {
+        Reader = reader ?? throw new ArgumentNullException(nameof(reader));
+    }
+
+    /// <inheritdoc/>
+    public override bool ReadSection()
+    {
+        while (Reader.Read())
+        {
+            if (Reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string sectionName = Reader.Value?.ToString()?.ToLowerInvariant() ?? string.Empty;
+                switch (sectionName)
+                {
+                    case "head":
+                        _section = RecordSection.Head;
+                        return true;
+                    case "columns":
+                        _section = RecordSection.Columns;
+                        Reader.Read();
+                        return true;
+                    case "rows":
+                        _section = RecordSection.Rows;
+                        Reader.Read();
+                        return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public override RecordHeader ReadHeader()
+    {
+        var header = new RecordHeader();
+
+        while (Reader.Read())
+        {
+            if (Reader.TokenType == JsonTokenType.StartObject)
+            {
+                continue;
+            }
+            else if (Reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+            else if (Reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string propertyName = Reader.Value?.ToString() ?? string.Empty;
+                Reader.Read(); // Move to value
+
+                string value = Reader.Value?.ToString() ?? string.Empty;
+                switch (propertyName)
+                {
+                    case "name": header.Name = value; break;
+                    case "columns": header.Columns = Valid.ToInt32(value); break;
+                    case "count": header.Count = Valid.ToInt32(value); break;
+                }
+            }
+        }
+
+        return header;
+    }
+
+    /// <inheritdoc/>
+    public override RecordColumnInfo ReadColumn()
+    {
+        var ret = new RecordColumnInfo { Type = typeof(Object) };
+
+        // Expect to be at the start of column object or move to next one
+        while (Reader.Read())
+        {
+            if (Reader.TokenType == JsonTokenType.StartObject)
+            {
+                break;
+            }
+            if (Reader.TokenType == JsonTokenType.EndArray)
+            {
+                return ret; // No more columns
+            }
+        }
+
+        while (Reader.Read())
+        {
+            if (Reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+
+            if (Reader.TokenType == JsonTokenType.PropertyName)
+            {
+                string propertyName = Reader.Value?.ToString() ?? string.Empty;
+                Reader.Read(); // Move to value
+
+                string value = Reader.Value?.ToString() ?? string.Empty;
+                switch (propertyName)
+                {
+                    case "name": ret.Name = value; break;
+                    case "code": ret.Code = Enum<RecordDataCode>.Parse(value); break;
+                    case "type": ret.ParseTypeName(value); break;
+                }
+            }
+        }
+
+        return ret;
+    }
+
+    /// <inheritdoc/>
+    public override bool ReadRow()
+    {
+        _currentRowData.Clear();
+        _currentRowKeys.Clear();
+        _currentFieldIndex = -1;
+
+        // Look for next object in rows array
+        while (Reader.Read())
+        {
+            if (Reader.TokenType == JsonTokenType.StartObject)
+            {
+                // Read all properties of this row object
+                while (Reader.Read())
+                {
+                    if (Reader.TokenType == JsonTokenType.EndObject)
+                    {
+                        break;
+                    }
+
+                    if (Reader.TokenType == JsonTokenType.PropertyName)
+                    {
+                        string propertyName = Reader.Value?.ToString() ?? string.Empty;
+                        Reader.Read(); // Move to value
+
+                        _currentRowData[propertyName] = Reader.Value;
+                        _currentRowKeys.Add(propertyName);
+                    }
+                }
+                return true;
+            }
+            else if (Reader.TokenType == JsonTokenType.EndArray)
+            {
+                return false; // End of rows array
+            }
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public override bool ReadField()
+    {
+        _currentFieldIndex++;
+        if (_currentFieldIndex < _currentRowKeys.Count)
+        {
+            _name = _currentRowKeys[_currentFieldIndex];
+            return true;
+        }
+        return false;
+    }
+
+    private bool TryGetCurrentValue(out object? value)
+    {
+        value = null;
+        if (_currentFieldIndex >= 0 && _currentFieldIndex < _currentRowKeys.Count)
+        {
+            string fieldName = _currentRowKeys[_currentFieldIndex];
+            return _currentRowData.TryGetValue(fieldName, out value);
+        }
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public override bool ReadBoolean()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is bool boolValue)
+                return boolValue;
+            return Valid.ToBoolean(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override byte ReadByte()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (byte)longValue;
+            return Valid.ToByte(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override char ReadChar()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            return Valid.ToChar(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override DateTime ReadDateTime()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            return Valid.ToDateTime(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override decimal ReadDecimal()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is double doubleValue)
+                return (decimal)doubleValue;
+            return Valid.ToDecimal(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override double ReadDouble()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is double doubleValue)
+                return doubleValue;
+            return Valid.ToDouble(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override short ReadInt16()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (short)longValue;
+            return Valid.ToInt16(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override int ReadInt32()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (int)longValue;
+            return Valid.ToInt32(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override long ReadInt64()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return longValue;
+            return Valid.ToInt64(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override sbyte ReadSByte()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (sbyte)longValue;
+            return Valid.ToSByte(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override float ReadSingle()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is double doubleValue)
+                return (float)doubleValue;
+            return Valid.ToSingle(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override string ReadString()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            return value?.ToString() ?? string.Empty;
+        }
+        return string.Empty;
+    }
+
+    /// <inheritdoc/>
+    public override ushort ReadUInt16()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (ushort)longValue;
+            return Valid.ToUInt16(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override uint ReadUInt32()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (uint)longValue;
+            return Valid.ToUInt32(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <inheritdoc/>
+    public override ulong ReadUInt64()
+    {
+        if (TryGetCurrentValue(out var value))
+        {
+            if (value is long longValue)
+                return (ulong)longValue;
+            return Valid.ToUInt64(value?.ToString() ?? string.Empty);
+        }
+        return default;
+    }
+
+    /// <exception cref="NotImplementedException">复杂类型的JSON读写暂不支持。</exception>
+    public override object? ReadObject(object type)
+    {
+        throw new NotImplementedException("复杂类型的JSON读写暂不支持");
+    }
+}

--- a/src/LuYao.Common/Data/Json/JsonRecordSaveAdapter.cs
+++ b/src/LuYao.Common/Data/Json/JsonRecordSaveAdapter.cs
@@ -1,0 +1,240 @@
+using LuYao.Data.Models;
+using LuYao.Text.Json;
+using System;
+using System.Collections.Generic;
+
+namespace LuYao.Data.Json;
+
+/// <summary>
+/// 提供将记录数据以JSON格式写入流的适配器实现。
+/// </summary>
+/// <remarks>
+/// 该类继承自 <see cref="RecordSaveAdapter"/>，专门用于将记录数据序列化为JSON格式。
+/// 它使用 <see cref="JsonWriter"/> 将各种数据类型写入底层流中。
+/// JSON结构包含header、columns和rows等部分。
+/// </remarks>
+public class JsonRecordSaveAdapter : RecordSaveAdapter
+{
+    /// <summary>
+    /// 获取用于写入JSON数据的 <see cref="JsonWriter"/> 实例。
+    /// </summary>
+    /// <value>用于执行JSON写入操作的 <see cref="JsonWriter"/> 对象。</value>
+    public JsonWriter Writer { get; }
+
+    /// <inheritdoc/>
+    public override IReadOnlyList<RecordSection> Layout { get; } = [RecordSection.Head, RecordSection.Columns, RecordSection.Rows];
+
+    /// <summary>
+    /// 使用指定的JSON写入器初始化 <see cref="JsonRecordSaveAdapter"/> 类的新实例。
+    /// </summary>
+    /// <param name="writer">用于写入JSON数据的 <see cref="JsonWriter"/> 实例。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="writer"/> 为 null 时抛出。</exception>
+    public JsonRecordSaveAdapter(JsonWriter writer)
+    {
+        Writer = writer ?? throw new ArgumentNullException(nameof(writer));
+    }
+
+    /// <remarks>
+    /// 将列信息写入JSON，作为对象并将属性存储为键值对。
+    /// </remarks>
+    public override void WriteColumn(RecordColumnInfo column)
+    {
+        string type = column.GetTypeName();
+        Writer.WriteStartObject();
+        Writer.WritePropertyName("name");
+        Writer.WriteValue(column.Name);
+        Writer.WritePropertyName("code");
+        Writer.WriteValue(Valid.ToString(column.Code));
+        Writer.WritePropertyName("type");
+        Writer.WriteValue(type);
+        Writer.WriteEndObject();
+    }
+
+    /// <remarks>
+    /// 将记录头信息写入JSON，作为对象并将属性存储为键值对。
+    /// </remarks>
+    public override void WriteHeader(RecordHeader header)
+    {
+        Writer.WriteStartObject();
+        Writer.WritePropertyName("name");
+        Writer.WriteValue(header.Name);
+        Writer.WritePropertyName("columns");
+        Writer.WriteValue(header.Columns);
+        Writer.WritePropertyName("count");
+        Writer.WriteValue(header.Count);
+        Writer.WriteEndObject();
+    }
+
+    /// <exception cref="NotImplementedException">复杂类型的JSON读写暂不支持。</exception>
+    public override void WriteObject(string name, int index, object? value) => throw new NotImplementedException("复杂类型的JSON读写暂不支持");
+
+    /// <remarks>
+    /// 将布尔值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteBoolean(string name, int index, bool value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(value);
+    }
+
+    /// <remarks>
+    /// 将字节值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteByte(string name, int index, byte value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将字符值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteChar(string name, int index, char value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(Valid.ToString(value));
+    }
+
+    /// <remarks>
+    /// 将日期时间值转换为ISO 8601格式后作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteDateTime(string name, int index, DateTime value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(value.ToString("O"));
+    }
+
+    /// <remarks>
+    /// 将十进制数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteDecimal(string name, int index, decimal value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((double)value);
+    }
+
+    /// <remarks>
+    /// 将双精度浮点数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteDouble(string name, int index, double value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(value);
+    }
+
+    /// <remarks>
+    /// 结束当前行对象的写入。
+    /// </remarks>
+    public override void WriteEndRow() => Writer.WriteEndObject();
+
+    /// <remarks>
+    /// 将16位有符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteInt16(string name, int index, short value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将32位有符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteInt32(string name, int index, int value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将64位有符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteInt64(string name, int index, long value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(value);
+    }
+
+    /// <remarks>
+    /// 将8位有符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteSByte(string name, int index, sbyte value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将单精度浮点数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteSingle(string name, int index, float value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((double)value);
+    }
+
+    /// <remarks>
+    /// 开始写入新的行对象。
+    /// </remarks>
+    public override void WriteStarRow() => Writer.WriteStartObject();
+
+    /// <remarks>
+    /// 将字符串值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteString(string name, int index, string value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue(value);
+    }
+
+    /// <remarks>
+    /// 将16位无符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteUInt16(string name, int index, ushort value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将32位无符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteUInt32(string name, int index, uint value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <remarks>
+    /// 将64位无符号整数值作为属性写入当前行对象。
+    /// </remarks>
+    public override void WriteUInt64(string name, int index, ulong value)
+    {
+        Writer.WritePropertyName(name);
+        Writer.WriteValue((long)value);
+    }
+
+    /// <inheritdoc/>
+    public override void WriteStart()
+    {
+        Writer.WriteStartObject();
+    }
+
+    /// <inheritdoc/>
+    public override void WriteEnd()
+    {
+        Writer.WriteEndObject();
+    }
+
+    /// <inheritdoc/>
+    public override void WriteStartSection(RecordSection section)
+    {
+        Writer.WritePropertyName(section.ToString().ToLowerInvariant());
+        Writer.WriteStartArray();
+    }
+
+    /// <inheritdoc/>
+    public override void WriteEndSection()
+    {
+        Writer.WriteEndArray();
+    }
+}


### PR DESCRIPTION
在 `JsonRecordLoadAdapter.cs` 中，新增了 `JsonRecordLoadAdapter` 类，用于从 JSON 格式读取记录，支持读取头部、列和行，并提供多种数据类型的读取方法。

在 `JsonRecordSaveAdapter.cs` 中，新增了 `JsonRecordSaveAdapter` 类，用于将记录写入 JSON 格式，支持写入头部、列和行，并实现了多种数据类型的写入方法。