### PR TITLE
重构列追加逻辑至RecordColumnCollection

### DIFF
--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -1,5 +1,4 @@
-﻿using LuYao.Data.Meta;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace LuYao.Data;
@@ -15,7 +14,7 @@ partial class Record
     public static Record From<T>(T data) where T : class
     {
         var re = new Record();
-        re.AppendColumns<T>();
+        re.Columns.AddFrom<T>();
 
         re.AddRow().CopyFrom(data);
 
@@ -30,9 +29,8 @@ partial class Record
     /// <returns>包含与集合等量行数据的新 <see cref="Record"/>。</returns>
     public static Record From<T>(IEnumerable<T> items) where T : class
     {
-        var props = XProp.GetAll(typeof(T));
         var re = new Record();
-        re.AppendColumns<T>();
+        re.Columns.AddFrom<T>();
 
         foreach (var item in items)
         {
@@ -43,77 +41,14 @@ partial class Record
     }
 
     /// <summary>
-    /// 按照类型 <typeparamref name="T"/> 的可读属性向当前 <see cref="Record"/> 追加对应的列定义。
-    /// </summary>
-    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
-    public void AppendColumns<T>() where T : class
-    {
-        var props = XProp.GetAll(typeof(T));
-        foreach (var p in props)
-        {
-            if (!Helpers.IsSupportedForReading(p)) continue;
-            this.Columns.Add(p.Name, p.Type);
-        }
-    }
-
-    /// <summary>
-    /// 根据对象实例（例如匿名类型实例）的可读属性向当前 <see cref="Record"/> 追加对应的列定义。
-    /// </summary>
-    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
-    /// <param name="template">用于推断列结构的对象实例；仅使用其编译时类型信息，不读取其属性值。</param>
-    /// <exception cref="ArgumentNullException"><paramref name="template"/> 为 <see langword="null"/>。</exception>
-    public void AppendColumns<T>(T template) where T : class
-    {
-        if (template == null) throw new ArgumentNullException(nameof(template));
-        this.AppendColumns<T>();
-    }
-
-    /// <summary>
-    /// 按照指定的属性名列表向当前 <see cref="Record"/> 追加列定义，列的追加顺序与 <paramref name="names"/> 的顺序一致。
-    /// 不在类型 <typeparamref name="T"/> 中或不受支持的属性名将被忽略。
-    /// 若 <paramref name="names"/> 为 <see langword="null"/> 或空数组，则不追加任何列。
-    /// </summary>
-    /// <typeparam name="T">提供列类型信息的对象类型。</typeparam>
-    /// <param name="names">要追加的属性名数组，列将按此顺序添加。</param>
-    public void AppendColumns<T>(string[] names) where T : class
-    {
-        if (names == null || names.Length == 0) return;
-        // 构建属性元数据索引，以便按 names 顺序快速查找类型信息。
-        var propMap = new Dictionary<string, XProp>(StringComparer.Ordinal);
-        foreach (var p in XProp.GetAll(typeof(T)))
-        {
-            if (Helpers.IsSupportedForReading(p))
-                propMap[p.Name] = p;
-        }
-        foreach (var name in names)
-        {
-            if (propMap.TryGetValue(name, out var prop))
-                this.Columns.Add(prop.Name, prop.Type);
-        }
-    }
-
-    /// <summary>
-    /// 通过 <see cref="NameFilter{T}"/> 的链式配置向当前 <see cref="Record"/> 追加列定义。
-    /// 列的追加顺序与 <paramref name="filter"/> 中配置的属性选取顺序一致。
-    /// </summary>
-    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
-    /// <param name="filter">用于配置属性过滤规则的委托，接收一个 <see cref="NameFilter{T}"/> 实例。</param>
-    public void AppendColumns<T>(Action<NameFilter<T>> filter) where T : class
-    {
-        var arg = new NameFilter<T>();
-        filter(arg);
-        this.AppendColumns<T>(arg.ToNames());
-    }
-
-    /// <summary>
     /// 向当前 <see cref="Record"/> 追加一行，并将 <paramref name="item"/> 的属性值写入该行。
     /// </summary>
     /// <typeparam name="T">数据来源的对象类型。</typeparam>
-    /// <param name="item">要导入的对象实例，不能为 <see langword="null"/>。</param>
-    /// <exception cref="System.ArgumentNullException"><paramref name="item"/> 为 <see langword="null"/>。</exception>
-    public void Import<T>(T item) where T : class
+    /// <param name="item">要追加的对象实例，不能为 <see langword="null"/>。</param>
+    /// <exception cref="ArgumentNullException"><paramref name="item"/> 为 <see langword="null"/>。</exception>
+    public void Append<T>(T item) where T : class
     {
-        if (item == null) throw new System.ArgumentNullException(nameof(item));
+        if (item == null) throw new ArgumentNullException(nameof(item));
         this.AddRow().CopyFrom(item);
     }
 
@@ -121,8 +56,8 @@ partial class Record
     /// 向当前 <see cref="Record"/> 批量追加行，每个 <paramref name="items"/> 元素对应一行。
     /// </summary>
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
-    /// <param name="items">要批量导入的对象集合。</param>
-    public void Import<T>(IEnumerable<T> items) where T : class
+    /// <param name="items">要批量追加的对象集合。</param>
+    public void Append<T>(IEnumerable<T> items) where T : class
     {
         foreach (var item in items)
         {

--- a/src/LuYao.Common/Data/RecordColumnCollection.cs
+++ b/src/LuYao.Common/Data/RecordColumnCollection.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LuYao.Data.Meta;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -157,6 +158,72 @@ public class RecordColumnCollection : List<RecordColumn>
         var col = new RecordColumn<T>(this.Record, name, typeof(T));
         base.Add(col);
         return col;
+    }
+
+    #endregion
+
+    #region AddFrom
+
+    /// <summary>
+    /// 按照类型 <typeparamref name="T"/> 的可读属性向当前集合追加对应的列定义。
+    /// </summary>
+    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
+    public void AddFrom<T>() where T : class
+    {
+        var props = XProp.GetAll(typeof(T));
+        foreach (var p in props)
+        {
+            if (!Helpers.IsSupportedForReading(p)) continue;
+            this.Add(p.Name, p.Type);
+        }
+    }
+
+    /// <summary>
+    /// 根据对象实例（例如匿名类型实例）的可读属性向当前集合追加对应的列定义。
+    /// </summary>
+    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
+    /// <param name="template">用于推断列结构的对象实例；仅使用其编译时类型信息，不读取其属性值。</param>
+    /// <exception cref="ArgumentNullException"><paramref name="template"/> 为 <see langword="null"/>。</exception>
+    public void AddFrom<T>(T template) where T : class
+    {
+        if (template == null) throw new ArgumentNullException(nameof(template));
+        this.AddFrom<T>();
+    }
+
+    /// <summary>
+    /// 按照指定的属性名列表向当前集合追加列定义，列的追加顺序与 <paramref name="names"/> 的顺序一致。
+    /// 不在类型 <typeparamref name="T"/> 中或不受支持的属性名将被忽略。
+    /// 若 <paramref name="names"/> 为 <see langword="null"/> 或空数组，则不追加任何列。
+    /// </summary>
+    /// <typeparam name="T">提供列类型信息的对象类型。</typeparam>
+    /// <param name="names">要追加的属性名数组，列将按此顺序添加。</param>
+    public void AddFrom<T>(string[] names) where T : class
+    {
+        if (names == null || names.Length == 0) return;
+        var propMap = new Dictionary<string, XProp>(StringComparer.Ordinal);
+        foreach (var p in XProp.GetAll(typeof(T)))
+        {
+            if (Helpers.IsSupportedForReading(p))
+                propMap[p.Name] = p;
+        }
+        foreach (var name in names)
+        {
+            if (propMap.TryGetValue(name, out var prop))
+                this.Add(prop.Name, prop.Type);
+        }
+    }
+
+    /// <summary>
+    /// 通过 <see cref="NameFilter{T}"/> 的链式配置向当前集合追加列定义。
+    /// 列的追加顺序与 <paramref name="filter"/> 中配置的属性选取顺序一致。
+    /// </summary>
+    /// <typeparam name="T">提供列定义的对象类型。</typeparam>
+    /// <param name="filter">用于配置属性过滤规则的委托，接收一个 <see cref="NameFilter{T}"/> 实例。</param>
+    public void AddFrom<T>(Action<NameFilter<T>> filter) where T : class
+    {
+        var arg = new NameFilter<T>();
+        filter(arg);
+        this.AddFrom<T>(arg.ToNames());
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Data/NameFilterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/NameFilterTests.cs
@@ -103,21 +103,21 @@ public class NameFilterTests
     }
 
     [TestMethod]
-    public void AppendColumns_WithNames_RespectsInputOrder()
+    public void AddFrom_WithNames_RespectsInputOrder()
     {
         // 传入顺序与声明顺序故意相反，验证列顺序与传入顺序一致
         var record = new Record();
-        record.AppendColumns<SampleData>(new[] { nameof(SampleData.Email), nameof(SampleData.Id) });
+        record.Columns.AddFrom<SampleData>(new[] { nameof(SampleData.Email), nameof(SampleData.Id) });
         Assert.AreEqual(nameof(SampleData.Email), record.Columns[0].Name);
         Assert.AreEqual(nameof(SampleData.Id), record.Columns[1].Name);
     }
 
     [TestMethod]
-    public void AppendColumns_WithAnonymousTemplate_AddsColumnsFromTemplateType()
+    public void AddFrom_WithAnonymousTemplate_AddsColumnsFromTemplateType()
     {
         var record = new Record();
 
-        record.AppendColumns(new { Id = 1, Name = "Test", IsOk = true });
+        record.Columns.AddFrom(new { Id = 1, Name = "Test", IsOk = true });
 
         Assert.AreEqual(3, record.Columns.Count);
         Assert.AreEqual("Id", record.Columns[0].Name);
@@ -129,21 +129,21 @@ public class NameFilterTests
     }
 
     [TestMethod]
-    public void AppendColumns_WithNullTemplate_ThrowsArgumentNullException()
+    public void AddFrom_WithNullTemplate_ThrowsArgumentNullException()
     {
         var record = new Record();
         SampleData template = null;
 
-        var ex = Assert.Throws<ArgumentNullException>(() => record.AppendColumns(template));
+        var ex = Assert.Throws<ArgumentNullException>(() => record.Columns.AddFrom(template));
         Assert.AreEqual("template", ex.ParamName);
     }
 
     [TestMethod]
-    public void AppendColumns_WithFilter_RespectsManualIncludeOrder()
+    public void AddFrom_WithFilter_RespectsManualIncludeOrder()
     {
         // 通过 NameFilter 手动 Include 的顺序应正确反映到 Record 列顺序
         var record = new Record();
-        record.AppendColumns<SampleData>(f => f.Clear()
+        record.Columns.AddFrom<SampleData>(f => f.Clear()
             .Include(x => x.CreatedAt)
             .Include(x => x.Name));
         Assert.AreEqual(nameof(SampleData.CreatedAt), record.Columns[0].Name);
@@ -151,32 +151,32 @@ public class NameFilterTests
     }
 
     [TestMethod]
-    public void AppendColumns_WithNames_OnlyAddsSpecifiedColumns()
+    public void AddFrom_WithNames_OnlyAddsSpecifiedColumns()
     {
         var record = new Record();
-        record.AppendColumns<SampleData>(new[] { nameof(SampleData.Id), nameof(SampleData.Name) });
+        record.Columns.AddFrom<SampleData>(new[] { nameof(SampleData.Id), nameof(SampleData.Name) });
         Assert.AreEqual(2, record.Columns.Count);
         Assert.IsNotNull(record.Columns[nameof(SampleData.Id)]);
         Assert.IsNotNull(record.Columns[nameof(SampleData.Name)]);
     }
 
     [TestMethod]
-    public void AppendColumns_WithNullOrEmptyNames_AddsNoColumns()
+    public void AddFrom_WithNullOrEmptyNames_AddsNoColumns()
     {
         var record1 = new Record();
-        record1.AppendColumns<SampleData>(new string[0]);
+        record1.Columns.AddFrom<SampleData>(new string[0]);
         Assert.AreEqual(0, record1.Columns.Count, "空数组不应追加任何列。");
 
         var record2 = new Record();
-        record2.AppendColumns<SampleData>((string[])null);
+        record2.Columns.AddFrom<SampleData>((string[])null);
         Assert.AreEqual(0, record2.Columns.Count, "null 不应追加任何列。");
     }
 
     [TestMethod]
-    public void AppendColumns_WithFilter_ExcludesSpecifiedColumn()
+    public void AddFrom_WithFilter_ExcludesSpecifiedColumn()
     {
         var record = new Record();
-        record.AppendColumns<SampleData>(f => f.Exclude(x => x.Email));
+        record.Columns.AddFrom<SampleData>(f => f.Exclude(x => x.Email));
         Assert.AreEqual(3, record.Columns.Count);
         Assert.IsNull(record.Columns[nameof(SampleData.Email)], "Email column should not exist.");
     }


### PR DESCRIPTION
将Record.AppendColumns*方法迁移至RecordColumnCollection.AddFrom*，实现列结构追加职责下沉。移除Record相关方法，调用统一改为record.Columns.AddFrom*。Import方法重命名为Append，提升语义清晰度。同步调整测试用例，确保AddFrom*方法的完整覆盖。此变更有助于RecordSet与DataSet互操作，优化API风格，便于链式调用和后续扩展。