### PR TITLE
统一异常断言为 Assert.Throws/ThrowsAsync 并升级 MSTest

### DIFF
--- a/tests/LuYao.Common.UnitTests/Collections/Concurrent/AsyncQueueTests.cs
+++ b/tests/LuYao.Common.UnitTests/Collections/Concurrent/AsyncQueueTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LuYao.Collections.Concurrent;
+namespace LuYao.Collections.Concurrent;
 
 [TestClass]
 public class AsyncQueueTests
@@ -53,7 +53,7 @@ public class AsyncQueueTests
         cts.Cancel();
 
         // Act & Assert
-        await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () =>
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
             await queue.DequeueAsync(cts.Token);
         });

--- a/tests/LuYao.Common.UnitTests/Collections/EnumerableExtensionsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Collections/EnumerableExtensionsTests.cs
@@ -63,26 +63,23 @@ public class EnumerableExtensionsTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void SplitToBatch_NullSource_ThrowsArgumentNullException()
     {
         List<int>? input = null;
-        _ = input.SplitToBatch(2).ToList();
+        Assert.Throws<ArgumentNullException>(() => _ = input.SplitToBatch(2).ToList());
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void SplitToBatch_BatchSizeZero_ThrowsArgumentOutOfRangeException()
     {
         var input = Enumerable.Range(1, 3);
-        _ = input.SplitToBatch(0).ToList();
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = input.SplitToBatch(0).ToList());
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void SplitToBatch_BatchSizeNegative_ThrowsArgumentOutOfRangeException()
     {
         var input = Enumerable.Range(1, 3);
-        _ = input.SplitToBatch(-1).ToList();
+        Assert.Throws<ArgumentOutOfRangeException>(() => _ = input.SplitToBatch(-1).ToList());
     }
 }

--- a/tests/LuYao.Common.UnitTests/Collections/Generic/KeyedListTests.cs
+++ b/tests/LuYao.Common.UnitTests/Collections/Generic/KeyedListTests.cs
@@ -63,13 +63,10 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Constructor_WithNullKeySelector_ThrowsArgumentNullException()
     {
-        // Arrange & Act
-        var keyedList = new KeyedList<int, TestItem>(null!);
-
-        // Assert: 期望抛出 ArgumentNullException
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new KeyedList<int, TestItem>(null!));
     }
 
     #endregion
@@ -87,13 +84,10 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Indexer_GetWithInvalidIndex_ThrowsArgumentOutOfRangeException()
     {
-        // Arrange & Act
-        var item = _keyedList[-1];
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => { var item = _keyedList[-1]; });
     }
 
     [TestMethod]
@@ -110,16 +104,13 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Indexer_SetWithInvalidIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         var newItem = new TestItem { Id = 10, Name = "New Item" };
 
-        // Act
-        _keyedList[10] = newItem;
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList[10] = newItem);
     }
 
     #endregion
@@ -375,39 +366,30 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void CopyTo_NullArray_ThrowsArgumentNullException()
     {
-        // Arrange & Act
-        _keyedList.CopyTo(null!, 0);
-
-        // Assert: 期望抛出 ArgumentNullException
+        // Arrange & Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _keyedList.CopyTo(null!, 0));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void CopyTo_NegativeArrayIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         var array = new TestItem[_keyedList.Count];
 
-        // Act
-        _keyedList.CopyTo(array, -1);
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList.CopyTo(array, -1));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void CopyTo_InsufficientArraySpace_ThrowsArgumentException()
     {
         // Arrange
         var array = new TestItem[_keyedList.Count - 1];
 
-        // Act
-        _keyedList.CopyTo(array, 0);
-
-        // Assert: 期望抛出 ArgumentException
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => _keyedList.CopyTo(array, 0));
     }
 
     #endregion
@@ -482,29 +464,23 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Insert_NegativeIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         var newItem = new TestItem { Id = 4, Name = "Item 4" };
 
-        // Act
-        _keyedList.Insert(-1, newItem);
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList.Insert(-1, newItem));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Insert_IndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
         var newItem = new TestItem { Id = 4, Name = "Item 4" };
 
-        // Act
-        _keyedList.Insert(_keyedList.Count + 1, newItem);
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList.Insert(_keyedList.Count + 1, newItem));
     }
 
     #endregion
@@ -562,23 +538,17 @@ public class KeyedListTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void RemoveAt_NegativeIndex_ThrowsArgumentOutOfRangeException()
     {
-        // Act
-        _keyedList.RemoveAt(-1);
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList.RemoveAt(-1));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void RemoveAt_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
     {
-        // Act
-        _keyedList.RemoveAt(_keyedList.Count);
-
-        // Assert: 期望抛出 ArgumentOutOfRangeException
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => _keyedList.RemoveAt(_keyedList.Count));
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Collections/Generic/WeakCollectionTests.cs
+++ b/tests/LuYao.Common.UnitTests/Collections/Generic/WeakCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -16,7 +16,7 @@ public class WeakCollectionTests
         var collection = new WeakCollection<object>();
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => collection.Add(null));
+        Assert.Throws<ArgumentNullException>(() => collection.Add(null));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -1,16 +1,16 @@
-ï»¿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 
 namespace LuYao.Data;
 
 /// <summary>
-/// æµ‹è¯•æ³›å‹ Set å’Œ To æ–¹æ³•çš„åŠŸèƒ½å’Œæ€§èƒ½
+/// ²âÊÔ·ºĞÍ Set ºÍ To ·½·¨µÄ¹¦ÄÜºÍĞÔÄÜ
 /// </summary>
 [TestClass]
 public class GenericMethodTests
 {
     /// <summary>
-    /// æµ‹è¯• RecordColumn çš„æ³›å‹ Set æ–¹æ³•
+    /// ²âÊÔ RecordColumn µÄ·ºĞÍ Set ·½·¨
     /// </summary>
     [TestMethod]
     public void RecordColumn_GenericSet_ShouldWorkWithAllTypes()
@@ -26,7 +26,7 @@ public class GenericMethodTests
         var row = record.AddRow();
         var rowIndex = 0;
 
-        // Act & Assert - æµ‹è¯•æ‰€æœ‰åŸºç¡€ç±»å‹
+        // Act & Assert - ²âÊÔËùÓĞ»ù´¡ÀàĞÍ
         intColumn.Set(42, rowIndex);
         Assert.AreEqual(42, intColumn.Get<Int32>(rowIndex));
 
@@ -45,7 +45,7 @@ public class GenericMethodTests
     }
 
     /// <summary>
-    /// æµ‹è¯• RecordRow çš„æ³›å‹ Set æ–¹æ³•
+    /// ²âÊÔ RecordRow µÄ·ºĞÍ Set ·½·¨
     /// </summary>
     [TestMethod]
     public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
@@ -70,7 +70,7 @@ public class GenericMethodTests
 
 
     /// <summary>
-    /// æµ‹è¯• To æ³›å‹æ–¹æ³•
+    /// ²âÊÔ To ·ºĞÍ·½·¨
     /// </summary>
     [TestMethod]
     public void GenericTo_ShouldReturnCorrectTypes()
@@ -81,7 +81,7 @@ public class GenericMethodTests
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var row = record.AddRow();
 
-        // è®¾ç½®ä¸€äº›æµ‹è¯•æ•°æ®
+        // ÉèÖÃÒ»Ğ©²âÊÔÊı¾İ
         intColumn.Set(42);
         stringColumn.Set("Hello");
 
@@ -92,11 +92,11 @@ public class GenericMethodTests
         string stringValue = stringColumn.Get<string>(0);
         Assert.AreEqual("Hello", stringValue);
 
-        // æµ‹è¯•ç±»å‹è½¬æ¢
+        // ²âÊÔÀàĞÍ×ª»»
         string intAsString = intColumn.Get<string>(0);
         Assert.AreEqual("42", intAsString);
 
-        // é€šè¿‡ RecordRow æµ‹è¯•
+        // Í¨¹ı RecordRow ²âÊÔ
         int intFromRow = row.Get<int>(intColumn);
         Assert.AreEqual(42, intFromRow);
 
@@ -105,7 +105,7 @@ public class GenericMethodTests
     }
 
     /// <summary>
-    /// æµ‹è¯•å¯ç©ºç±»å‹æ”¯æŒ
+    /// ²âÊÔ¿É¿ÕÀàĞÍÖ§³Ö
     /// </summary>
     [TestMethod]
     public void GenericMethods_NullableTypes_ShouldWork()
@@ -115,19 +115,19 @@ public class GenericMethodTests
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var row = record.AddRow();
 
-        // Act & Assert - æµ‹è¯•å¯ç©ºç±»å‹
+        // Act & Assert - ²âÊÔ¿É¿ÕÀàĞÍ
         int? nullableValue = 42;
         intColumn.SetValue(nullableValue, 0);
         Assert.AreEqual(42, intColumn.Get<Int32>(0));
 
-        // æµ‹è¯• null å€¼å¤„ç†
+        // ²âÊÔ null Öµ´¦Àí
         intColumn.SetValue(null, 0);
         int defaultValue = intColumn.Get<Int32>(0);
-        Assert.AreEqual(0, defaultValue); // é»˜è®¤å€¼
+        Assert.AreEqual(0, defaultValue); // Ä¬ÈÏÖµ
     }
 
     /// <summary>
-    /// æµ‹è¯•è¾¹ç•Œæƒ…å†µ
+    /// ²âÊÔ±ß½çÇé¿ö
     /// </summary>
     [TestMethod]
     public void GenericMethods_EdgeCases_ShouldHandleCorrectly()
@@ -137,18 +137,18 @@ public class GenericMethodTests
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var row = record.AddRow();
 
-        // Act & Assert - æµ‹è¯•ç©ºå­—ç¬¦ä¸²
+        // Act & Assert - ²âÊÔ¿Õ×Ö·û´®
         stringColumn.Set("", 0);
         Assert.AreEqual("", stringColumn.Get<String>(0));
 
-        // æµ‹è¯• null å­—ç¬¦ä¸²
+        // ²âÊÔ null ×Ö·û´®
         stringColumn.Set(null, 0);
         string result = stringColumn.Get<String>(0);
-        Assert.IsNull(result); // åº”è¯¥è¿”å› null
+        Assert.IsNull(result); // Ó¦¸Ã·µ»Ø null
     }
 
     /// <summary>
-    /// æµ‹è¯•ç´¢å¼•éªŒè¯
+    /// ²âÊÔË÷ÒıÑéÖ¤
     /// </summary>
     [TestMethod]
     public void GenericSet_InvalidIndex_ShouldThrowException()
@@ -156,18 +156,18 @@ public class GenericMethodTests
         // Arrange
         var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
-        record.AddRow(); // åªæœ‰ä¸€è¡Œï¼Œæœ‰æ•ˆç´¢å¼•æ˜¯ 0
+        record.AddRow(); // Ö»ÓĞÒ»ĞĞ£¬ÓĞĞ§Ë÷ÒıÊÇ 0
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(42, 1)); // æ— æ•ˆç´¢å¼•
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            intColumn.Set(42, 1)); // ÎŞĞ§Ë÷Òı
 
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(42, -1)); // è´Ÿç´¢å¼•
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            intColumn.Set(42, -1)); // ¸ºË÷Òı
     }
 
     /// <summary>
-    /// æ€§èƒ½å¯¹æ¯”æµ‹è¯• - å±•ç¤ºæ³›å‹æ–¹æ³•ç›¸å¯¹äºé€šç”¨æ–¹æ³•çš„ä¼˜åŠ¿
+    /// ĞÔÄÜ¶Ô±È²âÊÔ - Õ¹Ê¾·ºĞÍ·½·¨Ïà¶ÔÓÚÍ¨ÓÃ·½·¨µÄÓÅÊÆ
     /// </summary>
     [TestMethod]
     public void GenericMethods_PerformanceComparison()
@@ -176,19 +176,19 @@ public class GenericMethodTests
         var record = new Record("PerfTest", 1000);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
 
-        // æ·»åŠ  1000 è¡Œ
+        // Ìí¼Ó 1000 ĞĞ
         for (int i = 0; i < 1000; i++)
         {
             record.AddRow();
         }
 
-        //é¢„çƒ­
+        //Ô¤ÈÈ
         intColumn.Set(0, 0);
         intColumn.SetValue(1, 1);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
-        // æµ‹è¯•æ³›å‹æ–¹æ³•æ€§èƒ½
+        // ²âÊÔ·ºĞÍ·½·¨ĞÔÄÜ
         sw.Restart();
         for (int i = 0; i < 1000; i++)
         {
@@ -196,7 +196,7 @@ public class GenericMethodTests
         }
         var genericTime = sw.ElapsedTicks;
 
-        // æµ‹è¯•é€šç”¨æ–¹æ³•æ€§èƒ½  
+        // ²âÊÔÍ¨ÓÃ·½·¨ĞÔÄÜ  
         sw.Restart();
         for (int i = 0; i < 1000; i++)
         {
@@ -206,24 +206,24 @@ public class GenericMethodTests
 
         sw.Stop();
 
-        // éªŒè¯ç»“æœæ­£ç¡®æ€§
+        // ÑéÖ¤½á¹ûÕıÈ·ĞÔ
         for (int i = 0; i < 1000; i++)
         {
             Assert.AreEqual(i, intColumn.Get<Int32>(i));
         }
 
-        // è¾“å‡ºæ€§èƒ½å¯¹æ¯”ï¼ˆè°ƒè¯•ä¿¡æ¯ï¼‰
-        System.Diagnostics.Debug.WriteLine($"æ³›å‹æ–¹æ³•è€—æ—¶: {genericTime} ticks");
-        System.Diagnostics.Debug.WriteLine($"é€šç”¨æ–¹æ³•è€—æ—¶: {objectTime} ticks");
-        System.Diagnostics.Debug.WriteLine($"æ€§èƒ½æå‡: {(double)objectTime / genericTime:F2}x");
+        // Êä³öĞÔÄÜ¶Ô±È£¨µ÷ÊÔĞÅÏ¢£©
+        System.Diagnostics.Debug.WriteLine($"·ºĞÍ·½·¨ºÄÊ±: {genericTime} ticks");
+        System.Diagnostics.Debug.WriteLine($"Í¨ÓÃ·½·¨ºÄÊ±: {objectTime} ticks");
+        System.Diagnostics.Debug.WriteLine($"ĞÔÄÜÌáÉı: {(double)objectTime / genericTime:F2}x");
 
-        // æ³›å‹æ–¹æ³•åº”è¯¥æ›´å¿«ï¼ˆå…è®¸ä¸€å®šçš„æµ‹é‡è¯¯å·®ï¼‰
+        // ·ºĞÍ·½·¨Ó¦¸Ã¸ü¿ì£¨ÔÊĞíÒ»¶¨µÄ²âÁ¿Îó²î£©
         Assert.IsTrue(genericTime <= objectTime * 1.5,
-            $"æ³›å‹æ–¹æ³•æ€§èƒ½åº”è¯¥ä¼˜äºæˆ–æ¥è¿‘é€šç”¨æ–¹æ³•ã€‚æ³›å‹: {genericTime}, é€šç”¨: {objectTime}");
+            $"·ºĞÍ·½·¨ĞÔÄÜÓ¦¸ÃÓÅÓÚ»ò½Ó½üÍ¨ÓÃ·½·¨¡£·ºĞÍ: {genericTime}, Í¨ÓÃ: {objectTime}");
     }
 
     /// <summary>
-    /// æµ‹è¯•ä¸åŒæ•°æ®ç±»å‹çš„è½¬æ¢çŸ©é˜µ
+    /// ²âÊÔ²»Í¬Êı¾İÀàĞÍµÄ×ª»»¾ØÕó
     /// </summary>
     [TestMethod]
     public void GenericMethods_TypeConversionMatrix_ShouldWork()
@@ -237,25 +237,25 @@ public class GenericMethodTests
 
         var row = record.AddRow();
 
-        // Act & Assert - æµ‹è¯•å„ç§ç±»å‹è½¬æ¢
+        // Act & Assert - ²âÊÔ¸÷ÖÖÀàĞÍ×ª»»
 
-        // int -> å…¶ä»–ç±»å‹
+        // int -> ÆäËûÀàĞÍ
         intColumn.Set(42, 0);
         Assert.AreEqual(42.0, intColumn.Get<double>(0), 0.001);
         Assert.AreEqual("42", intColumn.Get<string>(0));
-        Assert.AreEqual(true, intColumn.Get<bool>(0)); // éé›¶å€¼ä¸º true
+        Assert.AreEqual(true, intColumn.Get<bool>(0)); // ·ÇÁãÖµÎª true
 
-        // double -> å…¶ä»–ç±»å‹
+        // double -> ÆäËûÀàĞÍ
         doubleColumn.Set(3.14, 0);
-        Assert.AreEqual(3, doubleColumn.Get<int>(0)); // æˆªæ–­
+        Assert.AreEqual(3, doubleColumn.Get<int>(0)); // ½Ø¶Ï
         Assert.AreEqual("3.14", doubleColumn.Get<string>(0));
 
-        // string -> å…¶ä»–ç±»å‹
+        // string -> ÆäËûÀàĞÍ
         stringColumn.Set("123", 0);
         Assert.AreEqual(123, stringColumn.Get<int>(0));
         Assert.AreEqual(123.0, stringColumn.Get<double>(0), 0.001);
 
-        // bool -> å…¶ä»–ç±»å‹
+        // bool -> ÆäËûÀàĞÍ
         boolColumn.Set(true, 0);
         Assert.AreEqual(1, boolColumn.Get<int>(0));
         Assert.AreEqual("True", boolColumn.Get<string>(0));

--- a/tests/LuYao.Common.UnitTests/Data/RecordLoaderTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordLoaderTests.cs
@@ -1,4 +1,4 @@
-ï»¿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -11,7 +11,7 @@ namespace LuYao.Data;
 public class RecordLoaderTests
 {
     /// <summary>
-    /// æµ‹è¯•ç”¨çš„å®ä½“ç±»
+    /// ²âÊÔÓÃµÄÊµÌåÀà
     /// </summary>
     public class TestEntity
     {
@@ -29,7 +29,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯•ç”¨çš„ç®€å•å®ä½“ç±»
+    /// ²âÊÔÓÃµÄ¼òµ¥ÊµÌåÀà
     /// </summary>
     public class SimpleEntity
     {
@@ -38,13 +38,13 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// åˆ›å»ºæµ‹è¯•ç”¨çš„ Record å’Œæ•°æ®
+    /// ´´½¨²âÊÔÓÃµÄ Record ºÍÊı¾İ
     /// </summary>
     private (Record record, RecordRow row) CreateTestRecord()
     {
         var record = new Record("TestTable", 1);
 
-        // æ·»åŠ åˆ—
+        // Ìí¼ÓÁĞ
         var idColumn = record.Columns.Add<Int32>("Id");
         var nameColumn = record.Columns.Add<String>("Name");
         var createTimeColumn = record.Columns.Add<DateTime>("CreateTime");
@@ -54,16 +54,16 @@ public class RecordLoaderTests
         var nullableIntColumn = record.Columns.Add<Int32>("NullableInt");
         var nullableDateTimeColumn = record.Columns.Add<DateTime>("NullableDateTime");
 
-        // æ·»åŠ ä¸€è¡Œæ•°æ®
+        // Ìí¼ÓÒ»ĞĞÊı¾İ
         var row = record.AddRow();
 
-        // è®¾ç½®æ•°æ®
+        // ÉèÖÃÊı¾İ
         idColumn.Set(123);
-        nameColumn.Set("æµ‹è¯•åç§°");
+        nameColumn.Set("²âÊÔÃû³Æ");
         createTimeColumn.Set(new DateTime(2023, 7, 28, 10, 30, 0));
         isActiveColumn.Set(true);
         scoreColumn.Set(95.5);
-        customColumn.Set("è‡ªå®šä¹‰å€¼");
+        customColumn.Set("×Ô¶¨ÒåÖµ");
         nullableIntColumn.Set(456);
         nullableDateTimeColumn.Set(new DateTime(2023, 8, 1));
 
@@ -71,7 +71,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• Populate æ–¹æ³• - åŸºæœ¬æ•°æ®ç±»å‹å¡«å……
+    /// ²âÊÔ Populate ·½·¨ - »ù±¾Êı¾İÀàĞÍÌî³ä
     /// </summary>
     [TestMethod]
     public void Populate_BasicDataTypes_ShouldFillEntityCorrectly()
@@ -85,17 +85,17 @@ public class RecordLoaderTests
 
         // Assert
         Assert.AreEqual(123, entity.Id);
-        Assert.AreEqual("æµ‹è¯•åç§°", entity.Name);
+        Assert.AreEqual("²âÊÔÃû³Æ", entity.Name);
         Assert.AreEqual(new DateTime(2023, 7, 28, 10, 30, 0), entity.CreateTime);
         Assert.AreEqual(true, entity.IsActive);
-        Assert.AreEqual(95.5, entity.Score, 0.001); // æµ®ç‚¹æ•°æ¯”è¾ƒ
-        Assert.AreEqual("è‡ªå®šä¹‰å€¼", entity.CustomField);
+        Assert.AreEqual(95.5, entity.Score, 0.001); // ¸¡µãÊı±È½Ï
+        Assert.AreEqual("×Ô¶¨ÒåÖµ", entity.CustomField);
         Assert.AreEqual(456, entity.NullableInt);
         Assert.AreEqual(new DateTime(2023, 8, 1), entity.NullableDateTime);
     }
 
     /// <summary>
-    /// æµ‹è¯• Populate æ–¹æ³• - åˆ—ä¸å­˜åœ¨çš„æƒ…å†µ
+    /// ²âÊÔ Populate ·½·¨ - ÁĞ²»´æÔÚµÄÇé¿ö
     /// </summary>
     [TestMethod]
     public void Populate_MissingColumns_ShouldNotThrowException()
@@ -108,7 +108,7 @@ public class RecordLoaderTests
 
         var entity = new TestEntity
         {
-            Name = "åŸå§‹åç§°",
+            Name = "Ô­Ê¼Ãû³Æ",
             Score = 50.0
         };
 
@@ -116,13 +116,13 @@ public class RecordLoaderTests
         RecordLoader<TestEntity>.Populate(row, entity);
 
         // Assert
-        Assert.AreEqual(100, entity.Id); // Id åˆ—å­˜åœ¨ï¼Œåº”è¯¥è¢«å¡«å……
-        Assert.AreEqual("åŸå§‹åç§°", entity.Name); // Name åˆ—ä¸å­˜åœ¨ï¼Œä¿æŒåŸå€¼
-        Assert.AreEqual(50.0, entity.Score); // Score åˆ—ä¸å­˜åœ¨ï¼Œä¿æŒåŸå€¼
+        Assert.AreEqual(100, entity.Id); // Id ÁĞ´æÔÚ£¬Ó¦¸Ã±»Ìî³ä
+        Assert.AreEqual("Ô­Ê¼Ãû³Æ", entity.Name); // Name ÁĞ²»´æÔÚ£¬±£³ÖÔ­Öµ
+        Assert.AreEqual(50.0, entity.Score); // Score ÁĞ²»´æÔÚ£¬±£³ÖÔ­Öµ
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteData æ–¹æ³• - åŸºæœ¬æ•°æ®å†™å…¥
+    /// ²âÊÔ WriteData ·½·¨ - »ù±¾Êı¾İĞ´Èë
     /// </summary>
     [TestMethod]
     public void WriteData_BasicDataTypes_ShouldWriteToRecordCorrectly()
@@ -130,7 +130,7 @@ public class RecordLoaderTests
         // Arrange
         var record = new Record("TestTable", 1);
 
-        // æ·»åŠ åˆ—
+        // Ìí¼ÓÁĞ
         var idColumn = record.Columns.Add<Int32>("Id");
         var nameColumn = record.Columns.Add<String>("Name");
         var createTimeColumn = record.Columns.Add<DateTime>("CreateTime");
@@ -144,11 +144,11 @@ public class RecordLoaderTests
         var entity = new TestEntity
         {
             Id = 789,
-            Name = "å†™å…¥æµ‹è¯•",
+            Name = "Ğ´Èë²âÊÔ",
             CreateTime = new DateTime(2023, 9, 15, 14, 20, 30),
             IsActive = false,
             Score = 88.8,
-            CustomField = "å†™å…¥è‡ªå®šä¹‰",
+            CustomField = "Ğ´Èë×Ô¶¨Òå",
             NullableInt = 999
         };
 
@@ -157,16 +157,16 @@ public class RecordLoaderTests
 
         // Assert
         Assert.AreEqual(789, row.Get<Int32>(idColumn));
-        Assert.AreEqual("å†™å…¥æµ‹è¯•", row.Get<String>(nameColumn));
+        Assert.AreEqual("Ğ´Èë²âÊÔ", row.Get<String>(nameColumn));
         Assert.AreEqual(new DateTime(2023, 9, 15, 14, 20, 30), row.Get<DateTime>(createTimeColumn));
         Assert.AreEqual(false, row.Get<Boolean>(isActiveColumn));
         Assert.AreEqual(88.8, row.Get<Double>(scoreColumn), 0.001);
-        Assert.AreEqual("å†™å…¥è‡ªå®šä¹‰", row.Get<String>(customColumn));
+        Assert.AreEqual("Ğ´Èë×Ô¶¨Òå", row.Get<String>(customColumn));
         Assert.AreEqual(999, row.Get<Int32>(nullableIntColumn));
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteData æ–¹æ³• - åˆ—ä¸å­˜åœ¨çš„æƒ…å†µ
+    /// ²âÊÔ WriteData ·½·¨ - ÁĞ²»´æÔÚµÄÇé¿ö
     /// </summary>
     [TestMethod]
     public void WriteData_MissingColumns_ShouldNotThrowException()
@@ -179,28 +179,28 @@ public class RecordLoaderTests
         var entity = new TestEntity
         {
             Id = 555,
-            Name = "éƒ¨åˆ†å†™å…¥",
+            Name = "²¿·ÖĞ´Èë",
             Score = 77.7
         };
 
-        // Act & Assert - ä¸åº”è¯¥æŠ›å‡ºå¼‚å¸¸
+        // Act & Assert - ²»Ó¦¸ÃÅ×³öÒì³£
         RecordLoader<TestEntity>.WriteToRow(entity, row);
 
-        // éªŒè¯å­˜åœ¨çš„åˆ—è¢«æ­£ç¡®å†™å…¥
+        // ÑéÖ¤´æÔÚµÄÁĞ±»ÕıÈ·Ğ´Èë
         Assert.AreEqual(555, row.Get<Int32>(idColumn));
     }
 
     /// <summary>
-    /// æµ‹è¯• RecordColumnNameAttribute ç‰¹æ€§
+    /// ²âÊÔ RecordColumnNameAttribute ÌØĞÔ
     /// </summary>
     [TestMethod]
     public void Populate_WithRecordColumnNameAttribute_ShouldUseAttributeName()
     {
         // Arrange
         var record = new Record("TestTable", 1);
-        var customColumn = record.Columns.Add<String>("custom_column"); // ä½¿ç”¨ç‰¹æ€§æŒ‡å®šçš„åç§°
+        var customColumn = record.Columns.Add<String>("custom_column"); // Ê¹ÓÃÌØĞÔÖ¸¶¨µÄÃû³Æ
         var row = record.AddRow();
-        customColumn.Set("ç‰¹æ€§æµ‹è¯•å€¼");
+        customColumn.Set("ÌØĞÔ²âÊÔÖµ");
 
         var entity = new TestEntity();
 
@@ -208,11 +208,11 @@ public class RecordLoaderTests
         RecordLoader<TestEntity>.Populate(row, entity);
 
         // Assert
-        Assert.AreEqual("ç‰¹æ€§æµ‹è¯•å€¼", entity.CustomField);
+        Assert.AreEqual("ÌØĞÔ²âÊÔÖµ", entity.CustomField);
     }
 
     /// <summary>
-    /// æµ‹è¯•å¯ç©ºç±»å‹çš„å¤„ç†
+    /// ²âÊÔ¿É¿ÕÀàĞÍµÄ´¦Àí
     /// </summary>
     [TestMethod]
     public void Populate_NullableTypes_ShouldHandleNullValues()
@@ -223,26 +223,26 @@ public class RecordLoaderTests
         var nullableDateTimeColumn = record.Columns.Add<DateTime>("NullableDateTime");
         var row = record.AddRow();
 
-        // è®¾ç½®ä¸º null å€¼ï¼ˆé€šè¿‡ä¸è®¾ç½®ä»»ä½•å€¼æ¥æ¨¡æ‹Ÿ nullï¼‰
+        // ÉèÖÃÎª null Öµ£¨Í¨¹ı²»ÉèÖÃÈÎºÎÖµÀ´Ä£Äâ null£©
 
         var entity = new TestEntity
         {
-            NullableInt = 100, // è®¾ç½®åˆå§‹å€¼
-            NullableDateTime = DateTime.Now // è®¾ç½®åˆå§‹å€¼
+            NullableInt = 100, // ÉèÖÃ³õÊ¼Öµ
+            NullableDateTime = DateTime.Now // ÉèÖÃ³õÊ¼Öµ
         };
 
         // Act
         RecordLoader<TestEntity>.Populate(row, entity);
 
         // Assert
-        // æ³¨æ„ï¼šç”±äº Record ç³»ç»Ÿçš„å®ç°å¯èƒ½ä¸ç›´æ¥æ”¯æŒ null å€¼ï¼Œ
-        // è¿™é‡Œä¸»è¦æµ‹è¯•ä¸ä¼šæŠ›å‡ºå¼‚å¸¸
-        // å…·ä½“çš„ null å¤„ç†é€»è¾‘å–å†³äºåº•å±‚ ColumnData çš„å®ç°
-        Assert.IsNotNull(entity); // åŸºæœ¬çš„éç©ºéªŒè¯
+        // ×¢Òâ£ºÓÉÓÚ Record ÏµÍ³µÄÊµÏÖ¿ÉÄÜ²»Ö±½ÓÖ§³Ö null Öµ£¬
+        // ÕâÀïÖ÷Òª²âÊÔ²»»áÅ×³öÒì³£
+        // ¾ßÌåµÄ null ´¦ÀíÂß¼­È¡¾öÓÚµ×²ã ColumnData µÄÊµÏÖ
+        Assert.IsNotNull(entity); // »ù±¾µÄ·Ç¿ÕÑéÖ¤
     }
 
     /// <summary>
-    /// æµ‹è¯•å¾€è¿”è½¬æ¢ï¼ˆRound-tripï¼‰
+    /// ²âÊÔÍù·µ×ª»»£¨Round-trip£©
     /// </summary>
     [TestMethod]
     public void PopulateAndWriteData_RoundTrip_ShouldMaintainDataIntegrity()
@@ -251,25 +251,25 @@ public class RecordLoaderTests
         var originalEntity = new TestEntity
         {
             Id = 999,
-            Name = "å¾€è¿”æµ‹è¯•",
+            Name = "Íù·µ²âÊÔ",
             CreateTime = new DateTime(2023, 12, 25, 18, 30, 45),
             IsActive = true,
             Score = 92.3,
-            CustomField = "å¾€è¿”è‡ªå®šä¹‰",
+            CustomField = "Íù·µ×Ô¶¨Òå",
             NullableInt = 777
         };
 
         var record = new Record("TestTable", 1);
 
-        // ä½¿ç”¨ WriteHeader æ–¹æ³•æ·»åŠ åˆ—
+        // Ê¹ÓÃ WriteHeader ·½·¨Ìí¼ÓÁĞ
         RecordLoader<TestEntity>.WriteHeader(record);
 
         var row = record.AddRow();
 
-        // Act - å†™å…¥ Record
+        // Act - Ğ´Èë Record
         RecordLoader<TestEntity>.WriteToRow(originalEntity, row);
 
-        // Act - ä» Record è¯»å–åˆ°æ–°å®ä½“
+        // Act - ´Ó Record ¶ÁÈ¡µ½ĞÂÊµÌå
         var newEntity = new TestEntity();
         RecordLoader<TestEntity>.Populate(row, newEntity);
 
@@ -284,7 +284,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯•ç®€å•å®ä½“ç±»
+    /// ²âÊÔ¼òµ¥ÊµÌåÀà
     /// </summary>
     [TestMethod]
     public void SimpleEntity_PopulateAndWrite_ShouldWorkCorrectly()
@@ -296,7 +296,7 @@ public class RecordLoaderTests
         var row = record.AddRow();
 
         valueColumn.Set(42);
-        textColumn.Set("ç®€å•æµ‹è¯•");
+        textColumn.Set("¼òµ¥²âÊÔ");
 
         var entity = new SimpleEntity();
 
@@ -305,35 +305,35 @@ public class RecordLoaderTests
 
         // Assert
         Assert.AreEqual(42, entity.Value);
-        Assert.AreEqual("ç®€å•æµ‹è¯•", entity.Text);
+        Assert.AreEqual("¼òµ¥²âÊÔ", entity.Text);
     }
 
     /// <summary>
-    /// æµ‹è¯•é™æ€æ„é€ å‡½æ•°åªæ‰§è¡Œä¸€æ¬¡
+    /// ²âÊÔ¾²Ì¬¹¹Ôìº¯ÊıÖ»Ö´ĞĞÒ»´Î
     /// </summary>
     [TestMethod]
     public void StaticConstructor_ShouldExecuteOnlyOnce()
     {
         // Arrange & Act
         var record = new Record("TestTable", 1);
-        var idColumn = record.Columns.Add<Int32>("Value"); // ä¿®æ­£åˆ—å
+        var idColumn = record.Columns.Add<Int32>("Value"); // ĞŞÕıÁĞÃû
         var row = record.AddRow();
         idColumn.Set(1);
 
         var entity1 = new SimpleEntity();
         var entity2 = new SimpleEntity();
 
-        // Act - å¤šæ¬¡è°ƒç”¨åº”è¯¥ä½¿ç”¨åŒä¸€ä¸ªç¼–è¯‘åçš„å§”æ‰˜
+        // Act - ¶à´Îµ÷ÓÃÓ¦¸ÃÊ¹ÓÃÍ¬Ò»¸ö±àÒëºóµÄÎ¯ÍĞ
         RecordLoader<SimpleEntity>.Populate(row, entity1);
         RecordLoader<SimpleEntity>.Populate(row, entity2);
 
-        // Assert - éªŒè¯ä¸¤æ¬¡è°ƒç”¨éƒ½æˆåŠŸï¼ˆé—´æ¥éªŒè¯é™æ€æ„é€ å‡½æ•°æ­£ç¡®æ‰§è¡Œï¼‰
+        // Assert - ÑéÖ¤Á½´Îµ÷ÓÃ¶¼³É¹¦£¨¼ä½ÓÑéÖ¤¾²Ì¬¹¹Ôìº¯ÊıÕıÈ·Ö´ĞĞ£©
         Assert.AreEqual(1, entity1.Value);
         Assert.AreEqual(1, entity2.Value);
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³•
+    /// ²âÊÔ WriteHeader ·½·¨
     /// </summary>
     [TestMethod]
     public void WriteHeader_ShouldCreateCorrectColumns()
@@ -350,13 +350,13 @@ public class RecordLoaderTests
         Assert.IsTrue(record.Columns.Contains("CreateTime"));
         Assert.IsTrue(record.Columns.Contains("IsActive"));
         Assert.IsTrue(record.Columns.Contains("Score"));
-        Assert.IsTrue(record.Columns.Contains("custom_column")); // ä½¿ç”¨ç‰¹æ€§æŒ‡å®šçš„åç§°
+        Assert.IsTrue(record.Columns.Contains("custom_column")); // Ê¹ÓÃÌØĞÔÖ¸¶¨µÄÃû³Æ
         Assert.IsTrue(record.Columns.Contains("NullableInt"));
         Assert.IsTrue(record.Columns.Contains("NullableDateTime"));
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - éªŒè¯åˆ—çš„æ•°æ®ç±»å‹
+    /// ²âÊÔ WriteHeader ·½·¨ - ÑéÖ¤ÁĞµÄÊı¾İÀàĞÍ
     /// </summary>
     [TestMethod]
     public void WriteHeader_ShouldCreateColumnsWithCorrectTypes()
@@ -402,7 +402,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - éªŒè¯åˆ—çš„æ•°é‡
+    /// ²âÊÔ WriteHeader ·½·¨ - ÑéÖ¤ÁĞµÄÊıÁ¿
     /// </summary>
     [TestMethod]
     public void WriteHeader_ShouldCreateCorrectNumberOfColumns()
@@ -414,12 +414,12 @@ public class RecordLoaderTests
         RecordLoader<TestEntity>.WriteHeader(record);
 
         // Assert
-        // TestEntity æœ‰ 8 ä¸ªå¯è¯»å†™å±æ€§
+        // TestEntity ÓĞ 8 ¸ö¿É¶ÁĞ´ÊôĞÔ
         Assert.AreEqual(8, record.Columns.Count);
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - ç®€å•å®ä½“ç±»
+    /// ²âÊÔ WriteHeader ·½·¨ - ¼òµ¥ÊµÌåÀà
     /// </summary>
     [TestMethod]
     public void WriteHeader_SimpleEntity_ShouldCreateCorrectColumns()
@@ -445,7 +445,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - ç©º Record
+    /// ²âÊÔ WriteHeader ·½·¨ - ¿Õ Record
     /// </summary>
     [TestMethod]
     public void WriteHeader_EmptyRecord_ShouldPopulateColumns()
@@ -463,7 +463,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - å¤šæ¬¡è°ƒç”¨ä¸ä¼šé‡å¤æ·»åŠ åˆ—
+    /// ²âÊÔ WriteHeader ·½·¨ - ¶à´Îµ÷ÓÃ²»»áÖØ¸´Ìí¼ÓÁĞ
     /// </summary>
     [TestMethod]
     public void WriteHeader_CalledTwice_ShouldThrowException()
@@ -473,15 +473,15 @@ public class RecordLoaderTests
         RecordLoader<TestEntity>.WriteHeader(record);
 
         // Act & Assert
-        // ç¬¬äºŒæ¬¡è°ƒç”¨åº”è¯¥æŠ›å‡ºå¼‚å¸¸ï¼Œå› ä¸ºåˆ—å·²ç»å­˜åœ¨
-        Assert.ThrowsException<DuplicateNameException>(() =>
+        // µÚ¶ş´Îµ÷ÓÃÓ¦¸ÃÅ×³öÒì³££¬ÒòÎªÁĞÒÑ¾­´æÔÚ
+        Assert.Throws<DuplicateNameException>(() =>
         {
             RecordLoader<TestEntity>.WriteHeader(record);
         });
     }
 
     /// <summary>
-    /// æµ‹è¯•ç”¨çš„åªè¯»å±æ€§å®ä½“ç±»
+    /// ²âÊÔÓÃµÄÖ»¶ÁÊôĞÔÊµÌåÀà
     /// </summary>
     public class ReadOnlyEntity
     {
@@ -491,7 +491,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - åªåŒ…å«å¯è¯»å†™å±æ€§
+    /// ²âÊÔ WriteHeader ·½·¨ - Ö»°üº¬¿É¶ÁĞ´ÊôĞÔ
     /// </summary>
     [TestMethod]
     public void WriteHeader_ReadOnlyEntity_ShouldOnlyIncludeReadWriteProperties()
@@ -503,15 +503,15 @@ public class RecordLoaderTests
         RecordLoader<ReadOnlyEntity>.WriteHeader(record);
 
         // Assert
-        // åªæœ‰ Name å±æ€§æ˜¯å¯è¯»å†™çš„
+        // Ö»ÓĞ Name ÊôĞÔÊÇ¿É¶ÁĞ´µÄ
         Assert.AreEqual(1, record.Columns.Count);
         Assert.IsTrue(record.Columns.Contains("Name"));
-        Assert.IsFalse(record.Columns.Contains("Id")); // åªè¯»å±æ€§
-        Assert.IsFalse(record.Columns.Contains("WriteOnlyProperty")); // åªå†™å±æ€§
+        Assert.IsFalse(record.Columns.Contains("Id")); // Ö»¶ÁÊôĞÔ
+        Assert.IsFalse(record.Columns.Contains("WriteOnlyProperty")); // Ö»Ğ´ÊôĞÔ
     }
 
     /// <summary>
-    /// æµ‹è¯•ç”¨çš„å¤æ‚ç±»å‹å®ä½“ç±»
+    /// ²âÊÔÓÃµÄ¸´ÔÓÀàĞÍÊµÌåÀà
     /// </summary>
     public class ComplexTypeEntity
     {
@@ -522,7 +522,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³• - å¤æ‚æ•°æ®ç±»å‹
+    /// ²âÊÔ WriteHeader ·½·¨ - ¸´ÔÓÊı¾İÀàĞÍ
     /// </summary>
     [TestMethod]
     public void WriteHeader_ComplexTypeEntity_ShouldHandleComplexTypes()
@@ -558,7 +558,7 @@ public class RecordLoaderTests
     }
 
     /// <summary>
-    /// æµ‹è¯• WriteHeader æ–¹æ³•ä¸ WriteData æ–¹æ³•çš„å…¼å®¹æ€§
+    /// ²âÊÔ WriteHeader ·½·¨Óë WriteData ·½·¨µÄ¼æÈİĞÔ
     /// </summary>
     [TestMethod]
     public void WriteHeader_WithWriteData_ShouldBeCompatible()
@@ -568,11 +568,11 @@ public class RecordLoaderTests
         var entity = new TestEntity
         {
             Id = 123,
-            Name = "å…¼å®¹æ€§æµ‹è¯•",
+            Name = "¼æÈİĞÔ²âÊÔ",
             CreateTime = DateTime.Now,
             IsActive = true,
             Score = 95.5,
-            CustomField = "è‡ªå®šä¹‰å€¼",
+            CustomField = "×Ô¶¨ÒåÖµ",
             NullableInt = 456
         };
 
@@ -582,7 +582,7 @@ public class RecordLoaderTests
         RecordLoader<TestEntity>.WriteToRow(entity, row);
 
         // Assert
-        // éªŒè¯æ‰€æœ‰åˆ—éƒ½èƒ½æ­£ç¡®å†™å…¥æ•°æ®
+        // ÑéÖ¤ËùÓĞÁĞ¶¼ÄÜÕıÈ·Ğ´ÈëÊı¾İ
         Assert.AreEqual(entity.Id, row.Get<Int32>("Id"));
         Assert.AreEqual(entity.Name, row.Get<String>(("Name")!));
         Assert.AreEqual(entity.CreateTime, row.Get<DateTime>(("CreateTime")!));

--- a/tests/LuYao.Common.UnitTests/Data/RecordObjectTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordObjectTests.cs
@@ -84,14 +84,13 @@ public class RecordObjectTests
     /// 测试 Add 方法传入 null 对象时抛出异常
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Add_NullObject_ShouldThrowArgumentNullException()
     {
         // Arrange
         var record = new Record();
 
-        // Act
-        record.Add<TestModel>(null!);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => record.Add<TestModel>(null!));
     }
 
     /// <summary>
@@ -154,11 +153,10 @@ public class RecordObjectTests
     /// 测试 From 方法传入 null 对象时抛出异常
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void From_SingleObject_Null_ShouldThrowArgumentNullException()
     {
-        // Act
-        Record.From<TestModel>((TestModel)null!);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => Record.From<TestModel>((TestModel)null!));
     }
 
     /// <summary>
@@ -297,11 +295,10 @@ public class RecordObjectTests
     /// 测试 From 方法传入 null 集合时抛出异常
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void From_NullCollection_ShouldThrowArgumentNullException()
     {
-        // Act
-        Record.FromList<TestModel>((TestModel[])null!);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => Record.FromList<TestModel>((TestModel[])null!));
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -1,16 +1,16 @@
-ï»¿using System;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.Data;
 
 /// <summary>
-/// RecordRow ç»“æ„ä½“çš„å•å…ƒæµ‹è¯•ç±»
+/// RecordRow ½á¹¹ÌåµÄµ¥Ôª²âÊÔÀà
 /// </summary>
 [TestClass]
 public class RecordRowTests
 {
     /// <summary>
-    /// åˆ›å»ºæµ‹è¯•ç”¨çš„ Record å’Œç›¸å…³æ•°æ®
+    /// ´´½¨²âÊÔÓÃµÄ Record ºÍÏà¹ØÊı¾İ
     /// </summary>
     private (Record record, RecordColumn<int> intColumn, RecordColumn<string> stringColumn, RecordColumn<bool> boolColumn) CreateTestRecord()
     {
@@ -19,7 +19,7 @@ public class RecordRowTests
         var stringColumn = record.Columns.Add<string>("StringColumn");
         var boolColumn = record.Columns.Add<bool>("BoolColumn");
 
-        // æ·»åŠ æµ‹è¯•æ•°æ®
+        // Ìí¼Ó²âÊÔÊı¾İ
         var row1 = record.AddRow();
         var row2 = record.AddRow();
 
@@ -33,10 +33,10 @@ public class RecordRowTests
         return (record, intColumn, stringColumn, boolColumn);
     }
 
-    #region æ„é€ å‡½æ•°æµ‹è¯•
+    #region ¹¹Ôìº¯Êı²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯•æ„é€ å‡½æ•° - æ­£å¸¸å‚æ•°
+    /// ²âÊÔ¹¹Ôìº¯Êı - Õı³£²ÎÊı
     /// </summary>
     [TestMethod]
     public void Constructor_ValidParameters_ShouldInitializeCorrectly()
@@ -53,17 +53,17 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯•æ„é€ å‡½æ•° - Record ä¸º null
+    /// ²âÊÔ¹¹Ôìº¯Êı - Record Îª null
     /// </summary>
     [TestMethod]
     public void Constructor_NullRecord_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => new RecordRow(null!, 0));
+        Assert.Throws<ArgumentNullException>(() => new RecordRow(null!, 0));
     }
 
     /// <summary>
-    /// æµ‹è¯•æ„é€ å‡½æ•° - è¡Œç´¢å¼•å°äº0
+    /// ²âÊÔ¹¹Ôìº¯Êı - ĞĞË÷ÒıĞ¡ÓÚ0
     /// </summary>
     [TestMethod]
     public void Constructor_NegativeRowIndex_ShouldThrowArgumentOutOfRangeException()
@@ -72,11 +72,11 @@ public class RecordRowTests
         var (record, _, _, _) = CreateTestRecord();
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new RecordRow(record, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, -1));
     }
 
     /// <summary>
-    /// æµ‹è¯•æ„é€ å‡½æ•° - è¡Œç´¢å¼•ç­‰äºæˆ–å¤§äº Record.Count
+    /// ²âÊÔ¹¹Ôìº¯Êı - ĞĞË÷ÒıµÈÓÚ»ò´óÓÚ Record.Count
     /// </summary>
     [TestMethod]
     public void Constructor_RowIndexOutOfRange_ShouldThrowArgumentOutOfRangeException()
@@ -85,16 +85,16 @@ public class RecordRowTests
         var (record, _, _, _) = CreateTestRecord();
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count + 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count + 1));
     }
 
     #endregion
 
-    #region å±æ€§æµ‹è¯•
+    #region ÊôĞÔ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯• Record å±æ€§
+    /// ²âÊÔ Record ÊôĞÔ
     /// </summary>
     [TestMethod]
     public void Record_Property_ShouldReturnCorrectRecord()
@@ -111,7 +111,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• Row å±æ€§
+    /// ²âÊÔ Row ÊôĞÔ
     /// </summary>
     [TestMethod]
     public void Row_Property_ShouldReturnCorrectRowIndex()
@@ -129,10 +129,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region éšå¼è½¬æ¢æµ‹è¯•
+    #region ÒşÊ½×ª»»²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯•éšå¼è½¬æ¢åˆ° int
+    /// ²âÊÔÒşÊ½×ª»»µ½ int
     /// </summary>
     [TestMethod]
     public void ImplicitConversion_ToInt_ShouldReturnRowIndex()
@@ -150,10 +150,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region GetBoolean æµ‹è¯•
+    #region GetBoolean ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯• GetBoolean(string name) - åˆ—å­˜åœ¨
+    /// ²âÊÔ GetBoolean(string name) - ÁĞ´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
@@ -170,7 +170,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetBoolean(string name) - åˆ—ä¸å­˜åœ¨
+    /// ²âÊÔ GetBoolean(string name) - ÁĞ²»´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
@@ -187,7 +187,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetBoolean(RecordColumn col) - åˆ—å±äºå½“å‰è®°å½•
+    /// ²âÊÔ GetBoolean(RecordColumn col) - ÁĞÊôÓÚµ±Ç°¼ÇÂ¼
     /// </summary>
     [TestMethod]
     public void GetBoolean_ByColumn_SameRecord_ShouldReturnCorrectValue()
@@ -204,7 +204,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetBoolean(RecordColumn col) - åˆ—å±äºä¸åŒè®°å½•
+    /// ²âÊÔ GetBoolean(RecordColumn col) - ÁĞÊôÓÚ²»Í¬¼ÇÂ¼
     /// </summary>
     [TestMethod]
     public void GetBoolean_ByColumn_DifferentRecord_ShouldFallbackToNameSearch()
@@ -218,15 +218,15 @@ public class RecordRowTests
         var result = recordRow.Get<Boolean>(boolColumn2);
 
         // Assert
-        Assert.AreEqual(true, result); // åº”è¯¥é€šè¿‡åˆ—åæŸ¥æ‰¾åˆ° record1 ä¸­çš„ BoolColumn
+        Assert.AreEqual(true, result); // Ó¦¸ÃÍ¨¹ıÁĞÃû²éÕÒµ½ record1 ÖĞµÄ BoolColumn
     }
 
     #endregion
 
-    #region GetString æµ‹è¯•
+    #region GetString ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯• GetString(string name) - åˆ—å­˜åœ¨
+    /// ²âÊÔ GetString(string name) - ÁĞ´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
@@ -243,7 +243,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetString(string name) - åˆ—ä¸å­˜åœ¨
+    /// ²âÊÔ GetString(string name) - ÁĞ²»´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
@@ -260,7 +260,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetString(RecordColumn col) - åˆ—å±äºå½“å‰è®°å½•
+    /// ²âÊÔ GetString(RecordColumn col) - ÁĞÊôÓÚµ±Ç°¼ÇÂ¼
     /// </summary>
     [TestMethod]
     public void GetString_ByColumn_SameRecord_ShouldReturnCorrectValue()
@@ -278,10 +278,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region GetInt32 æµ‹è¯•
+    #region GetInt32 ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯• GetInt32(string name) - åˆ—å­˜åœ¨
+    /// ²âÊÔ GetInt32(string name) - ÁĞ´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
@@ -298,7 +298,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetInt32(string name) - åˆ—ä¸å­˜åœ¨
+    /// ²âÊÔ GetInt32(string name) - ÁĞ²»´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
@@ -315,7 +315,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetInt32(RecordColumn col) - åˆ—å±äºå½“å‰è®°å½•
+    /// ²âÊÔ GetInt32(RecordColumn col) - ÁĞÊôÓÚµ±Ç°¼ÇÂ¼
     /// </summary>
     [TestMethod]
     public void GetInt32_ByColumn_SameRecord_ShouldReturnCorrectValue()
@@ -333,10 +333,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region æ³›å‹ Get<T> æµ‹è¯•
+    #region ·ºĞÍ Get<T> ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯• Get<T>(string name) - åˆ—å­˜åœ¨
+    /// ²âÊÔ Get<T>(string name) - ÁĞ´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
@@ -353,7 +353,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• Get<T>(string name) - åˆ—ä¸å­˜åœ¨
+    /// ²âÊÔ Get<T>(string name) - ÁĞ²»´æÔÚ
     /// </summary>
     [TestMethod]
     public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
@@ -370,7 +370,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• Get<T>(RecordColumn col) - åˆ—å±äºå½“å‰è®°å½•
+    /// ²âÊÔ Get<T>(RecordColumn col) - ÁĞÊôÓÚµ±Ç°¼ÇÂ¼
     /// </summary>
     [TestMethod]
     public void GetGeneric_ByColumn_SameRecord_ShouldReturnCorrectValue()
@@ -389,10 +389,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region æ•°å€¼ç±»å‹æµ‹è¯• (æŠ½æ ·æµ‹è¯•)
+    #region ÊıÖµÀàĞÍ²âÊÔ (³éÑù²âÊÔ)
 
     /// <summary>
-    /// æµ‹è¯• GetByte æ–¹æ³•
+    /// ²âÊÔ GetByte ·½·¨
     /// </summary>
     [TestMethod]
     public void GetByte_ByName_ShouldWork()
@@ -412,7 +412,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetDouble æ–¹æ³•
+    /// ²âÊÔ GetDouble ·½·¨
     /// </summary>
     [TestMethod]
     public void GetDouble_ByName_ShouldWork()
@@ -432,7 +432,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯• GetDateTime æ–¹æ³•
+    /// ²âÊÔ GetDateTime ·½·¨
     /// </summary>
     [TestMethod]
     public void GetDateTime_ByName_ShouldWork()
@@ -454,10 +454,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region è¾¹ç•Œæƒ…å†µå’Œå¼‚å¸¸æµ‹è¯•
+    #region ±ß½çÇé¿öºÍÒì³£²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯•ç©ºå­—ç¬¦ä¸²åˆ—å
+    /// ²âÊÔ¿Õ×Ö·û´®ÁĞÃû
     /// </summary>
     [TestMethod]
     public void GetMethods_EmptyColumnName_ShouldReturnDefault()
@@ -473,7 +473,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯•å¤šè¡Œæ•°æ®çš„æ­£ç¡®æ€§
+    /// ²âÊÔ¶àĞĞÊı¾İµÄÕıÈ·ĞÔ
     /// </summary>
     [TestMethod]
     public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
@@ -481,7 +481,7 @@ public class RecordRowTests
         // Arrange
         var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
 
-        // æ·»åŠ æ›´å¤šæµ‹è¯•æ•°æ®
+        // Ìí¼Ó¸ü¶à²âÊÔÊı¾İ
         var row3 = record.AddRow();
         intColumn.Set(300);
         stringColumn.Set("Test3");
@@ -507,10 +507,10 @@ public class RecordRowTests
 
     #endregion
 
-    #region æ€§èƒ½å’Œä¸€è‡´æ€§æµ‹è¯•
+    #region ĞÔÄÜºÍÒ»ÖÂĞÔ²âÊÔ
 
     /// <summary>
-    /// æµ‹è¯•ç›¸åŒæ•°æ®çš„é‡å¤è®¿é—®åº”è¯¥è¿”å›ç›¸åŒç»“æœ
+    /// ²âÊÔÏàÍ¬Êı¾İµÄÖØ¸´·ÃÎÊÓ¦¸Ã·µ»ØÏàÍ¬½á¹û
     /// </summary>
     [TestMethod]
     public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
@@ -531,7 +531,7 @@ public class RecordRowTests
     }
 
     /// <summary>
-    /// æµ‹è¯•ä¸åŒè·å–æ–¹å¼(æŒ‰åç§° vs æŒ‰åˆ—å¯¹è±¡)çš„ç»“æœä¸€è‡´æ€§
+    /// ²âÊÔ²»Í¬»ñÈ¡·½Ê½(°´Ãû³Æ vs °´ÁĞ¶ÔÏó)µÄ½á¹ûÒ»ÖÂĞÔ
     /// </summary>
     [TestMethod]
     public void GetMethods_ByNameVsByColumn_ShouldReturnSameResults()

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -1,4 +1,4 @@
-ï»¿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -27,8 +27,8 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add<int>("Id"); // æ›¿æ¢ Add<Int32> ä¸º Add<int>
-        var colName = table.Columns.Add<string>("Name"); // æ›¿æ¢ Add<String> ä¸º Add<string>
+        var colId = table.Columns.Add<int>("Id"); // Ìæ»» Add<Int32> Îª Add<int>
+        var colName = table.Columns.Add<string>("Name"); // Ìæ»» Add<String> Îª Add<string>
 
         // Act
         var row = table.AddRow();
@@ -38,8 +38,8 @@ public class RecordTests
         // Assert
         Assert.AreEqual(1, table.Count);
         Assert.AreEqual(2, table.Columns.Count);
-        Assert.AreEqual(1, colId.Get<int>(row.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
-        Assert.AreEqual("Test", colName.Get<string>(row.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
+        Assert.AreEqual(1, colId.Get<int>(row.Row)); // Ìæ»» GetValue Îª Get<T>
+        Assert.AreEqual("Test", colName.Get<string>(row.Row)); // Ìæ»» GetValue Îª Get<T>
     }
 
     [TestMethod]
@@ -60,9 +60,9 @@ public class RecordTests
     {
         // Arrange
         var table = new Record();
-        var colId = table.Columns.Add<int>("Id"); // æ›¿æ¢ Add<Int32> ä¸º Add<int>
-        var colName = table.Columns.Add<string>("Name"); // æ›¿æ¢ Add<String> ä¸º Add<string>
-        var colAge = table.Columns.Add<int>("Age"); // æ›¿æ¢ Add<Int32> ä¸º Add<int>
+        var colId = table.Columns.Add<int>("Id"); // Ìæ»» Add<Int32> Îª Add<int>
+        var colName = table.Columns.Add<string>("Name"); // Ìæ»» Add<String> Îª Add<string>
+        var colAge = table.Columns.Add<int>("Age"); // Ìæ»» Add<Int32> Îª Add<int>
 
         // Act
         var row1 = table.AddRow();
@@ -79,13 +79,13 @@ public class RecordTests
         Assert.AreEqual(2, table.Count);
         Assert.AreEqual(3, table.Columns.Count);
 
-        Assert.AreEqual(1, colId.Get<int>(row1.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
-        Assert.AreEqual("Alice", colName.Get<string>(row1.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
-        Assert.AreEqual(25, colAge.Get<int>(row1.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
+        Assert.AreEqual(1, colId.Get<int>(row1.Row)); // Ìæ»» GetValue Îª Get<T>
+        Assert.AreEqual("Alice", colName.Get<string>(row1.Row)); // Ìæ»» GetValue Îª Get<T>
+        Assert.AreEqual(25, colAge.Get<int>(row1.Row)); // Ìæ»» GetValue Îª Get<T>
 
-        Assert.AreEqual(2, colId.Get<int>(row2.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
-        Assert.AreEqual("Bob", colName.Get<string>(row2.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
-        Assert.AreEqual(30, colAge.Get<int>(row2.Row)); // æ›¿æ¢ GetValue ä¸º Get<T>
+        Assert.AreEqual(2, colId.Get<int>(row2.Row)); // Ìæ»» GetValue Îª Get<T>
+        Assert.AreEqual("Bob", colName.Get<string>(row2.Row)); // Ìæ»» GetValue Îª Get<T>
+        Assert.AreEqual(30, colAge.Get<int>(row2.Row)); // Ìæ»» GetValue Îª Get<T>
     }
 
     [TestMethod]
@@ -277,7 +277,7 @@ public class RecordTests
         var row = rows[1];
 
         // Act
-        int rowIndex = row; // éšå¼è½¬æ¢
+        int rowIndex = row; // ÒşÊ½×ª»»
 
         // Assert
         Assert.AreEqual(1, rowIndex);
@@ -681,7 +681,7 @@ public class RecordTests
         Assert.IsTrue(result.Contains("..") || result.Contains("LongStringTest"));
     }
 
-    // æ–°å¢çš„è¾¹ç•Œæ£€æŸ¥æµ‹è¯•æ–¹æ³•
+    // ĞÂÔöµÄ±ß½ç¼ì²é²âÊÔ·½·¨
 
     [TestMethod]
     public void GetValue_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
@@ -692,8 +692,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(-1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• -1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(-1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı -1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -705,8 +705,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -718,8 +718,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(5));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 5 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(5));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 5 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -731,8 +731,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• -1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı -1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -744,8 +744,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", 1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -757,8 +757,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", 5));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 5 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", 5));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 5 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -770,8 +770,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, -1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• -1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(true, -1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı -1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -783,8 +783,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(true, 1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(true, 1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -796,8 +796,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set(42, 5));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 5 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(42, 5));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 5 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -809,8 +809,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Get<Boolean>(-1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• -1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Boolean>(-1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı -1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -822,8 +822,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Get<Int32>(1));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 1 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Int32>(1));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 1 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -835,8 +835,8 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Get<String>(10));
-        Assert.IsTrue(exception.Message.Contains("è¡Œç´¢å¼• 10 è¶…å‡ºæœ‰æ•ˆèŒƒå›´"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<String>(10));
+        Assert.IsTrue(exception.Message.Contains("ĞĞË÷Òı 10 ³¬³öÓĞĞ§·¶Î§"));
     }
 
     [TestMethod]
@@ -881,8 +881,8 @@ public class RecordTests
         Assert.AreEqual("test2", col.GetValue(2));
 
         // Invalid indices should still throw
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(3));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("invalid", 4));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(3));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("invalid", 4));
     }
 
     [TestMethod]
@@ -909,21 +909,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all Set methods with invalid index
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => boolCol.Set(true, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => byteCol.Set((byte)1, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => charCol.Set('A', 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => dateTimeCol.Set(DateTime.Now, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => decimalCol.Set(1.0m, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => doubleCol.Set(1.0, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int16Col.Set((short)1, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int32Col.Set(1, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int64Col.Set(1L, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => sbyteCol.Set((sbyte)1, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => singleCol.Set(1.0f, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => stringCol.Set("test", 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint16Col.Set((ushort)1, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint32Col.Set(1u, 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint64Col.Set(1ul, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Set(true, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Set((byte)1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Set('A', 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Set(DateTime.Now, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Set(1.0m, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Set(1.0, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Set((short)1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.Set(1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Set(1L, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Set((sbyte)1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Set(1.0f, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Set("test", 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Set((ushort)1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Set(1u, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Set(1ul, 1));
     }
 
     [TestMethod]
@@ -950,21 +950,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all To methods with invalid index
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => boolCol.Get<Boolean>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => byteCol.Get<Byte>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => charCol.Get<Char>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => dateTimeCol.Get<DateTime>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => decimalCol.Get<Decimal>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => doubleCol.Get<Double>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int16Col.Get<Int16>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int32Col.Get<Int32>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => int64Col.Get<Int64>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => sbyteCol.Get<SByte>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => singleCol.Get<Single>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => stringCol.Get<String>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint16Col.Get<UInt16>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint32Col.Get<UInt32>(1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => uint64Col.Get<UInt64>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Get<Boolean>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Get<Byte>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Get<Char>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Get<DateTime>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Get<Decimal>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Get<Double>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Get<Int16>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.Get<Int32>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Get<Int64>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Get<SByte>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Get<Single>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Get<String>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Get<UInt16>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Get<UInt32>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Get<UInt64>(1));
     }
 
     [TestMethod]
@@ -976,8 +976,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(0));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Get<Boolean>(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Boolean>(0));
     }
 
     [TestMethod]
@@ -989,8 +989,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Negative indices should always throw
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.GetValue(-1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
     }
 
     [TestMethod]
@@ -1002,12 +1002,11 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Indices > 0 should throw even with auto-row creation
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set("test", 1));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => col.Set("test", 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set("test", 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set("test", 2));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DuplicateNameException))]
     public void Columns_AddDuplicateName_ThrowsException()
     {
         // Arrange
@@ -1015,11 +1014,10 @@ public class RecordTests
         table.Columns.Add<String>("TestColumn");
 
         // Act & Assert
-        table.Columns.Add<String>("TestColumn"); // åº”è¯¥æŠ›å‡ºå¼‚å¸¸
+        Assert.Throws<DuplicateNameException>(() => table.Columns.Add<String>("TestColumn")); // Ó¦¸ÃÅ×³öÒì³£
     }
 
     [TestMethod]
-    [ExpectedException(typeof(DuplicateNameException))]
     public void Columns_AddDuplicateNameDifferentType_ThrowsException()
     {
         // Arrange
@@ -1027,7 +1025,7 @@ public class RecordTests
         table.Columns.Add<String>("TestColumn");
 
         // Act & Assert
-        table.Columns.Add<Int32>("TestColumn"); // åº”è¯¥æŠ›å‡ºå¼‚å¸¸
+        Assert.Throws<DuplicateNameException>(() => table.Columns.Add<Int32>("TestColumn")); // Ó¦¸ÃÅ×³öÒì³£
     }
 
     public class Student
@@ -1063,6 +1061,6 @@ public class RecordTests
         var id = re.Columns.Add<Int32>("Id");
         var row = re.AddRow();
         // Act & Assert
-        Assert.ThrowsException<InvalidCastException>(() => raw.SetValue(1, row.Row));
+        Assert.Throws<InvalidCastException>(() => raw.SetValue(1, row.Row));
     }
 }

--- a/tests/LuYao.Common.UnitTests/DisposeActionTests.cs
+++ b/tests/LuYao.Common.UnitTests/DisposeActionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao;
 
@@ -8,7 +8,7 @@ public class DisposeActionTests
     [TestMethod]
     public void Constructor_WhenActionIsNull_ShouldThrowArgumentNullException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new DisposeAction(null!));
+        Assert.Throws<ArgumentNullException>(() => new DisposeAction(null!));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Encoders/Ascii85Tests.cs
+++ b/tests/LuYao.Common.UnitTests/Encoders/Ascii85Tests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
 namespace LuYao.Encoders;
@@ -50,7 +50,7 @@ public class Ascii85Tests
     {
         var ascii85 = new Ascii85 { EnforceMarks = true };
         string encoded = "87cURD_*#4DfTZ";
-        Assert.ThrowsException<Exception>(() => ascii85.Decode(encoded));
+        Assert.Throws<Exception>(() => ascii85.Decode(encoded));
     }
 
     [TestMethod]
@@ -59,7 +59,7 @@ public class Ascii85Tests
         var ascii85 = new Ascii85 { EnforceMarks = false };
         byte[] original = Encoding.UTF8.GetBytes("data");
         string encoded = ascii85.Encode(original);
-        // 去掉前后缀
+        // ȥ��ǰ��׺
         encoded = encoded.TrimStart('<', '~').TrimEnd('~', '>');
         byte[] decoded = ascii85.Decode(encoded);
         CollectionAssert.AreEqual(original, decoded);

--- a/tests/LuYao.Common.UnitTests/Encoders/Base16Tests.cs
+++ b/tests/LuYao.Common.UnitTests/Encoders/Base16Tests.cs
@@ -42,19 +42,17 @@ namespace LuYao.Encoders.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void FromBase16_InvalidHex_ThrowsFormatException()
         {
             string input = "ZZ";
-            Base16.FromBase16(input);
+            Assert.Throws<FormatException>(() => Base16.FromBase16(input));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void FromBase16_OddLength_ThrowsArgumentOutOfRangeException()
         {
             string input = "ABC";
-            Base16.FromBase16(input);
+            Assert.Throws<ArgumentOutOfRangeException>(() => Base16.FromBase16(input));
         }
     }
 }

--- a/tests/LuYao.Common.UnitTests/Encoders/Base32Tests.cs
+++ b/tests/LuYao.Common.UnitTests/Encoders/Base32Tests.cs
@@ -43,10 +43,9 @@ public class Base32Tests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void FromBase32_InvalidCharacter_ThrowsArgumentException()
     {
-        Base32.FromBase32("INVALID*");
+        Assert.Throws<ArgumentException>(() => Base32.FromBase32("INVALID*"));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Encoders/Base62Tests.cs
+++ b/tests/LuYao.Common.UnitTests/Encoders/Base62Tests.cs
@@ -1,4 +1,4 @@
-锘縰sing Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.Encoders;
 
@@ -28,7 +28,7 @@ public class Base62Tests
         string result = Base62.ToBase62(input);
 
         // Assert
-        // 棰勬湡鍊煎彲閫氳繃 FromBase62 楠岃瘉
+        // 预期值可通过 FromBase62 验证
         CollectionAssert.AreEqual(input, Base62.FromBase62(result));
     }
 
@@ -53,7 +53,7 @@ public class Base62Tests
         string input = "";
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => Base62.FromBase62(input));
+        Assert.Throws<ArgumentNullException>(() => Base62.FromBase62(input));
     }
 
     [TestMethod]
@@ -63,7 +63,7 @@ public class Base62Tests
         string input = "   ";
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => Base62.FromBase62(input));
+        Assert.Throws<ArgumentNullException>(() => Base62.FromBase62(input));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Encoders/Base64Tests.cs
+++ b/tests/LuYao.Common.UnitTests/Encoders/Base64Tests.cs
@@ -73,11 +73,10 @@ namespace LuYao.Encoders
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void FromBase64_InvalidString_ThrowsFormatException()
         {
-            // Act
-            Base64.FromBase64("!@#$");
+            // Act & Assert
+            Assert.Throws<FormatException>(() => Base64.FromBase64("!@#$"));
         }
     }
 }

--- a/tests/LuYao.Common.UnitTests/EnumTests.cs
+++ b/tests/LuYao.Common.UnitTests/EnumTests.cs
@@ -80,10 +80,9 @@ public class EnumTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void Parse_InvalidString_ThrowsException()
     {
-        Enum<TestEnum>.Parse("NonExistent");
+        Assert.Throws<ArgumentException>(() => Enum<TestEnum>.Parse("NonExistent"));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/GZipStringTests.cs
+++ b/tests/LuYao.Common.UnitTests/GZipStringTests.cs
@@ -54,7 +54,6 @@ public class GZipStringTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Compress_WithNullCompressor_ThrowsArgumentNullException()
     {
         // Arrange
@@ -62,12 +61,11 @@ public class GZipStringTests
         string compressor = null;
         string encoder = "base64";
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Compress_WithNullEncoder_ThrowsArgumentNullException()
     {
         // Arrange
@@ -75,12 +73,11 @@ public class GZipStringTests
         string compressor = "gzip";
         string encoder = null;
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(KeyNotFoundException))]
     public void Compress_WithInvalidCompressor_ThrowsKeyNotFoundException()
     {
         // Arrange
@@ -88,12 +85,11 @@ public class GZipStringTests
         string compressor = "invalid";
         string encoder = "base64";
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(KeyNotFoundException))]
     public void Compress_WithInvalidEncoder_ThrowsKeyNotFoundException()
     {
         // Arrange
@@ -101,8 +97,8 @@ public class GZipStringTests
         string compressor = "gzip";
         string encoder = "invalid";
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
@@ -122,7 +118,6 @@ public class GZipStringTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Compress_WithNullCompressorInterface_ThrowsArgumentNullException()
     {
         // Arrange
@@ -130,12 +125,11 @@ public class GZipStringTests
         GZipString.ICompressor compressor = null;
         var encoder = GZipString.Base64;
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Compress_WithNullEncoderInterface_ThrowsArgumentNullException()
     {
         // Arrange
@@ -143,8 +137,8 @@ public class GZipStringTests
         var compressor = GZipString.GZip;
         GZipString.IEncoder encoder = null;
 
-        // Act
-        GZipString.Compress(input, compressor, encoder);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => GZipString.Compress(input, compressor, encoder));
     }
 
     [TestMethod]
@@ -211,24 +205,22 @@ public class GZipStringTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(KeyNotFoundException))]
     public void Decompress_WithInvalidCompressorIdentifier_ThrowsKeyNotFoundException()
     {
         // Arrange
         string invalidCompressedString = "data:text/x-invalid;base64,ABCDEF";
 
-        // Act
-        GZipString.Decompress(invalidCompressedString);
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => GZipString.Decompress(invalidCompressedString));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(KeyNotFoundException))]
     public void Decompress_WithInvalidEncoderIdentifier_ThrowsKeyNotFoundException()
     {
         // Arrange
         string invalidCompressedString = "data:text/x-gzip;invalid,ABCDEF";
 
-        // Act
-        GZipString.Decompress(invalidCompressedString);
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => GZipString.Decompress(invalidCompressedString));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Globalization/RmbHelperTests.cs
+++ b/tests/LuYao.Common.UnitTests/Globalization/RmbHelperTests.cs
@@ -43,29 +43,26 @@ public class RmbHelperTests
     /// 测试金额超出范围时，期望抛出 ArgumentOutOfRangeException
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void ToRmbUpper_OutOfRangeAmount_ThrowsArgumentOutOfRangeException()
     {
-        RmbHelper.ToRmbUpper(10000000000000000M);
+        Assert.Throws<ArgumentOutOfRangeException>(() => RmbHelper.ToRmbUpper(10000000000000000M));
     }
 
     /// <summary>
     /// 测试金额为负数时，期望抛出 ArgumentOutOfRangeException
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void ToRmbUpper_NegativeAmount_ThrowsArgumentOutOfRangeException()
     {
-        RmbHelper.ToRmbUpper(-1M);
+        Assert.Throws<ArgumentOutOfRangeException>(() => RmbHelper.ToRmbUpper(-1M));
     }
 
     /// <summary>
     /// 测试金额为最大值时，期望抛出 ArgumentOutOfRangeException
     /// </summary>
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void ToRmbUpper_MaxValidAmount_ThrowsArgumentOutOfRangeException()
     {
-        RmbHelper.ToRmbUpper(9999999999999999.99M);
+        Assert.Throws<ArgumentOutOfRangeException>(() => RmbHelper.ToRmbUpper(9999999999999999.99M));
     }
 }

--- a/tests/LuYao.Common.UnitTests/IO/AutoCleanTempFileTests.cs
+++ b/tests/LuYao.Common.UnitTests/IO/AutoCleanTempFileTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.IO;
 
@@ -8,9 +8,9 @@ public class AutoCleanTempFileTests
     [TestMethod]
     public void Constructor_FileNameIsNullOrWhiteSpace_ThrowsArgumentException()
     {
-        Assert.ThrowsException<ArgumentException>(() => new AutoCleanTempFile(null));
-        Assert.ThrowsException<ArgumentException>(() => new AutoCleanTempFile(""));
-        Assert.ThrowsException<ArgumentException>(() => new AutoCleanTempFile("   "));
+        Assert.Throws<ArgumentException>(() => new AutoCleanTempFile(null));
+        Assert.Throws<ArgumentException>(() => new AutoCleanTempFile(""));
+        Assert.Throws<ArgumentException>(() => new AutoCleanTempFile("   "));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/IO/Hashing/Crc32Tests.cs
+++ b/tests/LuYao.Common.UnitTests/IO/Hashing/Crc32Tests.cs
@@ -1,4 +1,4 @@
-ï»¿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
 namespace LuYao.IO.Hashing;
@@ -9,7 +9,7 @@ public class Crc32Tests
     [TestMethod]
     public void Compute_EmptyBuffer_ReturnsZero()
     {
-        // ç©ºæ•°ç»„ CRC32 ç»“æœåº”ä¸º 0
+        // ¿ÕÊı×é CRC32 ½á¹ûÓ¦Îª 0
         var buffer = Array.Empty<byte>();
         var crc = Crc32.Compute(buffer);
         Assert.AreEqual(0u, crc);
@@ -18,7 +18,7 @@ public class Crc32Tests
     [TestMethod]
     public void Compute_KnownAsciiString_ReturnsExpectedCrc()
     {
-        // "123456789" çš„ CRC32 æ ‡å‡†å€¼ä¸º 0xCBF43926
+        // "123456789" µÄ CRC32 ±ê×¼ÖµÎª 0xCBF43926
         var buffer = Encoding.ASCII.GetBytes("123456789");
         var crc = Crc32.Compute(buffer);
         Assert.AreEqual(0xCBF43926u, crc);
@@ -45,7 +45,7 @@ public class Crc32Tests
     [TestMethod]
     public void Reflect_KnownValue_ReturnsExpectedResult()
     {
-        // 0x3A (00111010) åå°„ 8 ä½åº”ä¸º 0x5C (01011100)
+        // 0x3A (00111010) ·´Éä 8 Î»Ó¦Îª 0x5C (01011100)
         uint input = 0x3A;
         uint expected = 0x5C;
         var reflected = Crc32.reflect(input, 8);
@@ -55,7 +55,7 @@ public class Crc32Tests
     [TestMethod]
     public void HashAlgorithm_StreamInput_ReturnsExpectedCrc()
     {
-        // ä½¿ç”¨ HashAlgorithm æ¥å£å¤„ç†æµå¼æ•°æ®
+        // Ê¹ÓÃ HashAlgorithm ½Ó¿Ú´¦ÀíÁ÷Ê½Êı¾İ
         var buffer = Encoding.ASCII.GetBytes("123456789");
         using (var crc32 = new Crc32())
         {
@@ -63,7 +63,7 @@ public class Crc32Tests
             crc32.TransformBlock(buffer, 0, buffer.Length, buffer, 0);
             crc32.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             var hash = crc32.Hash;
-            // ç»“æœåº”ä¸º 0xCBF43926
+            // ½á¹ûÓ¦Îª 0xCBF43926
             Assert.IsNotNull(hash);
             Assert.AreEqual(4, hash.Length);
             Array.Reverse(hash);
@@ -75,10 +75,10 @@ public class Crc32Tests
     [TestMethod]
     public void Constructor_BigEndian_ThrowsPlatformNotSupportedException()
     {
-        // ä»…åœ¨éå°ç«¯å¹³å°æŠ›å‡ºå¼‚å¸¸ï¼Œé€šå¸¸ä¸ä¼šè§¦å‘
+        // ½öÔÚ·ÇĞ¡¶ËÆ½Ì¨Å×³öÒì³££¬Í¨³£²»»á´¥·¢
         if (!BitConverter.IsLittleEndian)
         {
-            Assert.ThrowsException<PlatformNotSupportedException>(() =>
+            Assert.Throws<PlatformNotSupportedException>(() =>
             {
                 var crc32 = new Crc32();
             });

--- a/tests/LuYao.Common.UnitTests/IO/Hashing/HashAgentTests.cs
+++ b/tests/LuYao.Common.UnitTests/IO/Hashing/HashAgentTests.cs
@@ -1,4 +1,4 @@
-ï»¿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Text;
 
 namespace LuYao.IO.Hashing;
@@ -13,7 +13,7 @@ public class HashAgentTests
     {
         // Arrange
         string input = "hello";
-        // é¢„æœŸå€¼å¯é€šè¿‡åœ¨çº¿å·¥å…·æˆ– .NET è®¡ç®—å¾—å‡º
+        // Ô¤ÆÚÖµ¿ÉÍ¨¹ıÔÚÏß¹¤¾ß»ò .NET ¼ÆËãµÃ³ö
         string expected = "5d41402abc4b2a76b9719d911017c592";
 
         // Act
@@ -92,6 +92,6 @@ public class HashAgentTests
     public void HashFile_FileNotExist_ThrowsFileNotFoundException()
     {
         // Act & Assert
-        Assert.ThrowsException<FileNotFoundException>(() => _md5Agent.HashFile("not_exist_file.txt"));
+        Assert.Throws<FileNotFoundException>(() => _md5Agent.HashFile("not_exist_file.txt"));
     }
 }

--- a/tests/LuYao.Common.UnitTests/IO/PathHelperTests.cs
+++ b/tests/LuYao.Common.UnitTests/IO/PathHelperTests.cs
@@ -1,9 +1,9 @@
-ï»¿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.IO;
 
 /// <summary>
-/// æµ‹è¯• PathHelper ç±»çš„åŠŸèƒ½ã€‚
+/// ²âÊÔ PathHelper ÀàµÄ¹¦ÄÜ¡£
 /// </summary>
 [TestClass]
 public class PathHelperTests
@@ -82,7 +82,7 @@ public class PathHelperTests
         // Arrange
         string extension = string.Empty;
         // Act & Assert
-        Assert.ThrowsException<ArgumentException>(() => PathHelper.GetMimeType(extension));
+        Assert.Throws<ArgumentException>(() => PathHelper.GetMimeType(extension));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Limiters/TokenBucket/TokenBucketsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Limiters/TokenBucket/TokenBucketsTests.cs
@@ -23,10 +23,9 @@ public class TokenBucketsTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentOutOfRangeException))]
     public void Builder_WithCapacity_NonPositive_ThrowsArgumentOutOfRangeException()
     {
-        TokenBuckets.Construct().WithCapacity(0);
+        Assert.Throws<ArgumentOutOfRangeException>(() => TokenBuckets.Construct().WithCapacity(0));
     }
 
     [TestMethod]
@@ -39,10 +38,9 @@ public class TokenBucketsTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Builder_WithRefillStrategy_Null_ThrowsArgumentNullException()
     {
-        TokenBuckets.Construct().WithRefillStrategy(null);
+        Assert.Throws<ArgumentNullException>(() => TokenBuckets.Construct().WithRefillStrategy(null));
     }
 
     [TestMethod]
@@ -68,10 +66,9 @@ public class TokenBucketsTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Builder_WithSleepStrategy_Null_ThrowsArgumentNullException()
     {
-        TokenBuckets.Construct().WithSleepStrategy(null);
+        Assert.Throws<ArgumentNullException>(() => TokenBuckets.Construct().WithSleepStrategy(null));
     }
 
     [TestMethod]
@@ -82,10 +79,9 @@ public class TokenBucketsTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidOperationException))]
     public void Builder_Build_WithoutCapacity_ThrowsInvalidOperationException()
     {
-        TokenBuckets.Construct().Build();
+        Assert.Throws<InvalidOperationException>(() => TokenBuckets.Construct().Build());
     }
 
     // Dummy implementations for test

--- a/tests/LuYao.Common.UnitTests/LuYao.Common.UnitTests.csproj
+++ b/tests/LuYao.Common.UnitTests/LuYao.Common.UnitTests.csproj
@@ -16,9 +16,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/LuYao.Common.UnitTests/Net/Http/HttpResponseMessageExtensionsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Net/Http/HttpResponseMessageExtensionsTests.cs
@@ -1,4 +1,4 @@
-锘縰sing Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +18,7 @@ public class HttpResponseMessageExtensionsTests
         HttpResponseMessage? response = null;
 
         // Act & Assert
-        await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
         {
             await HttpResponseMessageExtensions.ReadAsHtmlAsync(response);
         });
@@ -28,7 +28,7 @@ public class HttpResponseMessageExtensionsTests
     public async Task ReadAsHtmlAsync_CharsetInHeader_UsesHeaderEncoding()
     {
         // Arrange
-        var content = new StringContent("娴嬭瘯鍐呭", Encoding.Unicode);
+        var content = new StringContent("测试内容", Encoding.Unicode);
         if (content.Headers.ContentType != null)
         {
             content.Headers.ContentType.CharSet = "utf-16";
@@ -42,14 +42,14 @@ public class HttpResponseMessageExtensionsTests
         var result = await response.ReadAsHtmlAsync();
 
         // Assert
-        Assert.AreEqual("娴嬭瘯鍐呭", result);
+        Assert.AreEqual("测试内容", result);
     }
 
     [TestMethod]
     public async Task ReadAsHtmlAsync_CharsetInHtml_UsesHtmlEncoding()
     {
         // Arrange
-        var html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=gb2312\"><div>涓枃鍐呭</div>";
+        var html = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=gb2312\"><div>中文内容</div>";
         var bytes = Encoding.GetEncoding("gb2312").GetBytes(html);
         var content = new ByteArrayContent(bytes);
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/html");
@@ -62,14 +62,14 @@ public class HttpResponseMessageExtensionsTests
         var result = await response.ReadAsHtmlAsync();
 
         // Assert
-        Assert.IsTrue(result.Contains("涓枃鍐呭"));
+        Assert.IsTrue(result.Contains("中文内容"));
     }
 
     [TestMethod]
     public async Task ReadAsHtmlAsync_NoCharset_UsesUtf8ByDefault()
     {
         // Arrange
-        var text = "榛樿UTF8鍐呭";
+        var text = "默认UTF8内容";
         var bytes = Encoding.UTF8.GetBytes(text);
         var content = new ByteArrayContent(bytes);
         content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/plain");

--- a/tests/LuYao.Common.UnitTests/Text/CSharpStringBuilderTests.cs
+++ b/tests/LuYao.Common.UnitTests/Text/CSharpStringBuilderTests.cs
@@ -126,11 +126,10 @@ public class CSharpStringBuilderTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void SetNamespace_NullOrWhitespace_ThrowsArgumentNullException()
     {
         var builder = new CSharpStringBuilder();
-        builder.SetNamespace(" ");
+        Assert.Throws<ArgumentNullException>(() => builder.SetNamespace(" "));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Text/Json/JsonReaderTest.cs
+++ b/tests/LuYao.Common.UnitTests/Text/Json/JsonReaderTest.cs
@@ -44,11 +44,10 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Constructor_WithNullTextReader_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        new JsonReader((TextReader)null);
+        Assert.Throws<ArgumentNullException>(() => new JsonReader((TextReader)null));
     }
 
     [TestMethod]
@@ -154,36 +153,33 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_StringWithInvalidUnicodeEscape_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("\"\\uGGGG\"");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_StringWithInvalidEscape_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("\"\\x\"");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_UnterminatedString_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("\"unterminated");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
@@ -271,14 +267,13 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_InvalidNumber_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("-");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
@@ -310,14 +305,13 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_InvalidBoolean_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("tru");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
@@ -335,14 +329,13 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_InvalidNull_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("nul");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
@@ -457,26 +450,24 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_UnexpectedCharacter_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("@");
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ObjectDisposedException))]
     public void Read_AfterDispose_ShouldThrowObjectDisposedException()
     {
         // Arrange
         var jsonReader = new JsonReader("{}");
         jsonReader.Dispose();
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<ObjectDisposedException>(() => jsonReader.Read());
     }
 
     [TestMethod]
@@ -537,14 +528,13 @@ public class JsonReaderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(JsonException))]
     public void Read_StringWithUnescapedControlCharacter_ShouldThrowException()
     {
         // Arrange
         using var jsonReader = new JsonReader("\"\u0001\""); // 未转义的控制字符
 
-        // Act
-        jsonReader.Read();
+        // Act & Assert
+        Assert.Throws<JsonException>(() => jsonReader.Read());
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Text/Json/JsonWriterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Text/Json/JsonWriterTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
 using System.IO;
@@ -57,7 +57,7 @@ public class JsonWriterTests
     public void Constructor_WithNullTextWriter_ShouldThrowArgumentNullException()
     {
         // Arrange & Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => new JsonWriter((TextWriter)null));
+        Assert.Throws<ArgumentNullException>(() => new JsonWriter((TextWriter)null));
     }
 
     [TestMethod]
@@ -125,7 +125,7 @@ public class JsonWriterTests
     public void WriteEndObject_WithoutStartObject_ShouldThrowInvalidOperationException()
     {
         // Act & Assert
-        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndObject());
+        Assert.Throws<InvalidOperationException>(() => _writer.WriteEndObject());
     }
 
     #endregion
@@ -181,7 +181,7 @@ public class JsonWriterTests
     public void WriteEndArray_WithoutStartArray_ShouldThrowInvalidOperationException()
     {
         // Act & Assert
-        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndArray());
+        Assert.Throws<InvalidOperationException>(() => _writer.WriteEndArray());
     }
 
     #endregion
@@ -221,7 +221,7 @@ public class JsonWriterTests
     public void WritePropertyName_NullName_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => _writer.WritePropertyName(null));
+        Assert.Throws<ArgumentNullException>(() => _writer.WritePropertyName(null));
     }
 
     #endregion
@@ -421,7 +421,7 @@ public class JsonWriterTests
     public void WriteRaw_NullValue_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => _writer.WriteRaw(null));
+        Assert.Throws<ArgumentNullException>(() => _writer.WriteRaw(null));
     }
 
     #endregion
@@ -600,7 +600,7 @@ public class JsonWriterTests
     {
         // Act & Assert
         _writer.WriteStartObject();
-        Assert.ThrowsException<InvalidOperationException>(() => _writer.WriteEndArray());
+        Assert.Throws<InvalidOperationException>(() => _writer.WriteEndArray());
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Text/StringHelperTests.cs
+++ b/tests/LuYao.Common.UnitTests/Text/StringHelperTests.cs
@@ -12,15 +12,15 @@ public class StringHelperTests
     public void Truncate_ThrowsArgumentNullException_WhenTextIsNull()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => StringHelper.Truncate(null, 10, out _));
+        Assert.Throws<ArgumentNullException>(() => StringHelper.Truncate(null, 10, out _));
     }
 
     [TestMethod]
     public void Truncate_ThrowsArgumentOutOfRangeException_WhenMaxLengthIsLessThanOne()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => StringHelper.Truncate("test", 0, out _));
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => StringHelper.Truncate("test", -1, out _));
+        Assert.Throws<ArgumentOutOfRangeException>(() => StringHelper.Truncate("test", 0, out _));
+        Assert.Throws<ArgumentOutOfRangeException>(() => StringHelper.Truncate("test", -1, out _));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Threading/AsyncLockTests.cs
+++ b/tests/LuYao.Common.UnitTests/Threading/AsyncLockTests.cs
@@ -11,7 +11,7 @@ namespace LuYao.Threading
         [TestMethod]
         public async Task LockAsync_WithNullKey_ThrowsArgumentNullException()
         {
-            await Assert.ThrowsExceptionAsync<ArgumentNullException>(
+            await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await AsyncLock.LockAsync(null));
         }
 

--- a/tests/LuYao.Common.UnitTests/Threading/KeyedLockerTests.cs
+++ b/tests/LuYao.Common.UnitTests/Threading/KeyedLockerTests.cs
@@ -1,15 +1,15 @@
-ï»¿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.Threading;
 
 /// <summary>
-/// æµ‹è¯• KeyedLocker<T> ç±»å‹çš„åŠŸèƒ½ã€‚
+/// ²âÊÔ KeyedLocker<T> ÀàĞÍµÄ¹¦ÄÜ¡£
 /// </summary>
 [TestClass]
 public class KeyedLockerTests
 {
     /// <summary>
-    /// æµ‹è¯•ä½¿ç”¨æœ‰æ•ˆé”®è·å–é”å¯¹è±¡æ—¶ï¼Œé”å¯¹è±¡åº”æ­£ç¡®è¿”å›ã€‚
+    /// ²âÊÔÊ¹ÓÃÓĞĞ§¼ü»ñÈ¡Ëø¶ÔÏóÊ±£¬Ëø¶ÔÏóÓ¦ÕıÈ··µ»Ø¡£
     /// </summary>
     [TestMethod]
     public void GetLock_ValidKey_ReturnsLockObject()
@@ -21,11 +21,11 @@ public class KeyedLockerTests
         var lockObject = KeyedLocker<object>.GetLock(key);
 
         // Assert
-        Assert.IsNotNull(lockObject, "é”å¯¹è±¡ä¸åº”ä¸º nullã€‚");
+        Assert.IsNotNull(lockObject, "Ëø¶ÔÏó²»Ó¦Îª null¡£");
     }
 
     /// <summary>
-    /// æµ‹è¯•ä½¿ç”¨ null é”®è·å–é”å¯¹è±¡æ—¶ï¼Œåº”æŠ›å‡º ArgumentNullExceptionã€‚
+    /// ²âÊÔÊ¹ÓÃ null ¼ü»ñÈ¡Ëø¶ÔÏóÊ±£¬Ó¦Å×³ö ArgumentNullException¡£
     /// </summary>
     [TestMethod]
     public void GetLock_NullKey_ThrowsArgumentNullException()
@@ -34,11 +34,11 @@ public class KeyedLockerTests
         string? key = null;
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => KeyedLocker<object>.GetLock(key), "åº”æŠ›å‡º ArgumentNullExceptionã€‚");
+        Assert.Throws<ArgumentNullException>(() => KeyedLocker<object>.GetLock(key), "Ó¦Å×³ö ArgumentNullException¡£");
     }
 
     /// <summary>
-    /// æµ‹è¯•ä½¿ç”¨ç›¸åŒçš„é”®è·å–é”å¯¹è±¡æ—¶ï¼Œåº”è¿”å›ç›¸åŒçš„é”å¯¹è±¡ã€‚
+    /// ²âÊÔÊ¹ÓÃÏàÍ¬µÄ¼ü»ñÈ¡Ëø¶ÔÏóÊ±£¬Ó¦·µ»ØÏàÍ¬µÄËø¶ÔÏó¡£
     /// </summary>
     [TestMethod]
     public void GetLock_SameKey_ReturnsSameLockObject()
@@ -51,6 +51,6 @@ public class KeyedLockerTests
         var lockObject2 = KeyedLocker<object>.GetLock(key);
 
         // Assert
-        Assert.AreSame(lockObject1, lockObject2, "ç›¸åŒçš„é”®åº”è¿”å›ç›¸åŒçš„é”å¯¹è±¡ã€‚");
+        Assert.AreSame(lockObject1, lockObject2, "ÏàÍ¬µÄ¼üÓ¦·µ»ØÏàÍ¬µÄËø¶ÔÏó¡£");
     }
 }

--- a/tests/LuYao.Common.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
@@ -27,7 +27,7 @@ public class TaskExtensionsTests
         var task = Task.Run(() => throw new Exception("Test Exception"));
 
         // Act & Assert
-        await Assert.ThrowsExceptionAsync<Exception>(() => task);
+        await Assert.ThrowsAsync<Exception>(() => task);
         Assert.IsFalse(task.IsCompletedSuccessfully());
     }
 

--- a/tests/LuYao.Common.UnitTests/Xml/TranslatableXmlModelTests.cs
+++ b/tests/LuYao.Common.UnitTests/Xml/TranslatableXmlModelTests.cs
@@ -44,13 +44,12 @@ public class TranslatableXmlModelTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidOperationException))]
     public void Transform_NoResource_ShouldThrowException()
     {
         // Arrange
         var xml = "<Invalid>XML</Invalid>";
 
-        // Act
-        TestXmlModelNoResource.Transform(xml);
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => TestXmlModelNoResource.Transform(xml));
     }
 }

--- a/tests/LuYao.Text.Json.UnitTests/LuYao.Text.Json.UnitTests.csproj
+++ b/tests/LuYao.Text.Json.UnitTests/LuYao.Text.Json.UnitTests.csproj
@@ -19,8 +19,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="MSTest" Version="3.6.4" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+		<PackageReference Include="MSTest" Version="4.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/LuYao.Text.Json.UnitTests/TranslatableJsonModelTests.cs
+++ b/tests/LuYao.Text.Json.UnitTests/TranslatableJsonModelTests.cs
@@ -37,7 +37,7 @@ public class TranslatableJsonModelTests
         string json = "";
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentException>(() => TestJsonModel.Transform(json));
+        Assert.Throws<ArgumentException>(() => TestJsonModel.Transform(json));
     }
 
     /// <summary>
@@ -68,6 +68,6 @@ public class TranslatableJsonModelTests
         object? model = null;
 
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => TestJsonModel.Transform(model));
+        Assert.Throws<ArgumentNullException>(() => TestJsonModel.Transform(model));
     }
 }


### PR DESCRIPTION
将所有单元测试中的异常断言方式统一为 .NET 6+ 的 Assert.Throws/Assert.ThrowsAsync，移除 [ExpectedException] 特性，替换原有 Assert.ThrowsException/ThrowsExceptionAsync。同步升级 MSTest 相关 NuGet 包版本以支持新 API。此举提升了测试代码的现代性和可维护性，并兼容新版 MSTest 框架。