### PR TITLE
Feature/recordrow dynamic meta object

### DIFF
--- a/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
+++ b/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
@@ -1,0 +1,82 @@
+using System.Dynamic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace LuYao.Data;
+
+partial struct RecordRow
+{
+    /// <summary>
+    /// 为 <see cref="RecordRow"/> 提供动态成员绑定支持。
+    /// </summary>
+    private sealed class RecordRowMetaObject : DynamicMetaObject
+    {
+        private static readonly MethodInfo GetValueMethod =
+            typeof(RecordRow).GetMethod(nameof(RecordRow.Get), new[] { typeof(string) })!
+                             .MakeGenericMethod(typeof(object));
+
+        private static readonly MethodInfo SetValueMethod =
+            typeof(RecordRow).GetMethod(nameof(RecordRow.Set), new[] { typeof(string), typeof(object) })!;
+
+        public RecordRowMetaObject(Expression expression, RecordRow value)
+            : base(expression, BindingRestrictions.Empty, value)
+        {
+        }
+
+        private Expression GetLimitedSelf()
+            => Expression.Convert(Expression, typeof(RecordRow));
+
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var call = Expression.Call(
+                GetLimitedSelf(),
+                GetValueMethod,
+                Expression.Constant(binder.Name));
+            return new DynamicMetaObject(call, restrictions);
+        }
+
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var indexerSetter = typeof(RecordRow).GetProperty("Item")!.GetSetMethod()!;
+            var convertedValue = Expression.Convert(value.Expression, typeof(object));
+            var call = Expression.Call(
+                GetLimitedSelf(),
+                indexerSetter,
+                Expression.Constant(binder.Name),
+                convertedValue);
+            // DLR requires the expression to return object, not void
+            var block = Expression.Block(call, convertedValue);
+            return new DynamicMetaObject(block, restrictions);
+        }
+
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var key = Expression.Convert(indexes[0].Expression, typeof(string));
+            var call = Expression.Call(GetLimitedSelf(), GetValueMethod, key);
+            return new DynamicMetaObject(call, restrictions);
+        }
+
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var indexerSetter = typeof(RecordRow).GetProperty("Item")!.GetSetMethod()!;
+            var key = Expression.Convert(indexes[0].Expression, typeof(string));
+            var convertedValue = Expression.Convert(value.Expression, typeof(object));
+            var call = Expression.Call(
+                GetLimitedSelf(),
+                indexerSetter,
+                key,
+                convertedValue);
+            // DLR requires the expression to return object, not void
+            var block = Expression.Block(call, convertedValue);
+            return new DynamicMetaObject(block, restrictions);
+        }
+    }
+}

--- a/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
+++ b/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
@@ -1,4 +1,5 @@
 using System.Dynamic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -12,11 +13,10 @@ partial struct RecordRow
     private sealed class RecordRowMetaObject : DynamicMetaObject
     {
         private static readonly MethodInfo GetValueMethod =
-            typeof(RecordRow).GetMethod(nameof(RecordRow.Get), new[] { typeof(string) })!
-                             .MakeGenericMethod(typeof(object));
+            typeof(RecordRow).GetProperty("Item")!.GetGetMethod()!;
 
         private static readonly MethodInfo SetValueMethod =
-            typeof(RecordRow).GetMethod(nameof(RecordRow.Set), new[] { typeof(string), typeof(object) })!;
+            typeof(RecordRow).GetProperty("Item")!.GetSetMethod()!;
 
         public RecordRowMetaObject(Expression expression, RecordRow value)
             : base(expression, BindingRestrictions.Empty, value)
@@ -25,6 +25,10 @@ partial struct RecordRow
 
         private Expression GetLimitedSelf()
             => Expression.Convert(Expression, typeof(RecordRow));
+
+        /// <inheritdoc/>
+        public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
+            => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
 
         /// <inheritdoc/>
         public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
@@ -41,21 +45,19 @@ partial struct RecordRow
         public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
         {
             var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var indexerSetter = typeof(RecordRow).GetProperty("Item")!.GetSetMethod()!;
-            var convertedValue = Expression.Convert(value.Expression, typeof(object));
-            var call = Expression.Call(
-                GetLimitedSelf(),
-                indexerSetter,
-                Expression.Constant(binder.Name),
-                convertedValue);
+            var param = Expression.Variable(typeof(object));
+            var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
+            var call = Expression.Call(GetLimitedSelf(), SetValueMethod, Expression.Constant(binder.Name), param);
             // DLR requires the expression to return object, not void
-            var block = Expression.Block(call, convertedValue);
+            var block = Expression.Block(new[] { param }, assign, call, param);
             return new DynamicMetaObject(block, restrictions);
         }
 
         /// <inheritdoc/>
         public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
         {
+            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+                return base.BindGetIndex(binder, indexes);
             var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
             var key = Expression.Convert(indexes[0].Expression, typeof(string));
             var call = Expression.Call(GetLimitedSelf(), GetValueMethod, key);
@@ -65,17 +67,15 @@ partial struct RecordRow
         /// <inheritdoc/>
         public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
         {
+            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+                return base.BindSetIndex(binder, indexes, value);
             var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var indexerSetter = typeof(RecordRow).GetProperty("Item")!.GetSetMethod()!;
             var key = Expression.Convert(indexes[0].Expression, typeof(string));
-            var convertedValue = Expression.Convert(value.Expression, typeof(object));
-            var call = Expression.Call(
-                GetLimitedSelf(),
-                indexerSetter,
-                key,
-                convertedValue);
+            var param = Expression.Variable(typeof(object));
+            var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
+            var call = Expression.Call(GetLimitedSelf(), SetValueMethod, key, param);
             // DLR requires the expression to return object, not void
-            var block = Expression.Block(call, convertedValue);
+            var block = Expression.Block(new[] { param }, assign, call, param);
             return new DynamicMetaObject(block, restrictions);
         }
     }

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using LuYao.Data.Meta;
 
 namespace LuYao.Data;
@@ -8,7 +9,7 @@ namespace LuYao.Data;
 /// 代表一行数据，提供对列存储数据集合中特定行数据的访问。
 /// 实现了 <see cref="IPropertyAccessor"/> 接口，支持按属性名读写数据。
 /// </summary>
-public partial struct RecordRow : IPropertyAccessor
+public partial struct RecordRow : IPropertyAccessor, IDynamicMetaObjectProvider
 {
     /// <summary>
     /// 初始化 <see cref="RecordRow"/> 结构体的新实例。
@@ -93,6 +94,12 @@ public partial struct RecordRow : IPropertyAccessor
     }
 
     #endregion
+
+    /// <summary>
+    /// 返回 <see cref="DynamicMetaObject"/>，支持动态成员访问。
+    /// </summary>
+    public DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
+        => new RecordRowMetaObject(parameter, this);
 
     /// <summary>
     /// 根据列名设置当前行指定列的泛型类型值，避免值类型 boxing。

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace LuYao.Data;
@@ -544,6 +545,282 @@ public class RecordRowTests
         Assert.AreEqual(recordRow.Get<Int32>("IntColumn"), recordRow.Get<Int32>(intColumn));
         Assert.AreEqual(recordRow.Get<String>("StringColumn"), recordRow.Get<String>(stringColumn));
         Assert.AreEqual(recordRow.Get<Boolean>("BoolColumn"), recordRow.Get<Boolean>(boolColumn));
+    }
+
+    #endregion
+
+    #region IPropertyAccessor 测试
+
+    /// <summary>
+    /// Props 属性应返回 Record 的列集合
+    /// </summary>
+    [TestMethod]
+    public void Props_ShouldReturnRecordColumns()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var props = recordRow.Props;
+
+        // Assert
+        Assert.AreSame(record.Columns, props);
+    }
+
+    /// <summary>
+    /// 索引器 get - 列存在时应返回正确值
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Get_ColumnExists_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var result = recordRow["StringColumn"];
+
+        // Assert
+        Assert.AreEqual("Test1", result);
+    }
+
+    /// <summary>
+    /// 索引器 get - 列不存在时应返回 null
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Get_ColumnNotExists_ShouldReturnNull()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var result = recordRow["NoSuchColumn"];
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// 索引器 set - 列存在时应更新值
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_ColumnExists_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        recordRow["StringColumn"] = "Updated";
+
+        // Assert
+        Assert.AreEqual("Updated", recordRow.Get<string>("StringColumn"));
+    }
+
+    /// <summary>
+    /// 索引器 set - 列不存在时应静默跳过，不抛出异常
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_ColumnNotExists_ShouldNotThrow()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act & Assert
+        recordRow["NoSuchColumn"] = "Value"; // should not throw
+    }
+
+    #endregion
+
+    #region Set<T> 测试
+
+    /// <summary>
+    /// Set<T> - 强类型列赋值应成功
+    /// </summary>
+    [TestMethod]
+    public void Set_TypedColumn_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        recordRow.Set("IntColumn", 999);
+
+        // Assert
+        Assert.AreEqual(999, recordRow.Get<int>("IntColumn"));
+    }
+
+    /// <summary>
+    /// Set<T> - string 列赋值应成功
+    /// </summary>
+    [TestMethod]
+    public void Set_StringColumn_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
+
+        // Act
+        recordRow.Set("StringColumn", "NewValue");
+
+        // Assert
+        Assert.AreEqual("NewValue", recordRow.Get<string>("StringColumn"));
+    }
+
+    /// <summary>
+    /// Set<T> - 列不存在时应抛出 KeyNotFoundException
+    /// </summary>
+    [TestMethod]
+    public void Set_ColumnNotExists_ShouldThrowKeyNotFoundException()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => recordRow.Set("NoSuchColumn", 1));
+    }
+
+    /// <summary>
+    /// Set<T> 后通过索引器读取应一致
+    /// </summary>
+    [TestMethod]
+    public void Set_ThenReadViaIndexer_ShouldBeConsistent()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        recordRow.Set("IntColumn", 42);
+
+        // Assert
+        Assert.AreEqual(42, (int)recordRow["IntColumn"]!);
+    }
+
+    #endregion
+
+    #region IDynamicMetaObjectProvider (dynamic) 测试
+
+    /// <summary>
+    /// dynamic 成员读取 - 应返回正确值
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_GetMember_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+
+        // Act
+        var result = row.StringColumn;
+
+        // Assert
+        Assert.AreEqual("Test1", result);
+    }
+
+    /// <summary>
+    /// dynamic 成员写入 - 应更新列值
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_SetMember_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+
+        // Act
+        row.StringColumn = "DynValue";
+
+        // Assert
+        var recordRow = new RecordRow(record, 0);
+        Assert.AreEqual("DynValue", recordRow.Get<string>("StringColumn"));
+    }
+
+    /// <summary>
+    /// dynamic 索引器读取 - 应返回正确值
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_GetIndex_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 1);
+
+        // Act
+        var result = row["IntColumn"];
+
+        // Assert
+        Assert.AreEqual(200, (int)result!);
+    }
+
+    /// <summary>
+    /// dynamic 索引器写入 - 应更新列值
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_SetIndex_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+
+        // Act
+        row["IntColumn"] = 777;
+
+        // Assert
+        var recordRow = new RecordRow(record, 0);
+        Assert.AreEqual(777, recordRow.Get<int>("IntColumn"));
+    }
+
+    /// <summary>
+    /// dynamic 读取不存在的列 - 应返回 null（不抛异常）
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_GetMember_ColumnNotExists_ShouldReturnNull()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+
+        // Act
+        var result = row.NoSuchColumn;
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// dynamic 写入不存在的列 - 应静默跳过（不抛异常）
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_SetMember_ColumnNotExists_ShouldNotThrow()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+
+        // Act & Assert
+        row.NoSuchColumn = "ignored"; // should not throw
+    }
+
+    /// <summary>
+    /// dynamic 与强类型 Get 读取结果应一致
+    /// </summary>
+    [TestMethod]
+    public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
+    {
+        // Arrange
+        var (record, intColumn, _, boolColumn) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
+
+        // Act & Assert
+        Assert.AreEqual(recordRow.Get<int>("IntColumn"), (int)row.IntColumn!);
+        Assert.AreEqual(recordRow.Get<bool>("BoolColumn"), (bool)row.BoolColumn!);
     }
 
     #endregion


### PR DESCRIPTION
This pull request adds dynamic member access support to the `RecordRow` struct, allowing consumers to use C# `dynamic` syntax for getting and setting column values by name or index. It introduces a custom `DynamicMetaObject` implementation and updates the unit tests to verify the new behavior.

**Dynamic Member Access Support:**

* `RecordRow` now implements `IDynamicMetaObjectProvider`, enabling dynamic access to its columns using property or indexer syntax (e.g., `row.ColumnName` or `row["ColumnName"]`).
* Added a private `RecordRowMetaObject` class to handle dynamic binding logic, supporting dynamic get/set for both members and string indexers.
* Implemented the `GetMetaObject` method in `RecordRow` to return the custom meta-object for dynamic binding.

**Unit Test Enhancements:**

* Added comprehensive tests in `RecordRowTests` to validate dynamic get/set member and indexer access, including scenarios for missing columns and consistency with existing access methods.

**Usability Improvements:**

* Consumers can now interact with `RecordRow` instances in a more natural, dynamic way, improving developer experience when working with data rows. [[1]](diffhunk://#diff-c34e5a33f58876c73b51348e1cdc8fef8f990501b9ef0bc8cea3a4df5768b673L11-R12) [[2]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833R1-R82)