### PR TITLE
新增 RecordRow.Field 方法及其单元测试

### DIFF
--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -66,6 +66,20 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         return col != null ? col.Get<T>(this.Row) : default;
     }
 
+    /// <summary>
+    /// 根据列对象获取当前行指定列的值。
+    /// </summary>
+    /// <param name="col">要读取的列对象。</param>
+    /// <returns>如果列属于当前记录则直接返回该列当前行的值，否则按列名在当前记录中查找；列不存在时返回 <see langword="null"/>。</returns>
+    public object? Field(RecordColumn col) => col.Record == this.Record ? col.GetValue(this) : this.GetValueOrDefault(col.Name);
+
+    /// <summary>
+    /// 根据列名获取当前行指定列的值。
+    /// </summary>
+    /// <param name="name">列的名称。</param>
+    /// <returns>列存在时返回当前行对应值；列不存在时返回 <see langword="null"/>。</returns>
+    public object? Field(string name) => this.GetValueOrDefault(name);
+
     #endregion
 
     /// <summary>

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -720,5 +720,75 @@ public class RecordRowTests
         Assert.AreEqual(recordRow.Field<bool>("BoolColumn"), (bool)row.BoolColumn!);
     }
 
+    /// <summary>
+    /// <see cref="RecordRow.Field(string)"/> 按列名读取已存在列时，应返回对应对象值。
+    /// </summary>
+    [TestMethod]
+    public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var result = recordRow.Field("IntColumn");
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(100, (int)result!);
+    }
+
+    /// <summary>
+    /// <see cref="RecordRow.Field(string)"/> 按列名读取不存在列时，应返回 null。
+    /// </summary>
+    [TestMethod]
+    public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var result = recordRow.Field("NonExistentColumn");
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// <see cref="RecordRow.Field(RecordColumn)"/> 使用同一记录上的列对象读取时，应返回对应对象值。
+    /// </summary>
+    [TestMethod]
+    public void FieldObject_ByColumn_SameRecord_ShouldReturnValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
+
+        // Act
+        var result = recordRow.Field(stringColumn);
+
+        // Assert
+        Assert.AreEqual("Test2", result);
+    }
+
+    /// <summary>
+    /// <see cref="RecordRow.Field(RecordColumn)"/> 使用其他记录的同名列对象读取时，应回退到按列名查找并返回值。
+    /// </summary>
+    [TestMethod]
+    public void FieldObject_ByColumn_DifferentRecord_ShouldFallbackToNameSearch()
+    {
+        // Arrange
+        var (record1, _, _, _) = CreateTestRecord();
+        var (record2, _, _, boolColumn2) = CreateTestRecord();
+        var recordRow = new RecordRow(record1, 0);
+
+        // Act
+        var result = recordRow.Field(boolColumn2);
+
+        // Assert
+        Assert.AreEqual(true, result);
+    }
+
 }
 


### PR DESCRIPTION
新增两个 Field 重载方法，支持按列名或列对象读取当前行的值，列不存在时返回 null。补充了完整的单元测试，覆盖存在与不存在列、同记录与不同记录的列对象等场景。