### PR TITLE
优化Record映射API并新增单元测试

### DIFF
--- a/src/LuYao.Common/Data/Meta/XProp.cs
+++ b/src/LuYao.Common/Data/Meta/XProp.cs
@@ -29,6 +29,7 @@ public class XProp : IXProp
             var list = new List<XProp>(props.Length);
             foreach (var p in props)
             {
+                if (p.GetIndexParameters().Length > 0) continue; // 跳过索引器属性
                 list.Add(new XProp(p));
             }
             return list.AsReadOnly();

--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LuYao.Data.Meta;
+using System;
 using System.Collections.Generic;
 
 namespace LuYao.Data;
@@ -27,7 +28,7 @@ partial class Record
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
     /// <param name="items">用于填充行数据的对象集合。</param>
     /// <returns>包含与集合等量行数据的新 <see cref="Record"/>。</returns>
-    public static Record From<T>(IEnumerable<T> items) where T : class
+    public static Record FromList<T>(IEnumerable<T> items) where T : class
     {
         var re = new Record();
         re.Columns.AddFrom<T>();
@@ -46,10 +47,12 @@ partial class Record
     /// <typeparam name="T">数据来源的对象类型。</typeparam>
     /// <param name="item">要追加的对象实例，不能为 <see langword="null"/>。</param>
     /// <exception cref="ArgumentNullException"><paramref name="item"/> 为 <see langword="null"/>。</exception>
-    public void Append<T>(T item) where T : class
+    public RecordRow AddRow<T>(T item) where T : class
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
-        this.AddRow().CopyFrom(item);
+        var ret = this.AddRow();
+        ret.CopyFrom(item);
+        return ret;
     }
 
     /// <summary>
@@ -57,11 +60,13 @@ partial class Record
     /// </summary>
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
     /// <param name="items">要批量追加的对象集合。</param>
-    public void Append<T>(IEnumerable<T> items) where T : class
+    public IEnumerable<RecordRow> AddRows<T>(IEnumerable<T> items) where T : class
     {
         foreach (var item in items)
         {
-            this.AddRow().CopyFrom(item);
+            var it = this.AddRow();
+            it.CopyFrom(item);
+            yield return it;
         }
     }
 
@@ -79,5 +84,21 @@ partial class Record
             list.Add(item);
         }
         return list;
+    }
+
+    /// <summary>
+    /// 将当前 <see cref="Record"/> 的第一行转换为 <typeparamref name="T"/> 对象。
+    /// 如果 <see cref="Record"/> 没有任何行，则返回一个使用无参构造函数创建的默认实例。
+    /// </summary>
+    /// <typeparam name="T">目标对象类型，必须有无参构造函数。</typeparam>
+    /// <returns>转换后的对象实例。</returns>
+    public T To<T>() where T : class, new()
+    {
+        var ret = new T();
+        if (this.Count > 0)
+        {
+            XCopy<T>.CopyFrom(ret, this[0]);
+        }
+        return ret;
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.Mapping.cs
+++ b/src/LuYao.Common/Data/RecordRow.Mapping.cs
@@ -31,8 +31,5 @@ partial struct RecordRow
     /// </summary>
     /// <typeparam name="T">数据来源的对象类型。</typeparam>
     /// <param name="data">属性值的来源对象。</param>
-    public void CopyFrom<T>(T data) where T : class
-    {
-        XCopy<T>.CopyTo(data, this);
-    }
+    public void CopyFrom<T>(T data) where T : class => XCopy<T>.CopyTo(data, this);
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace LuYao.Data;
+
+[TestClass]
+public class RecordMappingTests
+{
+    private sealed class TestModel
+    {
+        public int Id { get; set; }
+
+        public string? Name { get; set; }
+    }
+
+    [TestMethod]
+    public void To_WithRows_ShouldMapFromFirstRow()
+    {
+        // Arrange
+        var record = new Record("Users", 2);
+        var idColumn = record.Columns.Add<int>("Id");
+        var nameColumn = record.Columns.Add<string>("Name");
+
+        var row1 = record.AddRow();
+        idColumn.Set(row1.Row, 1);
+        nameColumn.Set(row1.Row, "Alice");
+
+        var row2 = record.AddRow();
+        idColumn.Set(row2.Row, 2);
+        nameColumn.Set(row2.Row, "Bob");
+
+        // Act
+        var model = record.To<TestModel>();
+
+        // Assert
+        Assert.AreEqual(1, model.Id);
+        Assert.AreEqual("Alice", model.Name);
+    }
+
+    [TestMethod]
+    public void To_WithoutRows_ShouldReturnDefaultConstructedInstance()
+    {
+        // Arrange
+        var record = new Record("Users", 0);
+        record.Columns.Add<int>("Id");
+        record.Columns.Add<string>("Name");
+
+        // Act
+        var model = record.To<TestModel>();
+
+        // Assert
+        Assert.IsNotNull(model);
+        Assert.AreEqual(0, model.Id);
+        Assert.IsNull(model.Name);
+    }
+}


### PR DESCRIPTION
重命名From/Append方法为FromList/AddRow/AddRows，提升语义清晰度并支持链式调用。新增Record.To<T>()方法，支持将首行映射为对象。XProp跳过索引器属性，避免异常。简化RecordRow.CopyFrom实现。补充单元测试验证To<T>()行为。