### PR TITLE
统一 SetValue 参数顺序为 (row, value)

### DIFF
--- a/src/LuYao.Common/Data/Record.Binary.cs
+++ b/src/LuYao.Common/Data/Record.Binary.cs
@@ -197,7 +197,7 @@ public partial class Record
                 if (!hasValue) continue;
             }
             var val = ReadPrimitiveValue(reader, col.ColumnType);
-            col.SetValue(val, r);
+            col.SetValue(r, val);
         }
     }
 

--- a/src/LuYao.Common/Data/Record.cs
+++ b/src/LuYao.Common/Data/Record.cs
@@ -244,7 +244,7 @@ public partial class Record : IEnumerable<RecordRow>
             {
                 object val = dr.GetValue(i);
                 if (val == DBNull.Value) continue;
-                this.Columns[i].SetValue(val, row);
+                this.Columns[i].SetValue(row, val);
             }
         }
     }
@@ -466,7 +466,7 @@ public partial class Record : IEnumerable<RecordRow>
             {
                 var col = ret.Columns[i];
                 if (row.IsNull(i)) continue;
-                col.SetValue(row[i], recordRow);
+                col.SetValue(recordRow, row[i]);
             }
         }
         return ret;
@@ -521,7 +521,7 @@ public partial class Record : IEnumerable<RecordRow>
             var val = oldCol.GetValue(r);
             if (val is not null)
             {
-                newCol.SetValue(Valid.To(val, newType), r);
+                newCol.SetValue(r, Valid.To(val, newType));
             }
         }
 
@@ -564,7 +564,7 @@ public partial class Record : IEnumerable<RecordRow>
                 var val = this.Columns[c].GetValue(r);
                 if (val is not null)
                 {
-                    clone.Columns[c].SetValue(val, r);
+                    clone.Columns[c].SetValue(r, val);
                 }
             }
         }

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -52,7 +52,7 @@ public class RecordColumn<T> : RecordColumn
     }
 
     ///<inheritdoc/>
-    public override void SetValue(object? value, int row)
+    public override void SetValue(int row, object? value)
     {
         OnSet(row);
         if (value is null)

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -104,7 +104,7 @@ public class RecordColumn<T> : RecordColumn
     }
 
     ///<inheritdoc/>
-    public virtual void Set(T value, int row)
+    public virtual void Set(int row, T value)
     {
         OnSet(row);
         _data[row] = value;

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -56,10 +56,10 @@ public abstract class RecordColumn : IXProp
     /// <summary>
     /// 在指定行设置列的值。
     /// </summary>
-    /// <param name="value">要设置的值，可以为 null。</param>
     /// <param name="row">目标行索引，从 0 开始。</param>
+    /// <param name="value">要设置的值，可以为 null。</param>
     /// <exception cref="ArgumentOutOfRangeException">当 <paramref name="row"/> 超出有效范围时抛出。</exception>
-    public abstract void SetValue(object? value, int row);
+    public abstract void SetValue(int row, object? value);
 
     /// <summary>
     /// 获取指定行的列值。
@@ -138,7 +138,7 @@ public abstract class RecordColumn : IXProp
     bool IXProp.CanWrite => true;
 
     object? IXProp.GetValue(object instance) => GetValue(((RecordRow)instance).Row);
-    void IXProp.SetValue(object instance, object? value) => SetValue(value, ((RecordRow)instance).Row);
+    void IXProp.SetValue(object instance, object? value) => SetValue(((RecordRow)instance).Row, value);
 
     #endregion
 }

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -85,7 +85,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     internal void TrySetValue(string name, object? value)
     {
         var col = this.Record.Columns.Find(name);
-        if (col != null) col.SetValue(value, this);
+        if (col != null) col.SetValue(this.Row, value);
     }
 
     /// <summary>
@@ -98,12 +98,12 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         var existing = this.Record.Columns.Find(name);
         if (existing != null)
         {
-            existing.SetValue(value, this);
+            existing.SetValue(this.Row, value);
             return;
         }
         if (value is null) return;
         var col = this.Record.Columns.Add(name, value.GetType());
-        col.SetValue(value, this);
+        col.SetValue(this.Row, value);
     }
 
     /// <summary>

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -123,6 +123,6 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     public void Set<T>(string name, T value)
     {
         var col = this.Record.Columns.Add<T>(name);
-        col.Set(value, this.Row);
+        col.Set(this.Row, value);
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -27,20 +27,20 @@ public class GenericMethodTests
         var rowIndex = 0;
 
         // Act & Assert - verify all supported types
-        intColumn.Set(42, rowIndex);
+        intColumn.Set(rowIndex, 42);
         Assert.AreEqual(42, intColumn.Get<Int32>(rowIndex));
 
-        stringColumn.Set("Hello World", rowIndex);
+        stringColumn.Set(rowIndex, "Hello World");
         Assert.AreEqual("Hello World", stringColumn.Get<String>(rowIndex));
 
-        boolColumn.Set(true, rowIndex);
+        boolColumn.Set(rowIndex, true);
         Assert.AreEqual(true, boolColumn.Get<Boolean>(rowIndex));
 
         var testDate = new DateTime(2023, 7, 28, 10, 30, 0);
-        dateTimeColumn.Set(testDate, rowIndex);
+        dateTimeColumn.Set(rowIndex, testDate);
         Assert.AreEqual(testDate, dateTimeColumn.Get<DateTime>(rowIndex));
 
-        doubleColumn.Set(3.14159, rowIndex);
+        doubleColumn.Set(rowIndex, 3.14159);
         Assert.AreEqual(3.14159, doubleColumn.Get<Double>(rowIndex), 0.00001);
     }
 
@@ -58,9 +58,9 @@ public class GenericMethodTests
         var row = record.AddRow();
 
         // Act
-        intColumn.Set(123, row.Row);
-        stringColumn.Set("Test String", row.Row);
-        boolColumn.Set(false, row.Row);
+        intColumn.Set(row.Row, 123);
+        stringColumn.Set(row.Row, "Test String");
+        boolColumn.Set(row.Row, false);
 
         // Assert
         Assert.AreEqual(123, row.Field<Int32>(intColumn));
@@ -82,8 +82,8 @@ public class GenericMethodTests
         var row = record.AddRow();
 
         // Seed test data
-        intColumn.Set(42, 0);
-        stringColumn.Set("Hello", 0);
+        intColumn.Set(0, 42);
+        stringColumn.Set(0, "Hello");
 
         // Act & Assert
         int intValue = intColumn.Get<int>(0);
@@ -138,11 +138,11 @@ public class GenericMethodTests
         var row = record.AddRow();
 
         // Act & Assert - empty string
-        stringColumn.Set("", 0);
+        stringColumn.Set(0, "");
         Assert.AreEqual("", stringColumn.Get<String>(0));
 
         // Verify null string
-        stringColumn.Set(null, 0);
+        stringColumn.Set(0, null);
         string result = stringColumn.Get<String>(0);
         Assert.IsNull(result); // should return null
     }
@@ -160,10 +160,10 @@ public class GenericMethodTests
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(42, 1)); // invalid index
+            intColumn.Set(1, 42)); // invalid index
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(42, -1)); // negative index
+            intColumn.Set(-1, 42)); // negative index
     }
 
     /// <summary>
@@ -240,23 +240,23 @@ public class GenericMethodTests
         // Act & Assert - verify conversions across types
 
         // int -> other types
-        intColumn.Set(42, 0);
+        intColumn.Set(0, 42);
         Assert.AreEqual(42.0, intColumn.Get<double>(0), 0.001);
         Assert.AreEqual("42", intColumn.Get<string>(0));
         Assert.AreEqual(true, intColumn.Get<bool>(0)); // non-zero means true
 
         // double -> other types
-        doubleColumn.Set(3.14, 0);
+        doubleColumn.Set(0, 3.14);
         Assert.AreEqual(3, doubleColumn.Get<int>(0)); // truncated
         Assert.AreEqual("3.14", doubleColumn.Get<string>(0));
 
         // string -> other types
-        stringColumn.Set("123", 0);
+        stringColumn.Set(0, "123");
         Assert.AreEqual(123, stringColumn.Get<int>(0));
         Assert.AreEqual(123.0, stringColumn.Get<double>(0), 0.001);
 
         // bool -> other types
-        boolColumn.Set(true, 0);
+        boolColumn.Set(0, true);
         Assert.AreEqual(1, boolColumn.Get<int>(0));
         Assert.AreEqual("True", boolColumn.Get<string>(0));
     }

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -117,11 +117,11 @@ public class GenericMethodTests
 
         // Act & Assert - nullable value
         int? nullableValue = 42;
-        intColumn.SetValue(nullableValue, 0);
+        intColumn.SetValue(0, nullableValue);
         Assert.AreEqual(42, intColumn.Get<Int32>(0));
 
         // Verify null assignment
-        intColumn.SetValue(null, 0);
+        intColumn.SetValue(0, null);
         int defaultValue = intColumn.Get<Int32>(0);
         Assert.AreEqual(0, defaultValue); // default value
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -18,7 +18,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            col.Set(i, row.Row);
+            col.Set(row.Row, i);
         }
 
         Assert.AreEqual(rowCount, record.Count);
@@ -41,7 +41,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 5; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i * 10, row.Row);
+            idCol.Set(row.Row, i * 10);
         }
 
         // Delete middle row (index 2, value 20)
@@ -62,8 +62,8 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i, row.Row);
-            nameCol.Set($"Item{i}", row.Row);
+            idCol.Set(row.Row, i);
+            nameCol.Set(row.Row, $"Item{i}");
         }
 
         // Delete row 1
@@ -72,8 +72,8 @@ public class RecordBoundaryTests
 
         // Add a new row
         var newRow = record.AddRow();
-        idCol.Set(99, newRow.Row);
-        nameCol.Set("New", newRow.Row);
+        idCol.Set(newRow.Row, 99);
+        nameCol.Set(newRow.Row, "New");
 
         Assert.AreEqual(3, record.Count);
         Assert.AreEqual(99, idCol.Get<int>(2));
@@ -93,7 +93,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 5; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i, row.Row);
+            idCol.Set(row.Row, i);
         }
 
         int deleted = record.DeleteWhere(r => r.Field<int>("Id") % 2 == 0);
@@ -113,7 +113,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 5; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i * 10, row.Row);
+            idCol.Set(row.Row, i * 10);
         }
 
         int deleted = record.DeleteRows(new[] { 0, 2, 4 });
@@ -133,7 +133,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i, row.Row);
+            idCol.Set(row.Row, i);
         }
 
         int deleted = record.DeleteRows(new[] { 1, 1, 1 });
@@ -151,7 +151,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i, row.Row);
+            idCol.Set(row.Row, i);
         }
 
         int deleted = record.DeleteWhere(r => r.Field<int>("Id") > 100);

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -15,19 +15,19 @@ public class RecordQueryTests
         record.Columns.Add("IsActive", typeof(bool));
 
         var row1 = record.AddRow();
-        record.Columns["Id"].SetValue(1, row1);
-        record.Columns["Name"].SetValue("Alice", row1);
-        record.Columns["IsActive"].SetValue(true, row1);
+        record.Columns["Id"].SetValue(row1, 1);
+        record.Columns["Name"].SetValue(row1, "Alice");
+        record.Columns["IsActive"].SetValue(row1, true);
 
         var row2 = record.AddRow();
-        record.Columns["Id"].SetValue(2, row2);
-        record.Columns["Name"].SetValue("Bob", row2);
-        record.Columns["IsActive"].SetValue(false, row2);
+        record.Columns["Id"].SetValue(row2, 2);
+        record.Columns["Name"].SetValue(row2, "Bob");
+        record.Columns["IsActive"].SetValue(row2, false);
 
         var row3 = record.AddRow();
-        record.Columns["Id"].SetValue(3, row3);
-        record.Columns["Name"].SetValue("Charlie", row3);
-        record.Columns["IsActive"].SetValue(true, row3);
+        record.Columns["Id"].SetValue(row3, 3);
+        record.Columns["Name"].SetValue(row3, "Charlie");
+        record.Columns["IsActive"].SetValue(row3, true);
 
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
@@ -22,7 +22,7 @@ public class RecordRowSemanticsTests
         var record = new Record();
         var col = record.Columns.Add<int>("Id");
         var row = record.AddRow();
-        col.Set(123, row.Row);
+        col.Set(row.Row, 123);
         Assert.AreEqual(123, row.Field<int>("Id"));
     }
 

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -24,12 +24,12 @@ public class RecordRowTests
         var row1 = record.AddRow();
         var row2 = record.AddRow();
 
-        intColumn.Set(100, 0);
-        intColumn.Set(200, 1);
-        stringColumn.Set("Test1", 0);
-        stringColumn.Set("Test2", 1);
-        boolColumn.Set(true, 0);
-        boolColumn.Set(false, 1);
+        intColumn.Set(0, 100);
+        intColumn.Set(1, 200);
+        stringColumn.Set(0, "Test1");
+        stringColumn.Set(1, "Test2");
+        boolColumn.Set(0, true);
+        boolColumn.Set(1, false);
 
         return (record, intColumn, stringColumn, boolColumn);
     }
@@ -387,7 +387,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 1);
         var byteColumn = record.Columns.Add<byte>("ByteColumn");
         var row = record.AddRow();
-        byteColumn.Set(255, row.Row);
+        byteColumn.Set(row.Row, 255);
         var recordRow = new RecordRow(record, 0);
 
         // Act
@@ -407,7 +407,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 1);
         var doubleColumn = record.Columns.Add<double>("DoubleColumn");
         var row = record.AddRow();
-        doubleColumn.Set(3.14159, row.Row);
+        doubleColumn.Set(row.Row, 3.14159);
         var recordRow = new RecordRow(record, 0);
 
         // Act
@@ -428,7 +428,7 @@ public class RecordRowTests
         var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
         var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
         var row = record.AddRow();
-        dateTimeColumn.Set(testDate, row.Row);
+        dateTimeColumn.Set(row.Row, testDate);
         var recordRow = new RecordRow(record, 0);
 
         // Act
@@ -466,9 +466,9 @@ public class RecordRowTests
         var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
 
         var row3 = record.AddRow();
-        intColumn.Set(300, row3.Row);
-        stringColumn.Set("Test3", row3.Row);
-        boolColumn.Set(true, row3.Row);
+        intColumn.Set(row3.Row, 300);
+        stringColumn.Set(row3.Row, "Test3");
+        boolColumn.Set(row3.Row, true);
 
         var recordRow0 = new RecordRow(record, 0);
         var recordRow1 = new RecordRow(record, 1);

--- a/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
@@ -17,9 +17,9 @@ public class RecordSchemaOperationsTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i + 1, row.Row);
-            nameCol.Set($"Person{i + 1}", row.Row);
-            ageCol.Set(20 + i, row.Row);
+            idCol.Set(row.Row, i + 1);
+            nameCol.Set(row.Row, $"Person{i + 1}");
+            ageCol.Set(row.Row, 20 + i);
         }
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
@@ -242,7 +242,7 @@ public class RecordSchemaOperationsTests
         var record = CreateTestRecord();
 
         var clone = record.Clone();
-        clone.Columns[0].SetValue(999, 0);
+        clone.Columns[0].SetValue(0, 999);
 
         Assert.AreEqual(1, record.Columns[0].GetValue(0));
         Assert.AreEqual(999, clone.Columns[0].GetValue(0));

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -22,12 +22,12 @@ public class RecordSerializationTests
         record.MaxCount = 50;
 
         var row1 = record.AddRow();
-        idCol.Set(1, row1.Row);
-        nameCol.Set("Order-1", row1.Row);
+        idCol.Set(row1.Row, 1);
+        nameCol.Set(row1.Row, "Order-1");
 
         var row2 = record.AddRow();
-        idCol.Set(2, row2.Row);
-        nameCol.Set("Order-2", row2.Row);
+        idCol.Set(row2.Row, 2);
+        nameCol.Set(row2.Row, "Order-2");
 
         return record;
     }
@@ -94,7 +94,7 @@ public class RecordSerializationTests
         var record = new Record("Binary", 1);
         var col = record.Columns.Add<byte[]>("Data");
         var row = record.AddRow();
-        col.Set(new byte[] { 1, 2, 3, 4, 5 }, row.Row);
+        col.Set(row.Row, new byte[] { 1, 2, 3, 4, 5 });
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);
@@ -127,27 +127,27 @@ public class RecordSerializationTests
         record.Columns.Add<Guid>("Guid");
 
         var r = record.AddRow();
-        record.Columns.Find<bool>("Bool")!.Set(true, r.Row);
-        record.Columns.Find<sbyte>("SByte")!.Set(-1, r.Row);
-        record.Columns.Find<short>("Short")!.Set(short.MaxValue, r.Row);
-        record.Columns.Find<int>("Int")!.Set(42, r.Row);
-        record.Columns.Find<long>("Long")!.Set(long.MaxValue, r.Row);
-        record.Columns.Find<byte>("Byte")!.Set(255, r.Row);
-        record.Columns.Find<ushort>("UShort")!.Set(ushort.MaxValue, r.Row);
-        record.Columns.Find<uint>("UInt")!.Set(uint.MaxValue, r.Row);
-        record.Columns.Find<ulong>("ULong")!.Set(ulong.MaxValue, r.Row);
-        record.Columns.Find<float>("Float")!.Set(3.14f, r.Row);
-        record.Columns.Find<double>("Double")!.Set(3.14159265, r.Row);
-        record.Columns.Find<decimal>("Decimal")!.Set(99.99m, r.Row);
-        record.Columns.Find<char>("Char")!.Set('A', r.Row);
-        record.Columns.Find<string>("String")!.Set("Hello", r.Row);
+        record.Columns.Find<bool>("Bool")!.Set(r.Row, true);
+        record.Columns.Find<sbyte>("SByte")!.Set(r.Row, -1);
+        record.Columns.Find<short>("Short")!.Set(r.Row, short.MaxValue);
+        record.Columns.Find<int>("Int")!.Set(r.Row, 42);
+        record.Columns.Find<long>("Long")!.Set(r.Row, long.MaxValue);
+        record.Columns.Find<byte>("Byte")!.Set(r.Row, 255);
+        record.Columns.Find<ushort>("UShort")!.Set(r.Row, ushort.MaxValue);
+        record.Columns.Find<uint>("UInt")!.Set(r.Row, uint.MaxValue);
+        record.Columns.Find<ulong>("ULong")!.Set(r.Row, ulong.MaxValue);
+        record.Columns.Find<float>("Float")!.Set(r.Row, 3.14f);
+        record.Columns.Find<double>("Double")!.Set(r.Row, 3.14159265);
+        record.Columns.Find<decimal>("Decimal")!.Set(r.Row, 99.99m);
+        record.Columns.Find<char>("Char")!.Set(r.Row, 'A');
+        record.Columns.Find<string>("String")!.Set(r.Row, "Hello");
         var dt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
-        record.Columns.Find<DateTime>("DateTime")!.Set(dt, r.Row);
+        record.Columns.Find<DateTime>("DateTime")!.Set(r.Row, dt);
         var dto = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(8));
-        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.Set(dto, r.Row);
-        record.Columns.Find<TimeSpan>("TimeSpan")!.Set(TimeSpan.FromHours(2.5), r.Row);
+        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.Set(r.Row, dto);
+        record.Columns.Find<TimeSpan>("TimeSpan")!.Set(r.Row, TimeSpan.FromHours(2.5));
         var guid = Guid.NewGuid();
-        record.Columns.Find<Guid>("Guid")!.Set(guid, r.Row);
+        record.Columns.Find<Guid>("Guid")!.Set(r.Row, guid);
 
         var bytes = record.ToBytes();
         var d = Record.FromBytes(bytes);
@@ -179,8 +179,8 @@ public class RecordSerializationTests
         var favoriteCol = record.Columns.Add<FavoriteType>("Favorite");
         var nullableFavoriteCol = record.Columns.Add<FavoriteType?>("NullableFavorite");
         var row = record.AddRow();
-        favoriteCol.Set(FavoriteType.Chat, row.Row);
-        nullableFavoriteCol.Set(FavoriteType.Common, row.Row);
+        favoriteCol.Set(row.Row, FavoriteType.Chat);
+        nullableFavoriteCol.Set(row.Row, FavoriteType.Common);
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -248,13 +248,13 @@ public class RecordSetSerializationTests
         var orders = new Record("Orders", 1);
         orders.Columns.Add<int>("Id");
         var row = orders.AddRow();
-        orders.Columns[0].SetValue(1, row.Row);
+        orders.Columns[0].SetValue(row.Row, 1);
         set.Add("Orders", orders);
 
         var customers = new Record("Customers", 1);
         customers.Columns.Add<string>("Name");
         var row2 = customers.AddRow();
-        customers.Columns[0].SetValue("Alice", row2.Row);
+        customers.Columns[0].SetValue(row2.Row, "Alice");
         set.Add("Customers", customers);
 
         var bytes = set.ToBytes();

--- a/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
@@ -15,8 +15,8 @@ public class RecordSetTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            idCol.Set(i + 1, row.Row);
-            nameCol.Set($"Item{i + 1}", row.Row);
+            idCol.Set(row.Row, i + 1);
+            nameCol.Set(row.Row, $"Item{i + 1}");
         }
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -32,8 +32,8 @@ public class RecordTests
 
         // Act
         var row = table.AddRow();
-        colId.Set(1, row.Row);
-        colName.Set("Test", row.Row);
+        colId.Set(row.Row, 1);
+        colName.Set(row.Row, "Test");
 
         // Assert
         Assert.AreEqual(1, table.Count);
@@ -66,14 +66,14 @@ public class RecordTests
 
         // Act
         var row1 = table.AddRow();
-        colId.Set(1, row1.Row);
-        colName.Set("Alice", row1.Row);
-        colAge.Set(25, row1.Row);
+        colId.Set(row1.Row, 1);
+        colName.Set(row1.Row, "Alice");
+        colAge.Set(row1.Row, 25);
 
         var row2 = table.AddRow();
-        colId.Set(2, row2.Row);
-        colName.Set("Bob", row2.Row);
-        colAge.Set(30, row2.Row);
+        colId.Set(row2.Row, 2);
+        colName.Set(row2.Row, "Bob");
+        colAge.Set(row2.Row, 30);
 
         // Assert
         Assert.AreEqual(2, table.Count);
@@ -98,8 +98,8 @@ public class RecordTests
         table.AddRow();
 
         // Act
-        idCol.Set(42, 0);
-        nameCol.Set("TestUser", 0);
+        idCol.Set(0, 42);
+        nameCol.Set(0, "TestUser");
 
         // Assert
         Assert.AreEqual(42, idCol.Get<int>(0));
@@ -114,8 +114,8 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         var colName = table.Columns.Add<string>("Name");
         var row = table.AddRow();
-        colId.Set(123, row.Row);
-        colName.Set("TestValue", row.Row);
+        colId.Set(row.Row, 123);
+        colName.Set(row.Row, "TestValue");
 
         // Act & Assert
         Assert.AreEqual(123, colId.Get<int>(0));
@@ -168,8 +168,8 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         table.AddRow();
         table.AddRow();
-        colId.Set(10, 0);
-        colId.Set(20, 1);
+        colId.Set(0, 10);
+        colId.Set(1, 20);
 
         // Act
         var rows = table.ToArray();
@@ -204,9 +204,9 @@ public class RecordTests
         table.AddRow();
         table.AddRow();
         table.AddRow();
-        colId.Set(1, 0);
-        colId.Set(2, 1);
-        colId.Set(3, 2);
+        colId.Set(0, 1);
+        colId.Set(1, 2);
+        colId.Set(2, 3);
 
         // Act
         var rows = new List<RecordRow>();
@@ -244,15 +244,15 @@ public class RecordTests
         var testDate = new DateTime(2023, 12, 25);
 
         // Act
-        colBool.Set(true, row.Row);
-        colByte.Set((byte)255, row.Row);
-        colDateTime.Set(testDate, row.Row);
-        colDecimal.Set(123.45m, row.Row);
-        colDouble.Set(123.456, row.Row);
-        colInt16.Set((short)1000, row.Row);
-        colInt32.Set(100000, row.Row);
-        colInt64.Set(10000000000L, row.Row);
-        colString.Set("Hello World", row.Row);
+        colBool.Set(row.Row, true);
+        colByte.Set(row.Row, (byte)255);
+        colDateTime.Set(row.Row, testDate);
+        colDecimal.Set(row.Row, 123.45m);
+        colDouble.Set(row.Row, 123.456);
+        colInt16.Set(row.Row, (short)1000);
+        colInt32.Set(row.Row, 100000);
+        colInt64.Set(row.Row, 10000000000L);
+        colString.Set(row.Row, "Hello World");
 
         // Assert
         Assert.AreEqual(true, colBool.GetValue(row.Row));
@@ -294,13 +294,13 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colInt.Set(42, row.Row);
+        colInt.Set(row.Row, 42);
         Assert.AreEqual(42, colInt.Get<Int32>(row.Row));
 
-        colString.Set("Test", row.Row);
+        colString.Set(row.Row, "Test");
         Assert.AreEqual("Test", colString.Get<String>(row.Row));
 
-        colBool.Set(true, row.Row);
+        colBool.Set(row.Row, true);
         Assert.AreEqual(true, colBool.Get<Boolean>(row.Row));
     }
 
@@ -359,7 +359,7 @@ public class RecordTests
         var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         var row = table.AddRow();
-        col.Set("TestValue", row.Row);
+        col.Set(row.Row, "TestValue");
 
         // Verify data exists
         Assert.AreEqual("TestValue", col.GetValue(row.Row));
@@ -415,22 +415,22 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colChar.Set('A', row.Row);
+        colChar.Set(row.Row, 'A');
         Assert.AreEqual('A', colChar.Get<Char>(row.Row));
 
-        colSByte.Set((sbyte)-100, row.Row);
+        colSByte.Set(row.Row, (sbyte)-100);
         Assert.AreEqual((sbyte)-100, colSByte.Get<SByte>(row.Row));
 
-        colSingle.Set(3.14f, row.Row);
+        colSingle.Set(row.Row, 3.14f);
         Assert.AreEqual(3.14f, colSingle.Get<Single>(row.Row));
 
-        colUInt16.Set((ushort)65535, row.Row);
+        colUInt16.Set(row.Row, (ushort)65535);
         Assert.AreEqual((ushort)65535, colUInt16.Get<UInt16>(row.Row));
 
-        colUInt32.Set(4294967295u, row.Row);
+        colUInt32.Set(row.Row, 4294967295u);
         Assert.AreEqual(4294967295u, colUInt32.Get<UInt32>(row.Row));
 
-        colUInt64.Set(18446744073709551615ul, row.Row);
+        colUInt64.Set(row.Row, 18446744073709551615ul);
         Assert.AreEqual(18446744073709551615ul, colUInt64.Get<UInt64>(row.Row));
     }
 
@@ -492,7 +492,7 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert - Test null value
-        col.Set((string?)null, row.Row);
+        col.Set(row.Row, (string?)null);
         Assert.IsNull(col.GetValue(row.Row));
     }
 
@@ -586,11 +586,11 @@ public class RecordTests
         var idCol = record.Columns.Add<Int32>("Id");
         var nameCol = record.Columns.Add<String>("Name");
         record.AddRow();
-        idCol.Set(1, 0);
-        nameCol.Set("A", 0);
+        idCol.Set(0, 1);
+        nameCol.Set(0, "A");
         record.AddRow();
-        idCol.Set(2, 1);
-        nameCol.Set("B", 1);
+        idCol.Set(1, 2);
+        nameCol.Set(1, "B");
 
         var result = record.Delete(0);
 
@@ -606,9 +606,9 @@ public class RecordTests
         var record = new Record("Test", 0);
         var idCol = record.Columns.Add<Int32>("Id");
         record.AddRow();
-        idCol.Set(1, 0);
+        idCol.Set(0, 1);
         record.AddRow();
-        idCol.Set(2, 1);
+        idCol.Set(1, 2);
 
         var result = record.Delete(1);
 
@@ -632,8 +632,8 @@ public class RecordTests
         var nameCol = record.Columns.Add<String>("Name");
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
-        nameCol.Set("Alice", 0);
-        ageCol.Set(30, 0);
+        nameCol.Set(0, "Alice");
+        ageCol.Set(0, 30);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("TestTable"));
@@ -651,10 +651,10 @@ public class RecordTests
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
         record.AddRow();
-        nameCol.Set("Bob", 0);
-        ageCol.Set(25, 0);
-        nameCol.Set("Carol", 1);
-        ageCol.Set(28, 1);
+        nameCol.Set(0, "Bob");
+        ageCol.Set(0, 25);
+        nameCol.Set(1, "Carol");
+        ageCol.Set(1, 28);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("People"));
@@ -675,7 +675,7 @@ public class RecordTests
         record.AddRow();
         record.AddRow();
         string longValue = new string('A', 100);
-        descCol.Set(longValue, 0);
+        descCol.Set(0, longValue);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("..") || result.Contains("LongStringTest"));
@@ -770,7 +770,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(true, -1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(-1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -783,7 +783,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(true, 1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -796,7 +796,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(42, 5));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(5, 42));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -909,21 +909,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all Set methods with invalid index
-        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Set(true, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Set((byte)1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Set('A', 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Set(DateTime.Now, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Set(1.0m, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Set(1.0, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Set((short)1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Set(1, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Set(1, (byte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Set(1, 'A'));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Set(1, DateTime.Now));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Set(1, 1.0m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Set(1, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Set(1, (short)1));
         Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.Set(1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Set(1L, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Set((sbyte)1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Set(1.0f, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Set("test", 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Set((ushort)1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Set(1u, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Set(1ul, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Set(1, 1L));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Set(1, (sbyte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Set(1, 1.0f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Set(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Set(1, (ushort)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Set(1, 1u));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Set(1, 1ul));
     }
 
     [TestMethod]
@@ -1002,8 +1002,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Indices > 0 should throw even with auto-row creation
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set("test", 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set("test", 2));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(2, "test"));
     }
 
     [TestMethod]
@@ -1047,7 +1047,7 @@ public class RecordTests
 
         var row = re.AddRow();
         name.SetValue(row.Row, "John Doe");
-        id.Set(1, row.Row);
+        id.Set(row.Row, 1);
 
         // Assert
         Assert.AreEqual("John Doe", name.Get(row.Row));

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -382,8 +382,8 @@ public class RecordTests
         var row2 = table.AddRow();
 
         // Act
-        col.SetValue(100, row1.Row);
-        col.SetValue(200, row2.Row);
+        col.SetValue(row1.Row, 100);
+        col.SetValue(row2.Row, 200);
 
         // Assert
         Assert.AreEqual(100, col.GetValue(row1.Row));
@@ -731,7 +731,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(-1, "test"));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -744,7 +744,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", 1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(1, "test"));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -757,7 +757,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", 5));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(5, "test"));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -850,9 +850,9 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert - Valid indices should work
-        col.SetValue("value0", 0);
-        col.SetValue("value1", 1);
-        col.SetValue("value2", 2);
+        col.SetValue(0, "value0");
+        col.SetValue(1, "value1");
+        col.SetValue(2, "value2");
 
         Assert.AreEqual("value0", col.GetValue(0));
         Assert.AreEqual("value1", col.GetValue(1));
@@ -872,9 +872,9 @@ public class RecordTests
         table.AddRow(); // Index 2 - should trigger expansion
 
         // Act & Assert - Valid indices work
-        col.SetValue("test0", 0);
-        col.SetValue("test1", 1);
-        col.SetValue("test2", 2);
+        col.SetValue(0, "test0");
+        col.SetValue(1, "test1");
+        col.SetValue(2, "test2");
 
         Assert.AreEqual("test0", col.GetValue(0));
         Assert.AreEqual("test1", col.GetValue(1));
@@ -882,7 +882,7 @@ public class RecordTests
 
         // Invalid indices should still throw
         Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(3));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("invalid", 4));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(4, "invalid"));
     }
 
     [TestMethod]
@@ -990,7 +990,7 @@ public class RecordTests
 
         // Act & Assert - Negative indices should always throw
         Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue("test", -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(-1, "test"));
     }
 
     [TestMethod]
@@ -1046,7 +1046,7 @@ public class RecordTests
         var id = re.Columns.Add<Int32>("Id");
 
         var row = re.AddRow();
-        name.SetValue("John Doe", row.Row);
+        name.SetValue(row.Row, "John Doe");
         id.Set(1, row.Row);
 
         // Assert
@@ -1062,6 +1062,6 @@ public class RecordTests
         var id = re.Columns.Add<Int32>("Id");
         var row = re.AddRow();
         // Act & Assert - DateTime cannot be converted to int via SetValue
-        Assert.Throws<InvalidCastException>(() => id.SetValue(DateTime.Now, row.Row));
+        Assert.Throws<InvalidCastException>(() => id.SetValue(row.Row, DateTime.Now));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
@@ -95,8 +95,8 @@ public class RecordToStringTests
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
         var row = record.AddRow();
-        record.Columns[0].SetValue(1, row);
-        record.Columns[1].SetValue("Alice", row);
+        record.Columns[0].SetValue(row, 1);
+        record.Columns[1].SetValue(row, "Alice");
 
         // Act
         var result = record.ToString();
@@ -116,8 +116,8 @@ public class RecordToStringTests
         for (int i = 0; i < 2; i++)
         {
             var row = record.AddRow();
-            record.Columns[0].SetValue(i, row);
-            record.Columns[1].SetValue("R" + i, row);
+            record.Columns[0].SetValue(row, i);
+            record.Columns[1].SetValue(row, "R" + i);
         }
 
         // Act
@@ -137,7 +137,7 @@ public class RecordToStringTests
         record.Columns.Add<string>("Val");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue("A", r1);
+        record.Columns[0].SetValue(r1, "A");
         // r2 不设置值，保持 null
 
         // Act
@@ -156,8 +156,8 @@ public class RecordToStringTests
         record.Columns.Add<int>("X");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue(1, r1);
-        record.Columns[0].SetValue(2, r2);
+        record.Columns[0].SetValue(r1, 1);
+        record.Columns[0].SetValue(r2, 2);
 
         // Act
         var result = record.ToString();
@@ -178,8 +178,8 @@ public class RecordToStringTests
         record.Columns.Add<string>("Data");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue(new string('A', 100), r1);
-        record.Columns[0].SetValue("short", r2);
+        record.Columns[0].SetValue(r1, new string('A', 100));
+        record.Columns[0].SetValue(r2, "short");
 
         // Act
         var result = record.ToString();


### PR DESCRIPTION
将 RecordColumn 及相关调用的 SetValue 方法参数顺序由 (value, row) 调整为 (row, value)，涵盖泛型子类、接口实现、Record/RecordRow 调用、序列化、克隆、数据导入及所有测试用例。此更改提升了 API 一致性，与常见索引-值风格保持一致，增强了易用性和可读性。