### PR TITLE
Breaking/recordrow remove generic accessors

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -2,39 +2,52 @@
 
 ## 1. 目标
 
-`Record` 类型聚焦于内存数据处理能力，面向"列存储"场景，强调：
+`Record` 是面向内存列存储场景的数据容器，强调：
 
 - 实用
 - 易用
-- 可扩展
+- 可与 ADO.NET 互操作
+- 适合对象映射与轻量查询
 
-`RecordSet` 作为多表容器，用于组织和管理多个 `Record`。
+`RecordSet` 是多个 `Record` 的命名集合，用于管理多张内存表，并提供与 `DataSet` 的双向互操作。
 
 ---
 
-## 2. 设计边界
+## 2. 当前实现范围
 
-### 2.1 `Record` 核心职责
+### 2.1 `Record`
 
-- 负责内存中的表结构与数据处理。
-- 保留与 `IDataReader`、`DataTable` 的互操作。
-- 支持对象映射（`AddRow<T>`、`AddRows<T>`、`ToList<T>`、`To<T>`）。
-- 支持二进制序列化（`WriteTo` / `ReadFrom`）。
-- 支持服务端翻页元数据（`Page`、`PageSize`、`MaxCount`、`MaxPage`）。
+当前源码中的 `Record` 已提供以下能力：
 
-### 2.2 `RecordSet` 核心职责
+- 列存储结构管理：添加列、重命名列、转换列类型、导出 schema。
+- 行操作：新增、删除单行、按条件批量删除、清空全部行。
+- 行枚举：实现 `IEnumerable<RecordRow>`，支持 `foreach`。
+- 查询：按列值、Lambda、`dynamic` 条件查找。
+- 对象映射：`From<T>`、`FromList<T>`、`AddRow<T>`、`AddRows<T>`、`ToList<T>`、`To<T>`。
+- ADO.NET 互操作：`IDataReader`、`DataTable`。
+- 二进制序列化：`WriteTo` / `ReadFrom` / `ToBytes` / `FromBytes`。
+- 服务端翻页元数据：`Page`、`PageSize`、`MaxCount`、`MaxPage`。
 
-- 负责多个 `Record` 的命名管理。
-- 保持与 `DataSet` 的双向互操作能力。
+### 2.2 `RecordSet`
 
-### 2.3 非核心职责
+当前源码中的 `RecordSet` 已提供以下能力：
 
-- JSON、文本等协议能力通过扩展模块提供（如扩展方法或独立包）。
+- 按名称管理多个 `Record`。
+- 名称比较策略可配置（默认 `StringComparer.Ordinal`）。
+- 与 `DataSet` 双向互操作。
+- 二进制序列化。
+
+### 2.3 非目标
+
+以下能力当前不属于 `Record` / `RecordSet` 的核心实现：
+
+- JSON、CSV、文本协议层。
+- 线程安全容器。
+- 数据库查询翻译。
 
 ### 2.4 线程安全
 
-- `Record`、`RecordSet` 均为**非线程安全**类型（与 `DataTable` 一致）。
-- 多线程场景下，调用方需自行同步。
+`Record`、`RecordRow`、`RecordSet` 都是**非线程安全**类型。多线程场景需要调用方自行同步。
 
 ---
 
@@ -42,27 +55,77 @@
 
 ### 3.1 `RecordRow`
 
-`RecordRow` 是用户最常接触的类型之一，代表 `Record` 中的一行数据视图。
+`RecordRow` 是一个轻量 `struct`，表示某个 `Record` 中的单行视图。
 
-- 定义为 `struct`，持有所属 `Record` 引用与行索引（`Row`）。
-- 提供类型安全的数据读取：`Field<T>(string name)`（命名对齐 `System.Data.DataRowExtensions.Field<T>`，便于与 `DataTable` 互操作的用户迁移）。
-- 提供按列名写入：`Set<T>(string name, T value)`。**写入时若列不存在会按 `T` 自动建列**；同名列已存在但类型不一致时抛 `InvalidOperationException`。
-- 支持隐式转换为 `int`（返回行索引）。
-- 实现 `IDynamicMetaObjectProvider`：`dynamic` 成员/索引读取在列不存在时返回 `null`；写入时按 `value.GetType()` **自动建列**，若 `value` 为 `null` 且列不存在则跳过该次写入（无法推断列类型）。
-- 作为 `Where` 谓词参数、`foreach` 遍历结果等场景的核心类型。
+当前实现包含：
+
+- `Record`：所属 `Record`。
+- `Row`：当前行号。
+- `implicit operator int`：可隐式转为行号。
+- `this[string name]`：按列名读取或写入当前行的值。
+- `To<T>(string name)`：按列名读取并转换为目标类型；列不存在时返回 `default`。
+- `ToDictionary()`：将当前行转为 `Dictionary<string, object?>`。
+- `CopyTo<T>(T data)`：把当前行填充到已有对象。
+- `CopyFrom<T>(T data)`：把对象属性复制到当前行。
+- `To<T>()`：把当前行转换为新对象。
+- `IDynamicMetaObjectProvider`：支持 `dynamic` 成员与索引器读写。
+
+需要注意：当前 `RecordRow` **没有** `Field<T>(string name)` / `Set<T>(string name, value)` API；文档和示例应统一使用索引器、`To<T>(name)`、`CopyFrom`、`CopyTo` 等现有接口。
 
 ### 3.2 `RecordColumn` / `RecordColumn<T>`
 
 `RecordColumn` 是列的抽象基类，`RecordColumn<T>` 是泛型实现。
 
-- 每个列持有所属 `Record` 引用、列名（`Name`）和数据类型（`Type`）。列名可通过 `Record.RenameColumn` 修改。
-- 数据以数组 `T[]` 形式列存储，支持自动扩容。
-- 提供按行索引读写值：`GetValue(int row)` / `SetValue(object? value, int row)`。
-- 泛型列额外提供强类型读写：`Get(int row)` / `Set(T value, int row)`。
+当前实现中常用 API 为：
 
-### 3.4 列类型白名单
+- 基类：`Get(int row)` / `Set(int row, object? value)`
+- 基类：`To<T>(int row)`
+- 基类：`Delete(int row)` / `Clear()`
+- 泛型列：`GetValue(int row)` / `SetValue(int row, T value)`
 
-`RecordColumn<T>` 的类型参数 `T` 仅允许以下封闭白名单中的类型。调用 `Columns.Add<T>()` 或 `Columns.Add(name, type)` 时，若类型不在白名单内，抛出 `NotSupportedException`。
+说明：
+
+- 列绑定到创建它的 `Record`。
+- 列名可通过 `Record.RenameColumn` 或 `Record.Columns.Rename` 修改。
+- `CastColumn` 会创建新的列实例替换旧列；旧列引用不再适用于新 schema。
+
+### 3.3 `RecordColumnCollection`
+
+`RecordColumnCollection` 当前实现：
+
+- 实现 `IReadOnlyList<RecordColumn>`。
+- 内部使用 `KeyedList<string, RecordColumn>` 维护数据。
+- 名称比较使用 `StringComparer.Ordinal`。
+
+常用 API：
+
+| 操作 | 方法 | 行为 |
+|------|------|------|
+| 宽容查找 | `Find(name)` / `Find<T>(name)` | 不存在返回 `null` |
+| 严格查找 | `Get(name)` | 不存在抛 `KeyNotFoundException` |
+| 添加 | `Add(name, type)` / `Add<T>(name)` | 同名同类型返回已有列；同名不同类型抛 `InvalidOperationException` |
+| 删除 | `Remove(name)` | 不存在返回 `false` |
+| 重命名 | `Rename(oldName, newName)` | 重名抛 `DuplicateNameException` |
+| 批量按对象建列 | `AddFrom<T>()` 等重载 | 仅添加受支持属性 |
+
+### 3.4 `RecordSchema`
+
+`Record.GetSchema()` 返回 `RecordSchema`，用于导出当前列定义。
+
+每个 `ColumnDef` 包含：
+
+- `Name`
+- `ColumnType`
+- `IsNullable`
+- `Type`
+
+`RecordSchema` 反映的是当前实现使用的列类型编码信息，适合做 schema 比较、调试和序列化相关场景。
+
+---
+
+## 4. 支持的列类型
+
+当前实现支持以下列类型：
 
 | 类别 | 类型 |
 |------|------|
@@ -74,216 +137,287 @@
 | 时间 | `DateTime`, `DateTimeOffset`, `TimeSpan` |
 | 标识 | `Guid` |
 | 二进制 | `byte[]` |
-| 可空 | 以上所有值类型的 `Nullable<T>` |
+| 可空值类型 | 上述值类型的 `Nullable<T>` |
+| 枚举 | `enum` 及 `Nullable<enum>` |
 
-#### 设计约束
+说明：
 
-- **白名单封闭，不可外部扩展。** 不提供 TypeHandler 或类型注册机制。
-- 白名单覆盖 `IDataReader.GetFieldType()` 可能返回的所有常见类型，确保 `DataTable` / `DataSet` 互操作无损往返。
-- `Convert.ChangeType` 能覆盖白名单内所有类型间的转换，不需要额外转换基础设施。
-- 自定义类型（如 `Money`、`UserId`、`enum`）的转换职责在**对象映射层**（`AddRow<T>` / `ToList<T>`），不在列类型系统内。
-- 序列化场景可穷举处理所有列类型，不存在"不知道怎么序列化"的问题。
-
-### 3.3 `RecordColumnCollection`
-
-`RecordColumnCollection` 管理 `Record` 的列集合。
-
-- 实现 `IReadOnlyList<RecordColumn>`，**不再继承 `List<RecordColumn>`**：避免外部通过基类接口（`Add(RecordColumn)`、`Insert`、`Sort` 等）绕过列名/类型校验。
-- 内部以 `KeyedList<string, RecordColumn>`（`StringComparer.Ordinal`）维护数据，按列名查找为 O(log n)。
-
-方法语义遵循 “宽容 / 严格 / 补齐” 三档划分：
-
-| 操作 | 方法 | 列不存在时的行为 |
-|------|------|------------------|
-| 宽容查找 | `Find(name)` / `Find<T>(name)` | 返回 `null` |
-| 严格查找 | `Get(name)` | 抛 `KeyNotFoundException` |
-| 按需创建 | `Add(name, type)` / `Add<T>(name)` | 创建新列；同名同类型返回已有；同名不同类型抛 `InvalidOperationException` |
-
-其它能力：
-
-- 按索引访问：`this[int index]`
-- 按名称访问：`this[string name]`（返回 `null` 若不存在）
-- 判断：`Contains(string name)` / `IndexOf(string name)`
-- 删除：`Remove(string name)`
-- 重命名：`Rename(oldName, newName)`
-- 清空：`Clear()`
-- 计数：`Count`
+- 列类型白名单是封闭的。
+- 对象映射只处理白名单内属性。
+- 枚举列当前是被接受的，但底层类型信息会按其基础数值类型参与类型码与部分序列化逻辑。
 
 ---
 
-## 4. `Record` 功能需求
+## 5. `Record` API 概览
 
-### 4.1 可靠性与一致性
+### 5.1 构造与基础属性
 
-- 统一边界行为（空表、越界、空列、类型不匹配）。
-- 明确异常类型（`ArgumentException`、`ArgumentOutOfRangeException`、`InvalidOperationException` 等）。
-- 所有数据访问基于行索引（`int row`）或 `RecordRow`，无隐式状态依赖。
-- `SetValue` / `GetValue` 的边界检查一致：行索引超出 `[0, Count)` 时抛出 `ArgumentOutOfRangeException`。
+常用构造方式：
 
-### 4.2 Schema 操作
+- `new Record()`
+- `new Record(string name)`
+- `new Record(string? name, int rows)`
 
-用于列结构的管理与传输场景。
+常用属性：
 
-- `RenameColumn(string oldName, string newName)`：列重命名。
-- `CastColumn(string name, Type newType)`：列类型转换（数据按行逐值转换）。
-- `CloneSchema()`：仅复制列结构（零行），返回新 `Record`。
-- `Clone()`：复制列结构与全部行数据，返回新 `Record`。
-- `GetSchema()`：导出列定义信息（列名 + 类型），用于序列化、传输或 Schema 比较等场景。
+- `Name`
+- `Columns`
+- `Capacity`
+- `Count`
+- `IsEmpty`
 
-### 4.3 服务端翻页
+说明：
 
-`Record` 支持携带服务端翻页元数据，用于分页查询结果的传输。
+- 构造函数中的 `rows` 用于初始容量预估，不是实际行数。
+- `Count` 表示当前实际行数。
+- `Capacity` 会在增加行时按列容量自动扩展。
 
-- `Page`：当前页码（从 1 开始，默认值 1）。
-- `PageSize`：每页数据条数。
-- `MaxCount`：总数据条数。当值大于 0 时返回设置值，否则返回 `Count`。
-- `MaxPage`：总页数（只读，由 `MaxCount` 和 `PageSize` 计算得出）。当 `MaxCount` 为 0 时返回 0；`PageSize` 为 0 时按默认值 20 计算。
+### 5.2 行操作
 
-翻页属性仅作为元数据，不影响 `Record` 的数据操作行为。`Clone()` 和序列化会保留翻页属性。
+当前实现提供：
 
-### 4.4 序列化
+- `AddRow()`：新增一行并返回 `RecordRow`
+- `Delete(int row)`：删除指定行，越界返回 `false`
+- `DeleteWhere(Func<RecordRow, bool>)`：按条件批量删除
+- `DeleteRows(IEnumerable<int>)`：按索引集合批量删除
+- `ClearRows()`：清空所有行，保留列结构
+- `this[int row]`：按索引获取 `RecordRow`
+- `GetEnumerator()`：按行号顺序枚举行
 
-`Record` 和 `RecordSet` 支持通过 `WriteTo` / `ReadFrom` 方法进行二进制序列化。
+### 5.3 Schema 操作
 
-#### 二进制序列化
+当前实现提供：
 
-通过 `BinaryWriter` / `BinaryReader` 实现，按固定顺序写入：
+- `RenameColumn(string oldName, string newName)`
+- `CastColumn(string name, Type newType)`
+- `CloneSchema()`
+- `Clone()`
+- `GetSchema()`
 
-1. 格式版本号（`byte`）。
-2. 表名（`string`）。
-3. 翻页元数据：`Page`、`PageSize`、`MaxCount`（各 `int`）。
-4. 列数量（`int`），随后每列写入：列名（`string`）、类型码（`RecordColumnType`，`byte`）、是否可空（`bool`）。
-5. 行数量（`int`），随后按列顺序写入每列的数据。
+说明：
 
-`RecordSet` 序列化其包含的所有 `Record`。
+- `CloneSchema()` 仅复制表名和列结构，不复制行数据，也不复制翻页元数据。
+- `Clone()` 复制列结构、全部行数据和翻页元数据。
+- `CastColumn()` 会逐行转换旧列值，并替换底层列实例。
 
-### 4.5 查询与过滤
+### 5.4 服务端翻页元数据
 
-`Record` 提供了一组实用的查询方法，用于在内存中快速查找符合条件的数据行：
+`Record` 当前支持：
 
-- **泛型精确匹配**：`Find<T>(string name, T value)` 和 `FindAll<T>(string name, T value)` 可按指定列名与值进行快速精确匹配。如果指定列不存在或找不到匹配项，则返回 `null` 或空序列。
-- **Lambda 筛选**：`Find(Func<RecordRow, bool> filter)` 和 `FindAll(Func<RecordRow, bool> filter)` 允许通过自定义条件筛选 `RecordRow`。
-- **动态类型筛选**：`FindByDynamic(Func<dynamic, bool> filter)` 和 `FindAllByDynamic(Func<dynamic, bool> filter)` 配合 `dynamic` 提供更灵活的表达式查询。
+- `Page`：当前页，默认 `1`
+- `PageSize`
+- `MaxCount`
+- `MaxPage`
+
+行为说明：
+
+- `MaxCount` 取值大于 0 时返回设置值，否则返回 `Count`。
+- `MaxPage` 在 `_maxCount == 0` 时返回 `0`。
+- `MaxPage` 在 `PageSize == 0` 时按 `20` 计算。
+- 翻页属性不会影响数据操作本身。
+
+### 5.5 查询
+
+当前实现提供：
+
+- `Find<T>(string name, T value)`
+- `FindAll<T>(string name, T value)`
+- `Find(Func<RecordRow, bool> filter)`
+- `FindAll(Func<RecordRow, bool> filter)`
+- `FindByDynamic(Func<dynamic, bool> filter)`
+- `FindAllByDynamic(Func<dynamic, bool> filter)`
+
+行为说明：
+
+- `Find*` 未找到时返回 `null`。
+- `FindAll*` 未找到时返回空序列。
+- `FindAll*` 是延迟执行枚举。
+
+### 5.6 对象映射
+
+当前实现提供：
+
+- `Record.From<T>(T data)`
+- `Record.FromList<T>(IEnumerable<T> items)`
+- `record.AddRow<T>(T item)`
+- `record.AddRows<T>(IEnumerable<T> items)`
+- `record.ToList<T>()`
+- `record.To<T>()`
+
+同时 `RecordRow` 提供：
+
+- `row.CopyTo<T>(T data)`
+- `row.CopyFrom<T>(T data)`
+- `row.To<T>()`
+
+重要约束：
+
+- Mapping 路径**不会自动建列**。
+- `CopyFrom` / `AddRow<T>` / `AddRows<T>` 写入时，仅对已存在列赋值；缺失列会被静默跳过。
+- 建议在写入前先使用 `Columns.AddFrom<T>()` 或手动声明 schema。
+
+### 5.7 ADO.NET 互操作
+
+当前实现提供：
+
+- `void Read(IDataReader dr)`
+- `static Record Read(DataTable dt)`
+- `void Write(DataTable dt)`
+- `DataTable ToDataTable()`
+
+行为说明：
+
+- `Read(IDataReader)` 会先 `Columns.Clear()`，然后用 reader 结构重建整张表。
+- `DBNull.Value` 会被跳过，目标列保持默认值。
+- `Write(DataTable dt)` 会向传入的 `DataTable` 追加列和行；通常应传入空表。
+- `ToDataTable()` 会创建新 `DataTable`，表名取自 `Record.Name`。
+
+### 5.8 二进制序列化
+
+当前实现提供：
+
+- `WriteTo(Stream)` / `WriteTo(BinaryWriter)`
+- `ReadFrom(Stream)` / `ReadFrom(BinaryReader)`
+- `ToBytes()` / `FromBytes(byte[])`
+- `FromStream(Stream)`
+- `IsBinaryPayload(byte[])`
+
+当前二进制格式特点：
+
+1. 先写入带类型标识的 payload header。
+2. 再写格式版本号。
+3. 写 `Name`、`Page`、`PageSize`、`MaxCount`。
+4. 写列定义：列名、`RecordColumnType`、`IsNullable`。
+5. 写行数。
+6. 按列顺序写列数据。
+
+说明：
+
+- `Record` 和 `RecordSet` 使用不同的 payload type。
+- `FromBytes` / `ReadFrom` 会校验 payload type 与版本号。
+- `Clone()` 会保留翻页元数据，二进制序列化也会保留这些字段。
+- 枚举列做二进制往返时，当前反序列化结果会恢复为其基础数值列，而不是枚举列。
 
 ---
 
-## 5. 数据访问模型
+## 6. `RecordRow` 访问语义
 
-`Record` 采用基于行索引的无状态访问模型，不维护游标。
+### 6.1 按名称读取
 
-### 5.1 访问方式
+| 路径 | 列不存在时的行为 |
+|------|------------------|
+| `row["Name"]` | 返回 `null` |
+| `row.To<T>("Name")` | 返回 `default(T)` |
+| `record.Columns.Get("Name")` | 抛 `KeyNotFoundException` |
 
-- **行索引**：`record[int row]` 返回 `RecordRow`。
-- **遍历**：`foreach (var row in record)` 按行索引顺序产生 `RecordRow`。
-- **列级别**：`column.GetValue(int row)` / `column.SetValue(value, int row)` / `column.Get<T>(int row)` / `column.Set(T value, int row)`。
-- **行级别（强类型）**：`row.Field<T>(column)` / `row.Field<T>(name)` 读取；`row.Set<T>(name, value)` 写入。
-- **dynamic**：`dynamic d = row;` 之后 `d.Foo` / `d["Foo"]` 进行读写。
+### 6.2 按名称写入
 
-### 5.2 列与值访问语义约定（重要）
+| 路径 | 列不存在时的行为 |
+|------|------------------|
+| `row["Name"] = value` | `value != null` 时按运行时类型自动建列；`value == null` 时跳过 |
+| `dynamicRow.Name = value` | 与索引器写入语义一致 |
+| `row.CopyFrom(dto)` | 不自动建列；缺失列静默跳过 |
 
-| 路径 | 读取（列不存在） | 写入（列不存在） |
-|------|------------------|------------------|
-| `row.Field<T>(name)` | 返回 `default(T)` | — |
-| `row.Set<T>(name, value)` | — | **自动按 `T` 建列** |
-| `dynamic`（成员或索引器） | 返回 `null` | **按 `value.GetType()` 自动建列**；`value == null` 时跳过 |
+### 6.3 dynamic 行为
 
-约定优于配置：
+`RecordRow` 的 dynamic 支持基于 `this[string]` 索引器实现：
 
-- 自动建列只发生在显式的 `Set<T>` 与 dynamic 写入路径上。
-- Mapping（`Fill<T>` / `CopyFrom<T>` / `XCopy`）**不建列**。需要从 DTO 灌入数据前，请先 `Columns.AddFrom<T>()` 或手动 `Add` 声明 schema。
-
-### 5.3 设计约束
-
-- 所有读写操作必须显式指定行索引，不存在依赖隐式位置的 API。
-- `AddRow()` 返回新行的 `RecordRow`，不产生任何全局状态副作用。
-- `RecordRow` 是轻量 `struct`，持有 `Record` 引用和行索引，本身不可变。
+- `d.Foo` 等价于 `row["Foo"]`
+- `d.Foo = 1` 等价于 `row["Foo"] = 1`
+- `d["Foo"]` / `d["Foo"] = 1` 也受支持
 
 ---
 
-## 6. 空表行为约定
-
-所有操作对空表（零行）的处理遵循统一规则：
-
-- **返回值**：空表操作返回空 `Record`（零行但保留 Schema），**绝不返回 `null`**。
-
----
-
-## 7. `RecordSet` 功能需求
-
-`RecordSet` 应作为"命名 Record 集合"。`Record` 自身持有 `Name` 属性，`RecordSet` 以此作为管理键。
+## 7. `RecordSet` API 概览
 
 ### 7.1 基础管理
 
-- 按名称添加：`Add(name, record)`
-- 按名称覆盖：`Set(name, record)`
-- 获取：`Get(name)` / `TryGet(name, out record)`
-- 删除：`Remove(name)`
-- 判断存在：`Contains(name)`
-- 重命名：`Rename(oldName, newName)`
-- 清空：`Clear()`
+当前实现提供：
 
-### 7.2 集合信息与枚举
-
-- `Count`
+- `Add(name, record)`
+- `Set(name, record)`
+- `Get(name)`
+- `TryGet(name, out record)`
+- `Remove(name)`
+- `Contains(name)`
+- `Rename(oldName, newName)`
+- `Clear()`
+- `this[name]`
 - `Names`
-- 字符串索引器：`this[name]`
-- 实现 `IEnumerable<Record>`：枚举所有 `Record`（不暴露名称键，`Record.Name` 已持有名称信息）。
+- `Count`
 
-### 7.3 与 `DataSet` 互操作
+行为说明：
 
-- `FromDataSet(DataSet ds)`：从 `DataSet` 创建 `RecordSet`。
-- `ToDataSet()`：将当前 `RecordSet` 导出为 `DataSet`。
-- `WriteTo(DataSet ds)`：将当前内容写入指定 `DataSet`。
+- `Add` 重名时报 `ArgumentException`。
+- `Set` 重名时覆盖。
+- `Rename` 会同步更新 `record.Name`。
+- 名称比较策略由构造函数中的 `StringComparer` 决定。
 
-要求：
+### 7.2 枚举顺序
 
-- 以表名映射 `Record` 名称。
-- 当前 `FromDataSet` 采用“抛异常”策略：若名称冲突则抛出 `ArgumentException`。后续可扩展支持覆盖或重命名策略。
+当前 `RecordSet` 内部使用 `SortedDictionary<string, Record>`。
 
-### 7.4 行为约束
+这意味着：
 
-- 名称唯一。
-- 名称比较策略可配置（区分/不区分大小写）。
-- 对空名称、重复名称、空记录进行参数检查。
+- `Names` 与 `foreach` 的枚举顺序是**按比较器排序后的名称顺序**。
+- 当前实现**不是**按添加顺序枚举。
 
----
+### 7.3 `DataSet` 互操作
 
-## 8. API 设计原则
+当前实现提供：
 
-- 方法命名语义清晰，避免"读取游标"和"加载数据"同名冲突。
-- 同类操作保持一致的参数顺序与异常风格。
-- 对高频路径预留优化点（减少分配）。
+- `RecordSet.FromDataSet(DataSet ds)`
+- `ToDataSet()`
+- `WriteTo(DataSet ds)`
 
----
+说明：
 
-## 9. 建议实现顺序
+- `FromDataSet` 会把每个 `DataTable` 转成 `Record`，并以 `TableName` 为键。
+- 如果写入的名称冲突，`Add` 会抛出异常。
+- `WriteTo(DataSet ds)` 会向传入 `DataSet` 追加新表；通常应传入空 `DataSet` 或确保名称不冲突。
 
-1. `RecordSet` 基础容器能力（命名管理 + 索引器 + 枚举 + 校验）
-2. `RecordSet` 与 `DataSet` 双向互操作
-3. Schema 操作（`RenameColumn`、`CastColumn`、`CloneSchema`、`Clone`、`GetSchema`）
-4. 服务端翻页属性
-5. 二进制序列化（`WriteTo` / `ReadFrom`）
+### 7.4 二进制序列化
 
----
+当前实现提供：
 
-## 10. 验收标准（面向实用）
+- `WriteTo(Stream)` / `WriteTo(BinaryWriter)`
+- `ReadFrom(Stream)` / `ReadFrom(BinaryReader)`
+- `ToBytes()` / `FromBytes(byte[])`
+- `FromStream(Stream)`
+- `IsBinaryPayload(byte[])`
 
-- 常见数据处理场景可只用 `Record/RecordSet` 完成。
-- 支持从 `DataSet` 导入并回写 `DataSet`，映射规则清晰。
-- 空表操作返回空 `Record`（零行保留 Schema），不返回 `null`。
-- 异常信息清晰，便于排查问题。
-- 多目标框架编译通过，并有覆盖关键行为的单元测试。
-- `Record` / `RecordSet` 可通过 `WriteTo` / `ReadFrom` 正确往返二进制序列化。
-- 翻页属性在序列化、`Clone` 中得到保留。
+`RecordSet` 在序列化时会按键名写出每个 `Record`，以避免 `Record.Name` 被外部修改后与集合键不一致。
 
 ---
 
-## 11. 最佳实践
+## 8. 异常与边界行为
 
-### 11.1 创建与填充
+| 场景 | 当前行为 |
+|------|----------|
+| `record[row]` 越界 | 抛 `ArgumentOutOfRangeException` |
+| `new RecordRow(record, row)` 越界 | 抛 `ArgumentOutOfRangeException` |
+| `Columns.Get(name)` 不存在 | 抛 `KeyNotFoundException` |
+| `Columns.Find(name)` 不存在 | 返回 `null` |
+| `Record.Delete(row)` 越界 | 返回 `false` |
+| `DeleteWhere(null)` | 抛 `ArgumentNullException` |
+| `DeleteRows(null)` | 抛 `ArgumentNullException` |
+| `RecordSet.Get(name)` 不存在 | 抛 `KeyNotFoundException` |
+| `RecordSet.Add(null/空白, record)` | 抛 `ArgumentException` |
+| `RecordSet.Add(name, null)` | 抛 `ArgumentNullException` |
+
+说明：
+
+- 当前实现中，“查找”类 API 多使用 `null` / 空序列表示未命中。
+- “严格获取”类 API 才抛异常。
+- 文档中不应再使用“空表操作总是返回空 `Record`”这类旧约定描述当前实现。
+
+---
+
+## 9. 最佳实践
+
+### 9.1 创建与填充
 
 ```csharp
-// 推荐：先定义列结构，再逐行添加数据
 var record = new Record("Orders", expectedRows);
 var idCol = record.Columns.Add<int>("Id");
 var nameCol = record.Columns.Add<string>("Name");
@@ -292,196 +426,143 @@ var amountCol = record.Columns.Add<decimal>("Amount");
 for (int i = 0; i < count; i++)
 {
     var row = record.AddRow();
-    idCol.Set(i + 1, row.Row);
-    nameCol.Set($"Order-{i + 1}", row.Row);
-    amountCol.Set(amounts[i], row.Row);
+    idCol.SetValue(row.Row, i + 1);
+    nameCol.SetValue(row.Row, $"Order-{i + 1}");
+    amountCol.SetValue(row.Row, amounts[i]);
 }
 ```
 
-**要点**：
+要点：
 
-- 构造时传入预估行数 `expectedRows` 可减少列数组扩容次数。
-- 优先使用泛型 `Add<T>()` 添加列，返回 `RecordColumn<T>` 以获得强类型 `Set` / `Get`。
-- 使用 `AddRow()` 返回的 `RecordRow` 获取行索引，避免手动维护索引变量。
+- 优先先建列，再批量加行。
+- 热路径优先缓存 `RecordColumn<T>`。
+- 强类型写入优先使用 `SetValue`。
 
-### 11.2 读取数据
+### 9.2 读取当前行
 
 ```csharp
 foreach (var row in record)
 {
-    int id = row.Field<int>("Id");
-    string name = row.Field<string>("Name");
+    int id = row.To<int>("Id");
+    string name = row.To<string>("Name");
+    object? rawAmount = row["Amount"];
 }
 ```
 
-**要点**：
+要点：
 
-- `Field<T>` 在列不存在时返回 `default(T)`；如果你需要"列必须存在"的语义，可先调用 `record.Columns.Get(name)` 显式校验列存在性（列不存在会抛异常），然后再用 `Field<T>(name)` 读取数据。该方式会进行两次列名查找，强调显式失败语义，而非性能最优。
+- `row.To<T>(name)` 适合容错读取。
+- 如果列必须存在，先用 `record.Columns.Get(name)` 做显式校验。
 
-### 11.3 dynamic 与自动建列
+### 9.3 dynamic 与自动建列
 
 ```csharp
-var re = new Record();
-dynamic dto = re.AddRow();
-dto.Id = 100;        // 自动按 int 建列
-dto.Name = "abc";    // 自动按 string 建列
-dto.Tag = null;      // 列不存在 + 值为 null → 跳过，不建列
+var record = new Record();
+dynamic row = record.AddRow();
+
+row.Id = 100;
+row.Name = "abc";
+row.Tag = null;
 ```
 
-dynamic 写入是为快速原型/动态结构而生；如果你的 schema 在编译时已知，**优先**显式 `Columns.Add<T>()` + `row.Set<T>()`，可获得：
+要点：
 
-- 更早暴露列名拼写错误（同名不同类型直接抛 `InvalidOperationException`）；
-- 强类型路径，避免装箱与运行时类型推断；
-- 更好的可读性与重构友好度。
+- `Id`、`Name` 会自动建列。
+- `Tag = null` 不会建列。
+- schema 已知时，仍建议显式 `Columns.Add<T>()`。
 
-### 11.4 对象映射
+### 9.4 对象映射
 
 ```csharp
-// 推荐：先按 DTO 结构声明 Schema，再批量灌入
 record.Columns.AddFrom<MyDto>();
+
 foreach (var dto in dtos)
 {
-    var row = record.AddRow();
-    row.CopyFrom(dto);
+    record.AddRow(dto);
 }
+
+List<MyDto> list = record.ToList<MyDto>();
+MyDto first = record.To<MyDto>();
 ```
 
-**注意**：`Fill<T>` / `CopyFrom<T>` **不会自动建列**。若 DTO 有 `Foo` 属性而 Record 未声明 `Foo` 列，该属性的值会被静默丢弃。这是预期行为——schema 应由调用方显式声明。
-- 需要随机访问时使用 `record[index]` 索引器获取 `RecordRow`。
+要点：
 
-### 11.3 列引用的生命周期
+- `AddRow(dto)` 本质上仍然依赖既有列结构。
+- DTO 属性存在但列不存在时，该值会被忽略。
 
-```csharp
-// 列引用在 Record 生命周期内有效
-var col = record.Columns.Find<int>("Id")!;
-
-// ✅ 正确：同一 Record 内使用列引用
-int val = col.Get(0);
-
-// ⚠️ 注意：Clone / CloneSchema 产生的新 Record 有独立的列实例
-var clone = record.Clone();
-// col 仍指向原 Record，不能用于 clone
-var cloneCol = clone.Columns.Find<int>("Id")!;
-```
-
-**要点**：
-
-- `RecordColumn` 绑定到创建它的 `Record` 实例，不可跨 `Record` 使用。
-- `Clone()` / `CloneSchema()` 返回全新 `Record`，列引用不互通。
-- `RecordRow.Get<T>(RecordColumn)` 在检测到列不属于当前 `Record` 时，会自动回退到按名称查找。
-
-### 11.4 Schema 操作
+### 9.5 Schema 操作
 
 ```csharp
-// 重命名列
 record.RenameColumn("OldName", "NewName");
-
-// 类型转换（逐行转换）
 record.CastColumn("Price", typeof(decimal));
 
-// 复制结构用于构建新表
-var template = record.CloneSchema();
+var schemaOnly = record.CloneSchema();
+var clone = record.Clone();
+var schema = record.GetSchema();
 ```
 
-**要点**：
+要点：
 
-- `RenameColumn` 会使已持有的列引用名称同步更新（同一对象）。
-- `CastColumn` 会替换底层列实例。此前缓存的列引用将失效，需重新获取。
+- `CloneSchema()` 只复制结构。
+- `Clone()` 复制结构、数据和翻页信息。
+- `CastColumn()` 后应重新获取列引用。
 
-### 11.5 与 ADO.NET 互操作
+### 9.6 与 ADO.NET 互操作
 
 ```csharp
-// 从 IDataReader 填充
 var record = new Record();
 record.Read(dataReader);
 
-// 从 DataTable 创建
-var record = Record.Read(dataTable);
+var fromTable = Record.Read(dataTable);
+DataTable table = fromTable.ToDataTable();
 
-// 导出为 DataTable
-var dt = record.ToDataTable();
-
-// RecordSet <-> DataSet
 var set = RecordSet.FromDataSet(dataSet);
-var ds = set.ToDataSet();
+DataSet ds = set.ToDataSet();
 ```
 
-**要点**：
-
-- `Record.Read(IDataReader)` 会清空现有列和数据，完全用 Reader 的内容替换。
-- `Record.Read(DataTable)` 是静态方法，返回新实例；`record.Read(IDataReader)` 是实例方法，就地填充。
-- `DBNull.Value` 和 `null` 均映射为列类型的默认值（值类型为 `default(T)`，引用类型为 `null`）。
-
-### 11.6 RecordSet 管理
+### 9.7 RecordSet 管理
 
 ```csharp
 var set = new RecordSet();
 set.Add("Orders", ordersRecord);
-set.Add("Customers", customersRecord);
+set.Set("Customers", customersRecord);
 
-// 安全获取
 if (set.TryGet("Orders", out var orders))
 {
-    // 使用 orders
+    Console.WriteLine(orders.Count);
 }
 
-// 遍历（按添加顺序）
-foreach (var record in set)
+foreach (var item in set)
 {
-    Console.WriteLine($"{record.Name}: {record.Count} rows");
+    Console.WriteLine(item.Name);
 }
 ```
 
-**要点**：
+要点：
 
-- `RecordSet` 默认区分大小写（`StringComparer.Ordinal`）。如需不区分大小写，构造时传入 `StringComparer.OrdinalIgnoreCase`。
-- `Add` 名称重复时抛异常；`Set` 名称重复时覆盖。根据场景选择合适的方法。
-- `Rename` 会同步更新 `Record.Name` 属性。
-- 枚举顺序与添加顺序一致。
+- 枚举顺序按名称排序，不是按添加顺序。
+- 如需不区分大小写，可使用 `new RecordSet(StringComparer.OrdinalIgnoreCase)`。
 
-### 11.7 异常处理
-
-| 场景 | 异常类型 |
-|------|----------|
-| 行索引越界 | `ArgumentOutOfRangeException` |
-| 列名不存在（`Columns.Get`） | `KeyNotFoundException` |
-| 类型不匹配 | `InvalidCastException` |
-| 空参数 | `ArgumentNullException` |
-| 空/空白名称 | `ArgumentException` |
-
-**要点**：
-
-- `Columns.Find(name)` 不存在时返回 `null`（适合可选查找）。
-- `Columns.Get(name)` 不存在时抛 `KeyNotFoundException`（适合必须存在的场景）。
-- `record[row]` 索引越界时抛 `ArgumentOutOfRangeException`。
-
-### 11.8 性能提示
-
-- **预分配容量**：`new Record(name, expectedRows)` 减少列数组扩容。
-- **缓存列引用**：循环内避免反复调用 `Columns.Find` 或 `Columns["name"]`。
-- **优先泛型 API**：`RecordColumn<T>.Get(row)` / `Set(value, row)` 避免装箱拆箱，比 `GetValue` / `SetValue` 更高效。
-- **批量构建**：先添加所有列，再逐行填充。不要在行循环中动态添加列。
-
-### 11.9 数据查询
+### 9.8 二进制序列化
 
 ```csharp
-// 按强类型列值查找单条
-var row = record.Find<string>("Name", "Alice");
+byte[] bytes = record.ToBytes();
+Record copy = Record.FromBytes(bytes);
 
-// 使用 Lambda 过滤多条记录
-var activeRows = record.FindAll(r => r.Field<bool>("IsActive"));
-
-// 使用 dynamic 动态查询
-var dynamicRow = record.FindByDynamic(d => d.Id == 100);
+byte[] setBytes = set.ToBytes();
+RecordSet setCopy = RecordSet.FromBytes(setBytes);
 ```
-
-**要点**：
-
-- `Find` / `FindByDynamic` 若未找到匹配项或指定的列不存在，会直接返回 `null`。
-- `FindAll` 系列方法返回延迟执行的 `IEnumerable<RecordRow>`。
 
 ---
 
-## 12. 对象映射
+## 10. 当前文档与实现的关键对齐点
 
-对象映射能力属于 `Record` 核心职责（见 §2.1），提供 `AddRow<T>`、`AddRows<T>`、`ToList<T>`、`To<T>` 等扩展方法。
+为避免继续误导，以下旧说法已不再适用于当前源码：
+
+- `RecordRow.Field<T>(name)` / `Set<T>(name, value)`：当前实现中不存在。
+- `RecordColumn.Field` / `SetField`：已重命名为 `GetValue` / `SetValue`。
+- `RecordSet` 按添加顺序枚举：当前实现中不成立，实际按名称排序枚举。
+- 空表操作统一返回空 `Record`：当前实现并无这一统一规则。
+- 枚举列完全按枚举类型做二进制往返：当前实现中会还原为基础数值列。
+
+后续如再调整实现，请优先以 `src/LuYao.Common/Data` 下源码与单元测试为准更新本文。

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -43,9 +43,10 @@ public static class XCopy<T> where T : class
     /// <param name="row">目标行；仅写入类型受支持的可读属性。Mapping 路径下若列不存在则静默跳过，<b>不会自动建列</b>。</param>
     public static void CopyTo(T data, RecordRow row)
     {
+        var cols = row.Record.Columns;
         foreach (var prop in _readableProps)
         {
-            row.TrySetValue(prop.Name, prop.GetValue(data));
+            if (cols.Contains(prop.Name)) row[prop.Name] = prop.GetValue(data);
         }
     }
 
@@ -56,11 +57,11 @@ public static class XCopy<T> where T : class
     /// <param name="row">数据来源行。</param>
     public static void CopyFrom(T data, RecordRow row)
     {
-        var columns = row.Record.Columns;
+        var cols = row.Record.Columns;
         foreach (var prop in _writableProps)
         {
-            if (!columns.Contains(prop.Name)) continue;
-            prop.SetValue(data, row.GetValueOrDefault(prop.Name));
+            if (!cols.Contains(prop.Name)) continue;
+            prop.SetValue(data, row[prop.Name]);
         }
     }
     #endregion

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -46,7 +46,9 @@ public static class XCopy<T> where T : class
         var cols = row.Record.Columns;
         foreach (var prop in _readableProps)
         {
-            if (cols.Contains(prop.Name)) row[prop.Name] = prop.GetValue(data);
+            var col = cols.Find(prop.Name);
+            if (col == null) continue;
+            col.Set(row, prop.GetValue(data));
         }
     }
 
@@ -60,8 +62,9 @@ public static class XCopy<T> where T : class
         var cols = row.Record.Columns;
         foreach (var prop in _writableProps)
         {
-            if (!cols.Contains(prop.Name)) continue;
-            prop.SetValue(data, row[prop.Name]);
+            var col = cols.Find(prop.Name);
+            if (col == null) continue;
+            prop.SetValue(data, col.Get(row));
         }
     }
     #endregion

--- a/src/LuYao.Common/Data/Record.Binary.cs
+++ b/src/LuYao.Common/Data/Record.Binary.cs
@@ -171,7 +171,7 @@ public partial class Record
 
         for (int r = 0; r < rowCount; r++)
         {
-            var val = col.GetValue(r);
+            var val = col.Get(r);
             if (needsNullCheck)
             {
                 if (val is null)
@@ -197,7 +197,7 @@ public partial class Record
                 if (!hasValue) continue;
             }
             var val = ReadPrimitiveValue(reader, col.ColumnType);
-            col.SetValue(r, val);
+            col.Set(r, val);
         }
     }
 

--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -16,9 +16,7 @@ partial class Record
     {
         var re = new Record();
         re.Columns.AddFrom<T>();
-
-        re.AddRow().CopyFrom(data);
-
+        re.AddRow(data);
         return re;
     }
 
@@ -32,12 +30,7 @@ partial class Record
     {
         var re = new Record();
         re.Columns.AddFrom<T>();
-
-        foreach (var item in items)
-        {
-            re.AddRow().CopyFrom(item);
-        }
-
+        re.AddRows(items);
         return re;
     }
 
@@ -64,8 +57,7 @@ partial class Record
     {
         foreach (var item in items)
         {
-            var it = this.AddRow();
-            it.CopyFrom(item);
+            var it = this.AddRow(item);
             yield return it;
         }
     }

--- a/src/LuYao.Common/Data/Record.Query.cs
+++ b/src/LuYao.Common/Data/Record.Query.cs
@@ -22,7 +22,7 @@ public partial class Record
         var comparer = EqualityComparer<T>.Default;
         for (int i = 0; i < this.Count; i++)
         {
-            var val = col.Get<T>(i);
+            var val = col.To<T>(i);
             if (comparer.Equals(val, value)) return new RecordRow(this, i);
         }
         return null;
@@ -42,7 +42,7 @@ public partial class Record
         var comparer = EqualityComparer<T>.Default;
         for (int i = 0; i < this.Count; i++)
         {
-            var val = col.Get<T>(i);
+            var val = col.To<T>(i);
             if (comparer.Equals(val, value)) yield return new RecordRow(this, i);
         }
     }

--- a/src/LuYao.Common/Data/Record.cs
+++ b/src/LuYao.Common/Data/Record.cs
@@ -244,7 +244,7 @@ public partial class Record : IEnumerable<RecordRow>
             {
                 object val = dr.GetValue(i);
                 if (val == DBNull.Value) continue;
-                this.Columns[i].SetValue(row, val);
+                this.Columns[i].Set(row, val);
             }
         }
     }
@@ -268,7 +268,7 @@ public partial class Record : IEnumerable<RecordRow>
             {
                 sb.Append(PadRightByWidth(col.Name, max));
                 sb.Append(" | ");
-                sb.Append(col.GetValue(0));
+                sb.Append(col.Get(0));
                 sb.AppendLine();
             }
         }
@@ -285,7 +285,7 @@ public partial class Record : IEnumerable<RecordRow>
 
                 for (int i = 0; i < Count; i++)
                 {
-                    string s = Convert.ToString(col.GetValue(i)) ?? string.Empty;
+                    string s = Convert.ToString(col.Get(i)) ?? string.Empty;
                     int w = DisplayWidth(s);
                     if (w > MAX_WIDTH)
                     {
@@ -441,7 +441,7 @@ public partial class Record : IEnumerable<RecordRow>
             DataRow row = dt.Rows.Add();
             for (int i = 0; i < this.Columns.Count; i++)
             {
-                var val = this.Columns[i].GetValue(r);
+                var val = this.Columns[i].Get(r);
                 if (val is not null) row[i] = val;
             }
         }
@@ -466,7 +466,7 @@ public partial class Record : IEnumerable<RecordRow>
             {
                 var col = ret.Columns[i];
                 if (row.IsNull(i)) continue;
-                col.SetValue(recordRow, row[i]);
+                col.Set(recordRow, row[i]);
             }
         }
         return ret;
@@ -518,10 +518,10 @@ public partial class Record : IEnumerable<RecordRow>
 
         for (int r = 0; r < this.Count; r++)
         {
-            var val = oldCol.GetValue(r);
+            var val = oldCol.Get(r);
             if (val is not null)
             {
-                newCol.SetValue(r, Valid.To(val, newType));
+                newCol.Set(r, Valid.To(val, newType));
             }
         }
 
@@ -561,10 +561,10 @@ public partial class Record : IEnumerable<RecordRow>
             clone.AddRow();
             for (int c = 0; c < this.Columns.Count; c++)
             {
-                var val = this.Columns[c].GetValue(r);
+                var val = this.Columns[c].Get(r);
                 if (val is not null)
                 {
-                    clone.Columns[c].SetValue(r, val);
+                    clone.Columns[c].Set(r, val);
                 }
             }
         }

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -45,14 +45,14 @@ public class RecordColumn<T> : RecordColumn
     }
 
     ///<inheritdoc/>
-    public override object? GetValue(int row)
+    public override object? Get(int row)
     {
         OnGet(row);
         return _data[row];
     }
 
     ///<inheritdoc/>
-    public override void SetValue(int row, object? value)
+    public override void Set(int row, object? value)
     {
         OnSet(row);
         if (value is null)
@@ -94,17 +94,17 @@ public class RecordColumn<T> : RecordColumn
         Array.Copy(src, _data, len);
     }
 
-    #region Get / Set
+    #region Field
 
     ///<inheritdoc/>
-    public T Get(int row)
+    public T Field(int row)
     {
         OnGet(row);
         return _data[row];
     }
 
     ///<inheritdoc/>
-    public virtual void Set(int row, T value)
+    public virtual void SetField(int row, T value)
     {
         OnSet(row);
         _data[row] = value;

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -94,17 +94,17 @@ public class RecordColumn<T> : RecordColumn
         Array.Copy(src, _data, len);
     }
 
-    #region Field
+    #region Accessor
 
     ///<inheritdoc/>
-    public T Field(int row)
+    public T GetValue(int row)
     {
         OnGet(row);
         return _data[row];
     }
 
     ///<inheritdoc/>
-    public virtual void SetField(int row, T value)
+    public virtual void SetValue(int row, T value)
     {
         OnSet(row);
         _data[row] = value;

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -137,8 +137,19 @@ public abstract class RecordColumn : IXProp
     bool IXProp.CanRead => true;
     bool IXProp.CanWrite => true;
 
-    object? IXProp.GetValue(object instance) => Get(((RecordRow)instance).Row);
-    void IXProp.SetValue(object instance, object? value) => Set(((RecordRow)instance).Row, value);
+    object? IXProp.GetValue(object instance)
+    {
+        if (instance is RecordRow row) return Get(row.Row);
+        throw new InvalidOperationException();
+    }
+
+    void IXProp.SetValue(object instance, object? value)
+    {
+        if (instance is RecordRow row)
+            Set(row.Row, value);
+        else
+            throw new InvalidOperationException();
+    }
 
     #endregion
 }

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -140,7 +140,7 @@ public abstract class RecordColumn : IXProp
     object? IXProp.GetValue(object instance)
     {
         if (instance is RecordRow row) return Get(row.Row);
-        throw new InvalidOperationException();
+        throw new InvalidCastException();
     }
 
     void IXProp.SetValue(object instance, object? value)
@@ -148,7 +148,7 @@ public abstract class RecordColumn : IXProp
         if (instance is RecordRow row)
             Set(row.Row, value);
         else
-            throw new InvalidOperationException();
+            throw new InvalidCastException();
     }
 
     #endregion

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -59,7 +59,7 @@ public abstract class RecordColumn : IXProp
     /// <param name="row">目标行索引，从 0 开始。</param>
     /// <param name="value">要设置的值，可以为 null。</param>
     /// <exception cref="ArgumentOutOfRangeException">当 <paramref name="row"/> 超出有效范围时抛出。</exception>
-    public abstract void SetValue(int row, object? value);
+    public abstract void Set(int row, object? value);
 
     /// <summary>
     /// 获取指定行的列值。
@@ -67,7 +67,7 @@ public abstract class RecordColumn : IXProp
     /// <param name="row">行索引，从 0 开始。</param>
     /// <returns>指定行的列值，可能为 null。</returns>
     /// <exception cref="ArgumentOutOfRangeException">当 <paramref name="row"/> 超出有效范围时抛出。</exception>
-    public abstract object? GetValue(int row);
+    public abstract object? Get(int row);
 
     /// <summary>
     /// 删除指定行的列值。
@@ -112,7 +112,7 @@ public abstract class RecordColumn : IXProp
         if (row < 0 || row >= this.Record.Count) throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {Record.Count - 1}]");
     }
 
-    #region Get 
+    #region To 
     /// <summary>
     /// 获取指定行的值并转换为指定的泛型类型。
     /// </summary>
@@ -121,10 +121,10 @@ public abstract class RecordColumn : IXProp
     /// <returns>转换后的值，如果原值为 null 则返回类型 T 的默认值。</returns>
     /// <exception cref="ArgumentOutOfRangeException">当 <paramref name="row"/> 超出有效范围时抛出。</exception>
     /// <exception cref="InvalidCastException">当值无法转换为目标类型时抛出。</exception>
-    public virtual T? Get<T>(int row)
+    public virtual T? To<T>(int row)
     {
         OnGet(row);
-        object? value = this.GetValue(row);
+        object? value = this.Get(row);
         if (value is null) return default;
         if (value is T direct) return direct;
         return (T)Valid.To(value, typeof(T));
@@ -137,8 +137,8 @@ public abstract class RecordColumn : IXProp
     bool IXProp.CanRead => true;
     bool IXProp.CanWrite => true;
 
-    object? IXProp.GetValue(object instance) => GetValue(((RecordRow)instance).Row);
-    void IXProp.SetValue(object instance, object? value) => SetValue(((RecordRow)instance).Row, value);
+    object? IXProp.GetValue(object instance) => Get(((RecordRow)instance).Row);
+    void IXProp.SetValue(object instance, object? value) => Set(((RecordRow)instance).Row, value);
 
     #endregion
 }

--- a/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
+++ b/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
@@ -1,4 +1,5 @@
 using System.Dynamic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace LuYao.Data;
@@ -10,77 +11,60 @@ partial struct RecordRow
     /// </summary>
     private sealed class RecordRowMetaObject : DynamicMetaObject
     {
-        //// dynamic 读取走 GetValueOrDefault：列不存在返回 null。
-        //private static readonly MethodInfo GetMethod =
-        //    typeof(RecordRow).GetMethod(
-        //        nameof(RecordRow.GetValueOrDefault),
-        //        BindingFlags.Instance | BindingFlags.NonPublic)!;
-
-        //// dynamic 写入走 SetAndEnsureColumn：列不存在时按运行时类型自动建列；null 值且列不存在则跳过。
-        //private static readonly MethodInfo SetMethod =
-        //    typeof(RecordRow).GetMethod(
-        //        nameof(RecordRow.SetAndEnsureColumn),
-        //        BindingFlags.Instance | BindingFlags.NonPublic)!;
+        // dynamic 读取/写入走 this[string] 索引器
+        private static readonly System.Reflection.PropertyInfo IndexerProperty =
+            typeof(RecordRow).GetProperty("Item", new[] { typeof(string) })!;
 
         public RecordRowMetaObject(Expression expression, RecordRow value)
             : base(expression, BindingRestrictions.Empty, value)
         {
         }
 
-        //private Expression GetLimitedSelf()
-        //    => Expression.Convert(Expression, typeof(RecordRow));
+        private Expression GetLimitedSelf()
+            => Expression.Convert(Expression, typeof(RecordRow));
 
-        ///// <inheritdoc/>
-        //public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
-        //    => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
+        /// <inheritdoc/>
+        public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
+            => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
 
-        ///// <inheritdoc/>
-        //public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
-        //{
-        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-        //    var call = Expression.Call(
-        //        GetLimitedSelf(),
-        //        GetMethod,
-        //        Expression.Constant(binder.Name));
-        //    return new DynamicMetaObject(call, restrictions);
-        //}
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var call = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { Expression.Constant(binder.Name) });
+            return new DynamicMetaObject(call, restrictions);
+        }
 
-        ///// <inheritdoc/>
-        //public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
-        //{
-        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-        //    var param = Expression.Variable(typeof(object));
-        //    var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
-        //    var call = Expression.Call(GetLimitedSelf(), SetMethod, Expression.Constant(binder.Name), param);
-        //    // DLR requires the expression to return object, not void
-        //    var block = Expression.Block(new[] { param }, assign, call, param);
-        //    return new DynamicMetaObject(block, restrictions);
-        //}
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
+        {
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var indexAccess = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { Expression.Constant(binder.Name) });
+            var assign = Expression.Assign(indexAccess, Expression.Convert(value.Expression, typeof(object)));
+            return new DynamicMetaObject(assign, restrictions);
+        }
 
-        ///// <inheritdoc/>
-        //public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
-        //{
-        //    if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
-        //        return base.BindGetIndex(binder, indexes);
-        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-        //    var key = Expression.Convert(indexes[0].Expression, typeof(string));
-        //    var call = Expression.Call(GetLimitedSelf(), GetMethod, key);
-        //    return new DynamicMetaObject(call, restrictions);
-        //}
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
+        {
+            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+                return base.BindGetIndex(binder, indexes);
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var key = Expression.Convert(indexes[0].Expression, typeof(string));
+            var call = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { key });
+            return new DynamicMetaObject(call, restrictions);
+        }
 
-        ///// <inheritdoc/>
-        //public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
-        //{
-        //    if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
-        //        return base.BindSetIndex(binder, indexes, value);
-        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-        //    var key = Expression.Convert(indexes[0].Expression, typeof(string));
-        //    var param = Expression.Variable(typeof(object));
-        //    var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
-        //    var call = Expression.Call(GetLimitedSelf(), SetMethod, key, param);
-        //    // DLR requires the expression to return object, not void
-        //    var block = Expression.Block(new[] { param }, assign, call, param);
-        //    return new DynamicMetaObject(block, restrictions);
-        //}
+        /// <inheritdoc/>
+        public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
+        {
+            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+                return base.BindSetIndex(binder, indexes, value);
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+            var key = Expression.Convert(indexes[0].Expression, typeof(string));
+            var indexAccess = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { key });
+            var assign = Expression.Assign(indexAccess, Expression.Convert(value.Expression, typeof(object)));
+            return new DynamicMetaObject(assign, restrictions);
+        }
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
+++ b/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
@@ -1,7 +1,5 @@
 using System.Dynamic;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace LuYao.Data;
 
@@ -12,77 +10,77 @@ partial struct RecordRow
     /// </summary>
     private sealed class RecordRowMetaObject : DynamicMetaObject
     {
-        // dynamic 读取走 GetValueOrDefault：列不存在返回 null。
-        private static readonly MethodInfo GetMethod =
-            typeof(RecordRow).GetMethod(
-                nameof(RecordRow.GetValueOrDefault),
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
+        //// dynamic 读取走 GetValueOrDefault：列不存在返回 null。
+        //private static readonly MethodInfo GetMethod =
+        //    typeof(RecordRow).GetMethod(
+        //        nameof(RecordRow.GetValueOrDefault),
+        //        BindingFlags.Instance | BindingFlags.NonPublic)!;
 
-        // dynamic 写入走 SetAndEnsureColumn：列不存在时按运行时类型自动建列；null 值且列不存在则跳过。
-        private static readonly MethodInfo SetMethod =
-            typeof(RecordRow).GetMethod(
-                nameof(RecordRow.SetAndEnsureColumn),
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
+        //// dynamic 写入走 SetAndEnsureColumn：列不存在时按运行时类型自动建列；null 值且列不存在则跳过。
+        //private static readonly MethodInfo SetMethod =
+        //    typeof(RecordRow).GetMethod(
+        //        nameof(RecordRow.SetAndEnsureColumn),
+        //        BindingFlags.Instance | BindingFlags.NonPublic)!;
 
         public RecordRowMetaObject(Expression expression, RecordRow value)
             : base(expression, BindingRestrictions.Empty, value)
         {
         }
 
-        private Expression GetLimitedSelf()
-            => Expression.Convert(Expression, typeof(RecordRow));
+        //private Expression GetLimitedSelf()
+        //    => Expression.Convert(Expression, typeof(RecordRow));
 
-        /// <inheritdoc/>
-        public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
-            => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
+        ///// <inheritdoc/>
+        //public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
+        //    => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
 
-        /// <inheritdoc/>
-        public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
-        {
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var call = Expression.Call(
-                GetLimitedSelf(),
-                GetMethod,
-                Expression.Constant(binder.Name));
-            return new DynamicMetaObject(call, restrictions);
-        }
+        ///// <inheritdoc/>
+        //public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
+        //{
+        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+        //    var call = Expression.Call(
+        //        GetLimitedSelf(),
+        //        GetMethod,
+        //        Expression.Constant(binder.Name));
+        //    return new DynamicMetaObject(call, restrictions);
+        //}
 
-        /// <inheritdoc/>
-        public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
-        {
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var param = Expression.Variable(typeof(object));
-            var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
-            var call = Expression.Call(GetLimitedSelf(), SetMethod, Expression.Constant(binder.Name), param);
-            // DLR requires the expression to return object, not void
-            var block = Expression.Block(new[] { param }, assign, call, param);
-            return new DynamicMetaObject(block, restrictions);
-        }
+        ///// <inheritdoc/>
+        //public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
+        //{
+        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+        //    var param = Expression.Variable(typeof(object));
+        //    var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
+        //    var call = Expression.Call(GetLimitedSelf(), SetMethod, Expression.Constant(binder.Name), param);
+        //    // DLR requires the expression to return object, not void
+        //    var block = Expression.Block(new[] { param }, assign, call, param);
+        //    return new DynamicMetaObject(block, restrictions);
+        //}
 
-        /// <inheritdoc/>
-        public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
-        {
-            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
-                return base.BindGetIndex(binder, indexes);
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var key = Expression.Convert(indexes[0].Expression, typeof(string));
-            var call = Expression.Call(GetLimitedSelf(), GetMethod, key);
-            return new DynamicMetaObject(call, restrictions);
-        }
+        ///// <inheritdoc/>
+        //public override DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
+        //{
+        //    if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+        //        return base.BindGetIndex(binder, indexes);
+        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+        //    var key = Expression.Convert(indexes[0].Expression, typeof(string));
+        //    var call = Expression.Call(GetLimitedSelf(), GetMethod, key);
+        //    return new DynamicMetaObject(call, restrictions);
+        //}
 
-        /// <inheritdoc/>
-        public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
-        {
-            if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
-                return base.BindSetIndex(binder, indexes, value);
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
-            var key = Expression.Convert(indexes[0].Expression, typeof(string));
-            var param = Expression.Variable(typeof(object));
-            var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
-            var call = Expression.Call(GetLimitedSelf(), SetMethod, key, param);
-            // DLR requires the expression to return object, not void
-            var block = Expression.Block(new[] { param }, assign, call, param);
-            return new DynamicMetaObject(block, restrictions);
-        }
+        ///// <inheritdoc/>
+        //public override DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
+        //{
+        //    if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
+        //        return base.BindSetIndex(binder, indexes, value);
+        //    var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
+        //    var key = Expression.Convert(indexes[0].Expression, typeof(string));
+        //    var param = Expression.Variable(typeof(object));
+        //    var assign = Expression.Assign(param, Expression.Convert(value.Expression, typeof(object)));
+        //    var call = Expression.Call(GetLimitedSelf(), SetMethod, key, param);
+        //    // DLR requires the expression to return object, not void
+        //    var block = Expression.Block(new[] { param }, assign, call, param);
+        //    return new DynamicMetaObject(block, restrictions);
+        //}
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.Mapping.cs
+++ b/src/LuYao.Common/Data/RecordRow.Mapping.cs
@@ -9,7 +9,7 @@ partial struct RecordRow
     /// </summary>
     /// <typeparam name="T">目标对象类型。</typeparam>
     /// <param name="data">要被填充的对象实例。</param>
-    public void Fill<T>(T data) where T : class
+    public void CopyTo<T>(T data) where T : class
     {
         XCopy<T>.CopyFrom(data, this);
     }
@@ -22,7 +22,7 @@ partial struct RecordRow
     public T To<T>() where T : class, new()
     {
         var ret = new T();
-        this.Fill(ret);
+        this.CopyTo(ret);
         return ret;
     }
 

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -39,7 +39,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// <summary>
     /// 返回 <see cref="DynamicMetaObject"/>，支持动态成员访问。
     /// </summary>
-    public DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
+    public readonly DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
         => new RecordRowMetaObject(parameter, this);
 
     /// <summary>
@@ -53,7 +53,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// <summary>
     /// 返回包含行号与当前行列值的字符串表示。
     /// </summary>
-    public override string ToString()
+    public readonly override string ToString()
     {
         var sb = new StringBuilder();
         sb.Append("{ Row = ").Append(this.Row).Append(", Data = { ");
@@ -73,7 +73,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// 将当前行的所有列值转换为字典。
     /// </summary>
     /// <returns>键为列名、值为当前行对应列值的字典。</returns>
-    public Dictionary<string, object?> ToDictionary()
+    public readonly Dictionary<string, object?> ToDictionary()
     {
         var ret = new Dictionary<string, object?>(this.Record.Columns.Count, StringComparer.Ordinal);
         foreach (var col in this.Record.Columns)
@@ -88,7 +88,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// </summary>
     /// <param name="name">要访问或设置的列名。若为 null、空或仅空白，将返回默认值；查找列时使用 Record.Columns.Find(name)。</param>
     /// <returns>若指定列存在，返回该列在当前行的值；否则返回 null（或默认）。在设置器中：若列不存在且 value 非 null，将根据 value 的运行时类型创建新列并赋值。</returns>
-    public object? this[String name]
+    public readonly object? this[String name]
     {
         get
         {
@@ -109,5 +109,19 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
             }
             col.Set(this, value);
         }
+    }
+
+    /// <summary>
+    /// 将指定列名的当前行值转换为目标类型并返回。
+    /// </summary>
+    /// <typeparam name="T">目标类型。</typeparam>
+    /// <param name="name">要转换的列名。若为 null 或空白，返回默认值。</param>
+    /// <returns>转换后的值；若列不存在或无法转换则返回默认值。</returns>
+    public readonly T? To<T>(String name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return default;
+        var col = this.Record.Columns.Find(name);
+        if (col == null) return default;
+        return col.To<T>(this);
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Text;
-using LuYao.Data.Meta;
 
 namespace LuYao.Data;
 
@@ -37,6 +36,11 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// <value>从零开始的行索引。</value>
     public int Row { get; }
 
+    /// <summary>
+    /// 返回 <see cref="DynamicMetaObject"/>，支持动态成员访问。
+    /// </summary>
+    public DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
+        => new RecordRowMetaObject(parameter, this);
 
     /// <summary>
     /// 定义从 <see cref="RecordRow"/> 到 <see cref="int"/> 的隐式转换。
@@ -45,40 +49,6 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
     /// <param name="rowRef">要转换的 <see cref="RecordRow"/> 实例。</param>
     /// <returns>该行在数据集合中的索引位置。</returns>
     public static implicit operator int(RecordRow rowRef) => rowRef.Row;
-
-    #region 数据读取
-
-    /// <summary>
-    /// 根据列名获取当前行指定列的泛型类型值。列不存在时返回 <typeparamref name="T"/> 的默认值。
-    /// </summary>
-    /// <typeparam name="T">要获取的值的类型。</typeparam>
-    /// <param name="name">列的名称。</param>
-    public T? Field<T>(string name)
-    {
-        var col = this.Record.Columns.Find(name);
-        return col != null ? col.Get<T>(this.Row) : default;
-    }
-
-    /// <summary>
-    /// 根据列名获取当前行指定列的值。
-    /// </summary>
-    /// <param name="name">列的名称。</param>
-    /// <returns>列存在时返回当前行对应值；列不存在时返回 <see langword="null"/>。</returns>
-    public object? Field(string name) => this.GetValueOrDefault(name);
-
-    /// <summary>
-    /// 将当前行的所有列值转换为字典。
-    /// </summary>
-    /// <returns>键为列名、值为当前行对应列值的字典。</returns>
-    public Dictionary<string, object?> ToDictionary()
-    {
-        var ret = new Dictionary<string, object?>(this.Record.Columns.Count, StringComparer.Ordinal);
-        foreach (var col in this.Record.Columns)
-        {
-            ret[col.Name] = col.GetValue(this);
-        }
-        return ret;
-    }
 
     /// <summary>
     /// 返回包含行号与当前行列值的字符串表示。
@@ -99,63 +69,45 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         return sb.ToString();
     }
 
-    #endregion
-
     /// <summary>
-    /// 按列名读取值；列不存在时返回 <see langword="null"/>。
-    /// 供 Mapping、dynamic 读取等内部路径使用。
+    /// 将当前行的所有列值转换为字典。
     /// </summary>
-    internal object? GetValueOrDefault(string name)
+    /// <returns>键为列名、值为当前行对应列值的字典。</returns>
+    public Dictionary<string, object?> ToDictionary()
     {
-        var col = this.Record.Columns.Find(name);
-        return col?.GetValue(this);
-    }
-
-    /// <summary>
-    /// 按列名写入值；列不存在时静默跳过。
-    /// 供 Mapping 写入路径使用，<b>不会自动建列</b>。
-    /// </summary>
-    internal void TrySetValue(string name, object? value)
-    {
-        var col = this.Record.Columns.Find(name);
-        if (col != null) col.SetValue(this.Row, value);
-    }
-
-    /// <summary>
-    /// 按列名写入值；列不存在时按 <paramref name="value"/> 的运行时类型自动建列。
-    /// 当 <paramref name="value"/> 为 <see langword="null"/> 且列不存在时跳过该次写入（无法推断列类型）。
-    /// 供 dynamic 写入路径（成员/索引器赋值）使用。
-    /// </summary>
-    internal void SetAndEnsureColumn(string name, object? value)
-    {
-        var existing = this.Record.Columns.Find(name);
-        if (existing != null)
+        var ret = new Dictionary<string, object?>(this.Record.Columns.Count, StringComparer.Ordinal);
+        foreach (var col in this.Record.Columns)
         {
-            existing.SetValue(this.Row, value);
-            return;
+            ret[col.Name] = col.GetValue(this);
         }
-        if (value is null) return;
-        var col = this.Record.Columns.Add(name, value.GetType());
-        col.SetValue(this.Row, value);
+        return ret;
     }
 
     /// <summary>
-    /// 返回 <see cref="DynamicMetaObject"/>，支持动态成员访问。
+    /// 使用列名访问或设置当前行的列值。
     /// </summary>
-    public DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
-        => new RecordRowMetaObject(parameter, this);
-
-    /// <summary>
-    /// 根据列名设置当前行指定列的泛型类型值。
-    /// 列不存在时按 <typeparamref name="T"/> 自动建列；列已存在但类型不匹配时抛 <see cref="InvalidOperationException"/>。
-    /// </summary>
-    /// <typeparam name="T">要设置的值的类型。</typeparam>
-    /// <param name="name">列的名称。</param>
-    /// <param name="value">要设置的值。</param>
-    /// <exception cref="InvalidOperationException">当同名列已存在且类型与 <typeparamref name="T"/> 不一致时抛出。</exception>
-    public void Set<T>(string name, T value)
+    /// <param name="name">要访问或设置的列名。若为 null、空或仅空白，将返回默认值；查找列时使用 Record.Columns.Find(name)。</param>
+    /// <returns>若指定列存在，返回该列在当前行的值；否则返回 null（或默认）。在设置器中：若列不存在且 value 非 null，将根据 value 的运行时类型创建新列并赋值。</returns>
+    public object? this[String name]
     {
-        var col = this.Record.Columns.Add<T>(name);
-        col.Set(this.Row, value);
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                var col = this.Record.Columns.Find(name);
+                if (col != null) return col.GetValue(this);
+            }
+            return default;
+        }
+        set
+        {
+            var col = this.Record.Columns.Find(name);
+            if (col == null)
+            {
+                if (value == null) return;
+                col = this.Record.Columns.Add(name, value.GetType());
+            }
+            col.SetValue(this, value);
+        }
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -61,7 +61,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         foreach (var col in this.Record.Columns)
         {
             if (!first) sb.Append(", ");
-            var value = col.GetValue(this);
+            var value = col.Get(this);
             sb.Append(col.Name).Append(" = ").Append(value?.ToString() ?? string.Empty);
             first = false;
         }
@@ -78,7 +78,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         var ret = new Dictionary<string, object?>(this.Record.Columns.Count, StringComparer.Ordinal);
         foreach (var col in this.Record.Columns)
         {
-            ret[col.Name] = col.GetValue(this);
+            ret[col.Name] = col.Get(this);
         }
         return ret;
     }
@@ -95,7 +95,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
             if (!string.IsNullOrWhiteSpace(name))
             {
                 var col = this.Record.Columns.Find(name);
-                if (col != null) return col.GetValue(this);
+                if (col != null) return col.Get(this);
             }
             return default;
         }
@@ -107,7 +107,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
                 if (value == null) return;
                 col = this.Record.Columns.Add(name, value.GetType());
             }
-            col.SetValue(this, value);
+            col.Set(this, value);
         }
     }
 }

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -101,6 +101,7 @@ public partial struct RecordRow : IDynamicMetaObjectProvider
         }
         set
         {
+            if (string.IsNullOrWhiteSpace(name)) return;
             var col = this.Record.Columns.Find(name);
             if (col == null)
             {

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -27,20 +27,20 @@ public class GenericMethodTests
         var rowIndex = 0;
 
         // Act & Assert - verify all supported types
-        intColumn.SetField(rowIndex, 42);
+        intColumn.SetValue(rowIndex, 42);
         Assert.AreEqual(42, intColumn.To<Int32>(rowIndex));
 
-        stringColumn.SetField(rowIndex, "Hello World");
+        stringColumn.SetValue(rowIndex, "Hello World");
         Assert.AreEqual("Hello World", stringColumn.To<String>(rowIndex));
 
-        boolColumn.SetField(rowIndex, true);
+        boolColumn.SetValue(rowIndex, true);
         Assert.AreEqual(true, boolColumn.To<Boolean>(rowIndex));
 
         var testDate = new DateTime(2023, 7, 28, 10, 30, 0);
-        dateTimeColumn.SetField(rowIndex, testDate);
+        dateTimeColumn.SetValue(rowIndex, testDate);
         Assert.AreEqual(testDate, dateTimeColumn.To<DateTime>(rowIndex));
 
-        doubleColumn.SetField(rowIndex, 3.14159);
+        doubleColumn.SetValue(rowIndex, 3.14159);
         Assert.AreEqual(3.14159, doubleColumn.To<Double>(rowIndex), 0.00001);
     }
 
@@ -138,11 +138,11 @@ public class GenericMethodTests
         var row = record.AddRow();
 
         // Act & Assert - empty string
-        stringColumn.SetField(0, "");
+        stringColumn.SetValue(0, "");
         Assert.AreEqual("", stringColumn.To<String>(0));
 
         // Verify null string
-        stringColumn.SetField(0, null);
+        stringColumn.SetValue(0, null);
         string result = stringColumn.To<String>(0);
         Assert.IsNull(result); // should return null
     }
@@ -160,10 +160,10 @@ public class GenericMethodTests
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.SetField(1, 42)); // invalid index
+            intColumn.SetValue(1, 42)); // invalid index
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.SetField(-1, 42)); // negative index
+            intColumn.SetValue(-1, 42)); // negative index
     }
 
     /// <summary>
@@ -183,7 +183,7 @@ public class GenericMethodTests
         }
 
         // Warm up
-        intColumn.SetField(0, 0);
+        intColumn.SetValue(0, 0);
         intColumn.Set(1, (object)1);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -192,7 +192,7 @@ public class GenericMethodTests
         sw.Restart();
         for (int i = 0; i < 1000; i++)
         {
-            intColumn.SetField(i, i);
+            intColumn.SetValue(i, i);
         }
         var genericTime = sw.ElapsedTicks;
 
@@ -240,23 +240,23 @@ public class GenericMethodTests
         // Act & Assert - verify conversions across types
 
         // int -> other types
-        intColumn.SetField(0, 42);
+        intColumn.SetValue(0, 42);
         Assert.AreEqual(42.0, intColumn.To<double>(0), 0.001);
         Assert.AreEqual("42", intColumn.To<string>(0));
         Assert.AreEqual(true, intColumn.To<bool>(0)); // non-zero means true
 
         // double -> other types
-        doubleColumn.SetField(0, 3.14);
+        doubleColumn.SetValue(0, 3.14);
         Assert.AreEqual(3, doubleColumn.To<int>(0)); // truncated
         Assert.AreEqual("3.14", doubleColumn.To<string>(0));
 
         // string -> other types
-        stringColumn.SetField(0, "123");
+        stringColumn.SetValue(0, "123");
         Assert.AreEqual(123, stringColumn.To<int>(0));
         Assert.AreEqual(123.0, stringColumn.To<double>(0), 0.001);
 
         // bool -> other types
-        boolColumn.SetField(0, true);
+        boolColumn.SetValue(0, true);
         Assert.AreEqual(1, boolColumn.To<int>(0));
         Assert.AreEqual("True", boolColumn.To<string>(0));
     }

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -47,62 +47,62 @@ public class GenericMethodTests
     /// <summary>
     /// Verifies generic Set through RecordRow.
     /// </summary>
-    [TestMethod]
-    public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
-    {
-        // Arrange
-        var record = new Record("TestTable", 1);
-        var intColumn = record.Columns.Add<Int32>("IntColumn");
-        var stringColumn = record.Columns.Add<String>("StringColumn");
-        var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
-        var row = record.AddRow();
+    //[TestMethod]
+    //public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
+    //{
+    //    // Arrange
+    //    var record = new Record("TestTable", 1);
+    //    var intColumn = record.Columns.Add<Int32>("IntColumn");
+    //    var stringColumn = record.Columns.Add<String>("StringColumn");
+    //    var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
+    //    var row = record.AddRow();
 
-        // Act
-        intColumn.Set(row.Row, 123);
-        stringColumn.Set(row.Row, "Test String");
-        boolColumn.Set(row.Row, false);
+    //    // Act
+    //    intColumn.Set(row.Row, 123);
+    //    stringColumn.Set(row.Row, "Test String");
+    //    boolColumn.Set(row.Row, false);
 
-        // Assert
-        Assert.AreEqual(123, row.Field<Int32>("IntColumn"));
-        Assert.AreEqual("Test String", row.Field<String>("StringColumn"));
-        Assert.AreEqual(false, row.Field<Boolean>("BoolColumn"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(123, row.Field<Int32>("IntColumn"));
+    //    Assert.AreEqual("Test String", row.Field<String>("StringColumn"));
+    //    Assert.AreEqual(false, row.Field<Boolean>("BoolColumn"));
+    //}
 
 
     /// <summary>
     /// Verifies generic type conversion helpers.
     /// </summary>
-    [TestMethod]
-    public void GenericTo_ShouldReturnCorrectTypes()
-    {
-        // Arrange
-        var record = new Record("TestTable", 1);
-        var intColumn = record.Columns.Add<Int32>("IntColumn");
-        var stringColumn = record.Columns.Add<String>("StringColumn");
-        var row = record.AddRow();
+    //[TestMethod]
+    //public void GenericTo_ShouldReturnCorrectTypes()
+    //{
+    //    // Arrange
+    //    var record = new Record("TestTable", 1);
+    //    var intColumn = record.Columns.Add<Int32>("IntColumn");
+    //    var stringColumn = record.Columns.Add<String>("StringColumn");
+    //    var row = record.AddRow();
 
-        // Seed test data
-        intColumn.Set(0, 42);
-        stringColumn.Set(0, "Hello");
+    //    // Seed test data
+    //    intColumn.Set(0, 42);
+    //    stringColumn.Set(0, "Hello");
 
-        // Act & Assert
-        int intValue = intColumn.Get<int>(0);
-        Assert.AreEqual(42, intValue);
+    //    // Act & Assert
+    //    int intValue = intColumn.Get<int>(0);
+    //    Assert.AreEqual(42, intValue);
 
-        string stringValue = stringColumn.Get<string>(0);
-        Assert.AreEqual("Hello", stringValue);
+    //    string stringValue = stringColumn.Get<string>(0);
+    //    Assert.AreEqual("Hello", stringValue);
 
-        // Verify cross-type conversion
-        string intAsString = intColumn.Get<string>(0);
-        Assert.AreEqual("42", intAsString);
+    //    // Verify cross-type conversion
+    //    string intAsString = intColumn.Get<string>(0);
+    //    Assert.AreEqual("42", intAsString);
 
-        // Verify access through RecordRow
-        int intFromRow = row.Field<int>("IntColumn");
-        Assert.AreEqual(42, intFromRow);
+    //    // Verify access through RecordRow
+    //    int intFromRow = row.Field<int>("IntColumn");
+    //    Assert.AreEqual(42, intFromRow);
 
-        string stringFromRow = row.Field<string>("StringColumn");
-        Assert.AreEqual("Hello", stringFromRow);
-    }
+    //    string stringFromRow = row.Field<string>("StringColumn");
+    //    Assert.AreEqual("Hello", stringFromRow);
+    //}
 
     /// <summary>
     /// Verifies nullable type support.

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -47,62 +47,62 @@ public class GenericMethodTests
     /// <summary>
     /// Verifies generic Set through RecordRow.
     /// </summary>
-    //[TestMethod]
-    //public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
-    //{
-    //    // Arrange
-    //    var record = new Record("TestTable", 1);
-    //    var intColumn = record.Columns.Add<Int32>("IntColumn");
-    //    var stringColumn = record.Columns.Add<String>("StringColumn");
-    //    var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
-    //    var row = record.AddRow();
+    [TestMethod]
+    public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
+    {
+        // Arrange
+        var record = new Record("TestTable", 1);
+        var intColumn = record.Columns.Add<Int32>("IntColumn");
+        var stringColumn = record.Columns.Add<String>("StringColumn");
+        var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
+        var row = record.AddRow();
 
-    //    // Act
-    //    intColumn.Set(row.Row, 123);
-    //    stringColumn.Set(row.Row, "Test String");
-    //    boolColumn.Set(row.Row, false);
+        // Act
+        intColumn.Set(row.Row, 123);
+        stringColumn.Set(row.Row, "Test String");
+        boolColumn.Set(row.Row, false);
 
-    //    // Assert
-    //    Assert.AreEqual(123, row.Field<Int32>("IntColumn"));
-    //    Assert.AreEqual("Test String", row.Field<String>("StringColumn"));
-    //    Assert.AreEqual(false, row.Field<Boolean>("BoolColumn"));
-    //}
+        // Assert
+        Assert.AreEqual(123, row.To<Int32>("IntColumn"));
+        Assert.AreEqual("Test String", row.To<String>("StringColumn"));
+        Assert.AreEqual(false, row.To<Boolean>("BoolColumn"));
+    }
 
 
     /// <summary>
     /// Verifies generic type conversion helpers.
     /// </summary>
-    //[TestMethod]
-    //public void GenericTo_ShouldReturnCorrectTypes()
-    //{
-    //    // Arrange
-    //    var record = new Record("TestTable", 1);
-    //    var intColumn = record.Columns.Add<Int32>("IntColumn");
-    //    var stringColumn = record.Columns.Add<String>("StringColumn");
-    //    var row = record.AddRow();
+    [TestMethod]
+    public void GenericTo_ShouldReturnCorrectTypes()
+    {
+        // Arrange
+        var record = new Record("TestTable", 1);
+        var intColumn = record.Columns.Add<Int32>("IntColumn");
+        var stringColumn = record.Columns.Add<String>("StringColumn");
+        var row = record.AddRow();
 
-    //    // Seed test data
-    //    intColumn.Set(0, 42);
-    //    stringColumn.Set(0, "Hello");
+        // Seed test data
+        intColumn.Set(0, 42);
+        stringColumn.Set(0, "Hello");
 
-    //    // Act & Assert
-    //    int intValue = intColumn.Get<int>(0);
-    //    Assert.AreEqual(42, intValue);
+        // Act & Assert
+        int intValue = intColumn.To<int>(0);
+        Assert.AreEqual(42, intValue);
 
-    //    string stringValue = stringColumn.Get<string>(0);
-    //    Assert.AreEqual("Hello", stringValue);
+        string stringValue = stringColumn.To<string>(0);
+        Assert.AreEqual("Hello", stringValue);
 
-    //    // Verify cross-type conversion
-    //    string intAsString = intColumn.Get<string>(0);
-    //    Assert.AreEqual("42", intAsString);
+        // Verify cross-type conversion
+        string intAsString = intColumn.To<string>(0);
+        Assert.AreEqual("42", intAsString);
 
-    //    // Verify access through RecordRow
-    //    int intFromRow = row.Field<int>("IntColumn");
-    //    Assert.AreEqual(42, intFromRow);
+        // Verify access through RecordRow
+        int intFromRow = row.To<int>("IntColumn");
+        Assert.AreEqual(42, intFromRow);
 
-    //    string stringFromRow = row.Field<string>("StringColumn");
-    //    Assert.AreEqual("Hello", stringFromRow);
-    //}
+        string stringFromRow = row.To<string>("StringColumn");
+        Assert.AreEqual("Hello", stringFromRow);
+    }
 
     /// <summary>
     /// Verifies nullable type support.

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -27,21 +27,21 @@ public class GenericMethodTests
         var rowIndex = 0;
 
         // Act & Assert - verify all supported types
-        intColumn.Set(rowIndex, 42);
-        Assert.AreEqual(42, intColumn.Get<Int32>(rowIndex));
+        intColumn.SetField(rowIndex, 42);
+        Assert.AreEqual(42, intColumn.To<Int32>(rowIndex));
 
-        stringColumn.Set(rowIndex, "Hello World");
-        Assert.AreEqual("Hello World", stringColumn.Get<String>(rowIndex));
+        stringColumn.SetField(rowIndex, "Hello World");
+        Assert.AreEqual("Hello World", stringColumn.To<String>(rowIndex));
 
-        boolColumn.Set(rowIndex, true);
-        Assert.AreEqual(true, boolColumn.Get<Boolean>(rowIndex));
+        boolColumn.SetField(rowIndex, true);
+        Assert.AreEqual(true, boolColumn.To<Boolean>(rowIndex));
 
         var testDate = new DateTime(2023, 7, 28, 10, 30, 0);
-        dateTimeColumn.Set(rowIndex, testDate);
-        Assert.AreEqual(testDate, dateTimeColumn.Get<DateTime>(rowIndex));
+        dateTimeColumn.SetField(rowIndex, testDate);
+        Assert.AreEqual(testDate, dateTimeColumn.To<DateTime>(rowIndex));
 
-        doubleColumn.Set(rowIndex, 3.14159);
-        Assert.AreEqual(3.14159, doubleColumn.Get<Double>(rowIndex), 0.00001);
+        doubleColumn.SetField(rowIndex, 3.14159);
+        Assert.AreEqual(3.14159, doubleColumn.To<Double>(rowIndex), 0.00001);
     }
 
     /// <summary>
@@ -117,12 +117,12 @@ public class GenericMethodTests
 
         // Act & Assert - nullable value
         int? nullableValue = 42;
-        intColumn.SetValue(0, nullableValue);
-        Assert.AreEqual(42, intColumn.Get<Int32>(0));
+        intColumn.Set(0, nullableValue);
+        Assert.AreEqual(42, intColumn.To<Int32>(0));
 
         // Verify null assignment
-        intColumn.SetValue(0, null);
-        int defaultValue = intColumn.Get<Int32>(0);
+        intColumn.Set(0, null);
+        int defaultValue = intColumn.To<Int32>(0);
         Assert.AreEqual(0, defaultValue); // default value
     }
 
@@ -138,12 +138,12 @@ public class GenericMethodTests
         var row = record.AddRow();
 
         // Act & Assert - empty string
-        stringColumn.Set(0, "");
-        Assert.AreEqual("", stringColumn.Get<String>(0));
+        stringColumn.SetField(0, "");
+        Assert.AreEqual("", stringColumn.To<String>(0));
 
         // Verify null string
-        stringColumn.Set(0, null);
-        string result = stringColumn.Get<String>(0);
+        stringColumn.SetField(0, null);
+        string result = stringColumn.To<String>(0);
         Assert.IsNull(result); // should return null
     }
 
@@ -160,10 +160,10 @@ public class GenericMethodTests
 
         // Act & Assert
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(1, 42)); // invalid index
+            intColumn.SetField(1, 42)); // invalid index
 
         Assert.Throws<ArgumentOutOfRangeException>(() =>
-            intColumn.Set(-1, 42)); // negative index
+            intColumn.SetField(-1, 42)); // negative index
     }
 
     /// <summary>
@@ -183,8 +183,8 @@ public class GenericMethodTests
         }
 
         // Warm up
-        intColumn.Set(0, 0);
-        intColumn.SetValue(1, 1);
+        intColumn.SetField(0, 0);
+        intColumn.Set(1, (object)1);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
 
@@ -192,7 +192,7 @@ public class GenericMethodTests
         sw.Restart();
         for (int i = 0; i < 1000; i++)
         {
-            intColumn.Set(i, i);
+            intColumn.SetField(i, i);
         }
         var genericTime = sw.ElapsedTicks;
 
@@ -200,7 +200,7 @@ public class GenericMethodTests
         sw.Restart();
         for (int i = 0; i < 1000; i++)
         {
-            intColumn.SetValue(i, i);
+            intColumn.Set(i, (object)i);
         }
         var objectTime = sw.ElapsedTicks;
 
@@ -209,7 +209,7 @@ public class GenericMethodTests
         // Verify results
         for (int i = 0; i < 1000; i++)
         {
-            Assert.AreEqual(i, intColumn.Get<Int32>(i));
+            Assert.AreEqual(i, intColumn.To<Int32>(i));
         }
 
         // Output comparison details
@@ -240,24 +240,24 @@ public class GenericMethodTests
         // Act & Assert - verify conversions across types
 
         // int -> other types
-        intColumn.Set(0, 42);
-        Assert.AreEqual(42.0, intColumn.Get<double>(0), 0.001);
-        Assert.AreEqual("42", intColumn.Get<string>(0));
-        Assert.AreEqual(true, intColumn.Get<bool>(0)); // non-zero means true
+        intColumn.SetField(0, 42);
+        Assert.AreEqual(42.0, intColumn.To<double>(0), 0.001);
+        Assert.AreEqual("42", intColumn.To<string>(0));
+        Assert.AreEqual(true, intColumn.To<bool>(0)); // non-zero means true
 
         // double -> other types
-        doubleColumn.Set(0, 3.14);
-        Assert.AreEqual(3, doubleColumn.Get<int>(0)); // truncated
-        Assert.AreEqual("3.14", doubleColumn.Get<string>(0));
+        doubleColumn.SetField(0, 3.14);
+        Assert.AreEqual(3, doubleColumn.To<int>(0)); // truncated
+        Assert.AreEqual("3.14", doubleColumn.To<string>(0));
 
         // string -> other types
-        stringColumn.Set(0, "123");
-        Assert.AreEqual(123, stringColumn.Get<int>(0));
-        Assert.AreEqual(123.0, stringColumn.Get<double>(0), 0.001);
+        stringColumn.SetField(0, "123");
+        Assert.AreEqual(123, stringColumn.To<int>(0));
+        Assert.AreEqual(123.0, stringColumn.To<double>(0), 0.001);
 
         // bool -> other types
-        boolColumn.Set(0, true);
-        Assert.AreEqual(1, boolColumn.Get<int>(0));
-        Assert.AreEqual("True", boolColumn.Get<string>(0));
+        boolColumn.SetField(0, true);
+        Assert.AreEqual(1, boolColumn.To<int>(0));
+        Assert.AreEqual("True", boolColumn.To<string>(0));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -18,14 +18,14 @@ public class RecordBoundaryTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            col.Set(row.Row, i);
+            col.SetField(row.Row, i);
         }
 
         Assert.AreEqual(rowCount, record.Count);
         // Verify data integrity at boundaries
-        Assert.AreEqual(0, col.Get<int>(0));
-        Assert.AreEqual(rowCount - 1, col.Get<int>(rowCount - 1));
-        Assert.AreEqual(5000, col.Get<int>(5000));
+        Assert.AreEqual(0, col.To<int>(0));
+        Assert.AreEqual(rowCount - 1, col.To<int>(rowCount - 1));
+        Assert.AreEqual(5000, col.To<int>(5000));
     }
 
     #endregion
@@ -62,8 +62,8 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(row.Row, i);
-            nameCol.Set(row.Row, $"Item{i}");
+            idCol.SetField(row.Row, i);
+            nameCol.SetField(row.Row, $"Item{i}");
         }
 
         // Delete row 1
@@ -72,12 +72,12 @@ public class RecordBoundaryTests
 
         // Add a new row
         var newRow = record.AddRow();
-        idCol.Set(newRow.Row, 99);
-        nameCol.Set(newRow.Row, "New");
+        idCol.SetField(newRow.Row, 99);
+        nameCol.SetField(newRow.Row, "New");
 
         Assert.AreEqual(3, record.Count);
-        Assert.AreEqual(99, idCol.Get<int>(2));
-        Assert.AreEqual("New", nameCol.Get<string>(2));
+        Assert.AreEqual(99, idCol.To<int>(2));
+        Assert.AreEqual("New", nameCol.To<string>(2));
     }
 
     #endregion
@@ -133,7 +133,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(row.Row, i);
+            idCol.SetField(row.Row, i);
         }
 
         int deleted = record.DeleteRows(new[] { 1, 1, 1 });

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -18,7 +18,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            col.SetField(row.Row, i);
+            col.SetValue(row.Row, i);
         }
 
         Assert.AreEqual(rowCount, record.Count);
@@ -62,8 +62,8 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.SetField(row.Row, i);
-            nameCol.SetField(row.Row, $"Item{i}");
+            idCol.SetValue(row.Row, i);
+            nameCol.SetValue(row.Row, $"Item{i}");
         }
 
         // Delete row 1
@@ -72,8 +72,8 @@ public class RecordBoundaryTests
 
         // Add a new row
         var newRow = record.AddRow();
-        idCol.SetField(newRow.Row, 99);
-        nameCol.SetField(newRow.Row, "New");
+        idCol.SetValue(newRow.Row, 99);
+        nameCol.SetValue(newRow.Row, "New");
 
         Assert.AreEqual(3, record.Count);
         Assert.AreEqual(99, idCol.To<int>(2));
@@ -133,7 +133,7 @@ public class RecordBoundaryTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.SetField(row.Row, i);
+            idCol.SetValue(row.Row, i);
         }
 
         int deleted = record.DeleteRows(new[] { 1, 1, 1 });

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -32,25 +32,25 @@ public class RecordBoundaryTests
 
     #region Delete Consistency
 
-    [TestMethod]
-    public void WhenDeleteThenEnumerationIsConsistent()
-    {
-        var record = new Record("Test", 5);
-        var idCol = record.Columns.Add<int>("Id");
+    //[TestMethod]
+    //public void WhenDeleteThenEnumerationIsConsistent()
+    //{
+    //    var record = new Record("Test", 5);
+    //    var idCol = record.Columns.Add<int>("Id");
 
-        for (int i = 0; i < 5; i++)
-        {
-            var row = record.AddRow();
-            idCol.Set(row.Row, i * 10);
-        }
+    //    for (int i = 0; i < 5; i++)
+    //    {
+    //        var row = record.AddRow();
+    //        idCol.Set(row.Row, i * 10);
+    //    }
 
-        // Delete middle row (index 2, value 20)
-        record.Delete(2);
+    //    // Delete middle row (index 2, value 20)
+    //    record.Delete(2);
 
-        Assert.AreEqual(4, record.Count);
-        var values = record.Select(r => r.Field<int>("Id")).ToArray();
-        CollectionAssert.AreEqual(new[] { 0, 10, 30, 40 }, values);
-    }
+    //    Assert.AreEqual(4, record.Count);
+    //    var values = record.Select(r => r.Field<int>("Id")).ToArray();
+    //    CollectionAssert.AreEqual(new[] { 0, 10, 30, 40 }, values);
+    //}
 
     [TestMethod]
     public void WhenDeleteThenAddRowThenDataIsCorrect()
@@ -84,45 +84,45 @@ public class RecordBoundaryTests
 
     #region Batch Delete
 
-    [TestMethod]
-    public void WhenDeleteWhereThenMatchingRowsRemoved()
-    {
-        var record = new Record("Test", 5);
-        var idCol = record.Columns.Add<int>("Id");
+    //[TestMethod]
+    //public void WhenDeleteWhereThenMatchingRowsRemoved()
+    //{
+    //    var record = new Record("Test", 5);
+    //    var idCol = record.Columns.Add<int>("Id");
 
-        for (int i = 0; i < 5; i++)
-        {
-            var row = record.AddRow();
-            idCol.Set(row.Row, i);
-        }
+    //    for (int i = 0; i < 5; i++)
+    //    {
+    //        var row = record.AddRow();
+    //        idCol.Set(row.Row, i);
+    //    }
 
-        int deleted = record.DeleteWhere(r => r.Field<int>("Id") % 2 == 0);
+    //    int deleted = record.DeleteWhere(r => r.Field<int>("Id") % 2 == 0);
 
-        Assert.AreEqual(3, deleted);
-        Assert.AreEqual(2, record.Count);
-        var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
-        CollectionAssert.AreEqual(new[] { 1, 3 }, remaining);
-    }
+    //    Assert.AreEqual(3, deleted);
+    //    Assert.AreEqual(2, record.Count);
+    //    var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
+    //    CollectionAssert.AreEqual(new[] { 1, 3 }, remaining);
+    //}
 
-    [TestMethod]
-    public void WhenDeleteRowsWithIndicesThenCorrectRowsRemoved()
-    {
-        var record = new Record("Test", 5);
-        var idCol = record.Columns.Add<int>("Id");
+    //[TestMethod]
+    //public void WhenDeleteRowsWithIndicesThenCorrectRowsRemoved()
+    //{
+    //    var record = new Record("Test", 5);
+    //    var idCol = record.Columns.Add<int>("Id");
 
-        for (int i = 0; i < 5; i++)
-        {
-            var row = record.AddRow();
-            idCol.Set(row.Row, i * 10);
-        }
+    //    for (int i = 0; i < 5; i++)
+    //    {
+    //        var row = record.AddRow();
+    //        idCol.Set(row.Row, i * 10);
+    //    }
 
-        int deleted = record.DeleteRows(new[] { 0, 2, 4 });
+    //    int deleted = record.DeleteRows(new[] { 0, 2, 4 });
 
-        Assert.AreEqual(3, deleted);
-        Assert.AreEqual(2, record.Count);
-        var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
-        CollectionAssert.AreEqual(new[] { 10, 30 }, remaining);
-    }
+    //    Assert.AreEqual(3, deleted);
+    //    Assert.AreEqual(2, record.Count);
+    //    var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
+    //    CollectionAssert.AreEqual(new[] { 10, 30 }, remaining);
+    //}
 
     [TestMethod]
     public void WhenDeleteRowsWithDuplicateIndicesThenDeduplicates()
@@ -142,42 +142,42 @@ public class RecordBoundaryTests
         Assert.AreEqual(2, record.Count);
     }
 
-    [TestMethod]
-    public void WhenDeleteWhereNoMatchThenNothingDeleted()
-    {
-        var record = new Record("Test", 3);
-        var idCol = record.Columns.Add<int>("Id");
+    //[TestMethod]
+    //public void WhenDeleteWhereNoMatchThenNothingDeleted()
+    //{
+    //    var record = new Record("Test", 3);
+    //    var idCol = record.Columns.Add<int>("Id");
 
-        for (int i = 0; i < 3; i++)
-        {
-            var row = record.AddRow();
-            idCol.Set(row.Row, i);
-        }
+    //    for (int i = 0; i < 3; i++)
+    //    {
+    //        var row = record.AddRow();
+    //        idCol.Set(row.Row, i);
+    //    }
 
-        int deleted = record.DeleteWhere(r => r.Field<int>("Id") > 100);
+    //    int deleted = record.DeleteWhere(r => r.Field<int>("Id") > 100);
 
-        Assert.AreEqual(0, deleted);
-        Assert.AreEqual(3, record.Count);
-    }
+    //    Assert.AreEqual(0, deleted);
+    //    Assert.AreEqual(3, record.Count);
+    //}
 
     #endregion
 
     #region RecordRow.Set<T>
 
-    [TestMethod]
-    public void WhenRecordRowSetGenericThenValueSetCorrectly()
-    {
-        var record = new Record("Test", 1);
-        record.Columns.Add<int>("Id");
-        record.Columns.Add<string>("Name");
+    //[TestMethod]
+    //public void WhenRecordRowSetGenericThenValueSetCorrectly()
+    //{
+    //    var record = new Record("Test", 1);
+    //    record.Columns.Add<int>("Id");
+    //    record.Columns.Add<string>("Name");
 
-        var row = record.AddRow();
-        row.Set("Id", 42);
-        row.Set("Name", "Test");
+    //    var row = record.AddRow();
+    //    row.Set("Id", 42);
+    //    row.Set("Name", "Test");
 
-        Assert.AreEqual(42, row.Field<int>("Id"));
-        Assert.AreEqual("Test", row.Field<string>("Name"));
-    }
+    //    Assert.AreEqual(42, row.Field<int>("Id"));
+    //    Assert.AreEqual("Test", row.Field<string>("Name"));
+    //}
 
     #endregion
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -32,25 +32,25 @@ public class RecordBoundaryTests
 
     #region Delete Consistency
 
-    //[TestMethod]
-    //public void WhenDeleteThenEnumerationIsConsistent()
-    //{
-    //    var record = new Record("Test", 5);
-    //    var idCol = record.Columns.Add<int>("Id");
+    [TestMethod]
+    public void WhenDeleteThenEnumerationIsConsistent()
+    {
+        var record = new Record("Test", 5);
+        var idCol = record.Columns.Add<int>("Id");
 
-    //    for (int i = 0; i < 5; i++)
-    //    {
-    //        var row = record.AddRow();
-    //        idCol.Set(row.Row, i * 10);
-    //    }
+        for (int i = 0; i < 5; i++)
+        {
+            var row = record.AddRow();
+            idCol.Set(row.Row, i * 10);
+        }
 
-    //    // Delete middle row (index 2, value 20)
-    //    record.Delete(2);
+        // Delete middle row (index 2, value 20)
+        record.Delete(2);
 
-    //    Assert.AreEqual(4, record.Count);
-    //    var values = record.Select(r => r.Field<int>("Id")).ToArray();
-    //    CollectionAssert.AreEqual(new[] { 0, 10, 30, 40 }, values);
-    //}
+        Assert.AreEqual(4, record.Count);
+        var values = record.Select(r => r.To<int>("Id")).ToArray();
+        CollectionAssert.AreEqual(new[] { 0, 10, 30, 40 }, values);
+    }
 
     [TestMethod]
     public void WhenDeleteThenAddRowThenDataIsCorrect()
@@ -84,45 +84,45 @@ public class RecordBoundaryTests
 
     #region Batch Delete
 
-    //[TestMethod]
-    //public void WhenDeleteWhereThenMatchingRowsRemoved()
-    //{
-    //    var record = new Record("Test", 5);
-    //    var idCol = record.Columns.Add<int>("Id");
+    [TestMethod]
+    public void WhenDeleteWhereThenMatchingRowsRemoved()
+    {
+        var record = new Record("Test", 5);
+        var idCol = record.Columns.Add<int>("Id");
 
-    //    for (int i = 0; i < 5; i++)
-    //    {
-    //        var row = record.AddRow();
-    //        idCol.Set(row.Row, i);
-    //    }
+        for (int i = 0; i < 5; i++)
+        {
+            var row = record.AddRow();
+            idCol.Set(row.Row, i);
+        }
 
-    //    int deleted = record.DeleteWhere(r => r.Field<int>("Id") % 2 == 0);
+        int deleted = record.DeleteWhere(r => r.To<int>("Id") % 2 == 0);
 
-    //    Assert.AreEqual(3, deleted);
-    //    Assert.AreEqual(2, record.Count);
-    //    var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
-    //    CollectionAssert.AreEqual(new[] { 1, 3 }, remaining);
-    //}
+        Assert.AreEqual(3, deleted);
+        Assert.AreEqual(2, record.Count);
+        var remaining = record.Select(r => r.To<int>("Id")).ToArray();
+        CollectionAssert.AreEqual(new[] { 1, 3 }, remaining);
+    }
 
-    //[TestMethod]
-    //public void WhenDeleteRowsWithIndicesThenCorrectRowsRemoved()
-    //{
-    //    var record = new Record("Test", 5);
-    //    var idCol = record.Columns.Add<int>("Id");
+    [TestMethod]
+    public void WhenDeleteRowsWithIndicesThenCorrectRowsRemoved()
+    {
+        var record = new Record("Test", 5);
+        var idCol = record.Columns.Add<int>("Id");
 
-    //    for (int i = 0; i < 5; i++)
-    //    {
-    //        var row = record.AddRow();
-    //        idCol.Set(row.Row, i * 10);
-    //    }
+        for (int i = 0; i < 5; i++)
+        {
+            var row = record.AddRow();
+            idCol.Set(row.Row, i * 10);
+        }
 
-    //    int deleted = record.DeleteRows(new[] { 0, 2, 4 });
+        int deleted = record.DeleteRows(new[] { 0, 2, 4 });
 
-    //    Assert.AreEqual(3, deleted);
-    //    Assert.AreEqual(2, record.Count);
-    //    var remaining = record.Select(r => r.Field<int>("Id")).ToArray();
-    //    CollectionAssert.AreEqual(new[] { 10, 30 }, remaining);
-    //}
+        Assert.AreEqual(3, deleted);
+        Assert.AreEqual(2, record.Count);
+        var remaining = record.Select(r => r.To<int>("Id")).ToArray();
+        CollectionAssert.AreEqual(new[] { 10, 30 }, remaining);
+    }
 
     [TestMethod]
     public void WhenDeleteRowsWithDuplicateIndicesThenDeduplicates()
@@ -142,42 +142,42 @@ public class RecordBoundaryTests
         Assert.AreEqual(2, record.Count);
     }
 
-    //[TestMethod]
-    //public void WhenDeleteWhereNoMatchThenNothingDeleted()
-    //{
-    //    var record = new Record("Test", 3);
-    //    var idCol = record.Columns.Add<int>("Id");
+    [TestMethod]
+    public void WhenDeleteWhereNoMatchThenNothingDeleted()
+    {
+        var record = new Record("Test", 3);
+        var idCol = record.Columns.Add<int>("Id");
 
-    //    for (int i = 0; i < 3; i++)
-    //    {
-    //        var row = record.AddRow();
-    //        idCol.Set(row.Row, i);
-    //    }
+        for (int i = 0; i < 3; i++)
+        {
+            var row = record.AddRow();
+            idCol.Set(row.Row, i);
+        }
 
-    //    int deleted = record.DeleteWhere(r => r.Field<int>("Id") > 100);
+        int deleted = record.DeleteWhere(r => r.To<int>("Id") > 100);
 
-    //    Assert.AreEqual(0, deleted);
-    //    Assert.AreEqual(3, record.Count);
-    //}
+        Assert.AreEqual(0, deleted);
+        Assert.AreEqual(3, record.Count);
+    }
 
     #endregion
 
     #region RecordRow.Set<T>
 
-    //[TestMethod]
-    //public void WhenRecordRowSetGenericThenValueSetCorrectly()
-    //{
-    //    var record = new Record("Test", 1);
-    //    record.Columns.Add<int>("Id");
-    //    record.Columns.Add<string>("Name");
+    [TestMethod]
+    public void WhenRecordRowSetGenericThenValueSetCorrectly()
+    {
+        var record = new Record("Test", 1);
+        record.Columns.Add<int>("Id");
+        record.Columns.Add<string>("Name");
 
-    //    var row = record.AddRow();
-    //    row.Set("Id", 42);
-    //    row.Set("Name", "Test");
+        var row = record.AddRow();
+        row["Id"] = 42;
+        row["Name"] = "Test";
 
-    //    Assert.AreEqual(42, row.Field<int>("Id"));
-    //    Assert.AreEqual("Test", row.Field<string>("Name"));
-    //}
+        Assert.AreEqual(42, row.To<int>("Id"));
+        Assert.AreEqual("Test", row.To<string>("Name"));
+    }
 
     #endregion
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
@@ -21,12 +21,12 @@ public class RecordMappingTests
         var nameColumn = record.Columns.Add<string>("Name");
 
         var row1 = record.AddRow();
-        idColumn.SetField(row1.Row, 1);
-        nameColumn.SetField(row1.Row, "Alice");
+        idColumn.SetValue(row1.Row, 1);
+        nameColumn.SetValue(row1.Row, "Alice");
 
         var row2 = record.AddRow();
-        idColumn.SetField(row2.Row, 2);
-        nameColumn.SetField(row2.Row, "Bob");
+        idColumn.SetValue(row2.Row, 2);
+        nameColumn.SetValue(row2.Row, "Bob");
 
         // Act
         var model = record.To<TestModel>();

--- a/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
@@ -21,12 +21,12 @@ public class RecordMappingTests
         var nameColumn = record.Columns.Add<string>("Name");
 
         var row1 = record.AddRow();
-        idColumn.Set(row1.Row, 1);
-        nameColumn.Set(row1.Row, "Alice");
+        idColumn.SetField(row1.Row, 1);
+        nameColumn.SetField(row1.Row, "Alice");
 
         var row2 = record.AddRow();
-        idColumn.Set(row2.Row, 2);
-        nameColumn.Set(row2.Row, "Bob");
+        idColumn.SetField(row2.Row, 2);
+        nameColumn.SetField(row2.Row, "Bob");
 
         // Act
         var model = record.To<TestModel>();

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -32,19 +32,19 @@ public class RecordQueryTests
         return record;
     }
 
-    [TestMethod]
-    public void FindT_WithExistingValue_ReturnsFirstMatch()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void FindT_WithExistingValue_ReturnsFirstMatch()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var result = record.Find<bool>("IsActive", true);
+    //    // Act
+    //    var result = record.Find<bool>("IsActive", true);
 
-        // Assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual(1, result.Value.Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(1, result.Value.Field<int>("Id"));
+    //}
 
     [TestMethod]
     public void FindT_WithNonExistingValue_ReturnsNull()
@@ -72,76 +72,76 @@ public class RecordQueryTests
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public void FindAllT_WithExistingValue_ReturnsAllMatches()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void FindAllT_WithExistingValue_ReturnsAllMatches()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var results = record.FindAll<bool>("IsActive", true).ToList();
+    //    // Act
+    //    var results = record.FindAll<bool>("IsActive", true).ToList();
 
-        // Assert
-        Assert.AreEqual(2, results.Count);
-        Assert.AreEqual(1, results[0].Field<int>("Id"));
-        Assert.AreEqual(3, results[1].Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(2, results.Count);
+    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
+    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
+    //}
 
-    [TestMethod]
-    public void Find_WithValidPredicate_ReturnsFirstMatch()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void Find_WithValidPredicate_ReturnsFirstMatch()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var result = record.Find(r => r.Field<string>("Name") == "Bob");
+    //    // Act
+    //    var result = record.Find(r => r.Field<string>("Name") == "Bob");
 
-        // Assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual(2, result.Value.Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(2, result.Value.Field<int>("Id"));
+    //}
 
-    [TestMethod]
-    public void Find_WithInvalidPredicate_ReturnsNull()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void Find_WithInvalidPredicate_ReturnsNull()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var result = record.Find(r => r.Field<int>("Id") > 10);
+    //    // Act
+    //    var result = record.Find(r => r.Field<int>("Id") > 10);
 
-        // Assert
-        Assert.IsNull(result);
-    }
+    //    // Assert
+    //    Assert.IsNull(result);
+    //}
 
-    [TestMethod]
-    public void FindAll_WithValidPredicate_ReturnsAllMatches()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void FindAll_WithValidPredicate_ReturnsAllMatches()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var results = record.FindAll(r => r.Field<bool>("IsActive")).ToList();
+    //    // Act
+    //    var results = record.FindAll(r => r.Field<bool>("IsActive")).ToList();
 
-        // Assert
-        Assert.AreEqual(2, results.Count);
-        Assert.AreEqual(1, results[0].Field<int>("Id"));
-        Assert.AreEqual(3, results[1].Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(2, results.Count);
+    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
+    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
+    //}
 
-    [TestMethod]
-    public void FindByDynamic_WithValidPredicate_ReturnsFirstMatch()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void FindByDynamic_WithValidPredicate_ReturnsFirstMatch()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var result = record.FindByDynamic(d => d.Name == "Charlie");
+    //    // Act
+    //    var result = record.FindByDynamic(d => d.Name == "Charlie");
 
-        // Assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual(3, result.Value.Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(3, result.Value.Field<int>("Id"));
+    //}
 
     [TestMethod]
     public void FindByDynamic_WithInvalidPredicate_ReturnsNull()
@@ -156,18 +156,18 @@ public class RecordQueryTests
         Assert.IsNull(result);
     }
 
-    [TestMethod]
-    public void FindAllByDynamic_WithValidPredicate_ReturnsAllMatches()
-    {
-        // Arrange
-        var record = CreateTestRecord();
+    //[TestMethod]
+    //public void FindAllByDynamic_WithValidPredicate_ReturnsAllMatches()
+    //{
+    //    // Arrange
+    //    var record = CreateTestRecord();
 
-        // Act
-        var results = record.FindAllByDynamic(d => d.IsActive == true).ToList();
+    //    // Act
+    //    var results = record.FindAllByDynamic(d => d.IsActive == true).ToList();
 
-        // Assert
-        Assert.AreEqual(2, results.Count);
-        Assert.AreEqual(1, results[0].Field<int>("Id"));
-        Assert.AreEqual(3, results[1].Field<int>("Id"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(2, results.Count);
+    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
+    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
+    //}
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -32,19 +32,19 @@ public class RecordQueryTests
         return record;
     }
 
-    //[TestMethod]
-    //public void FindT_WithExistingValue_ReturnsFirstMatch()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void FindT_WithExistingValue_ReturnsFirstMatch()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var result = record.Find<bool>("IsActive", true);
+        // Act
+        var result = record.Find<bool>("IsActive", true);
 
-    //    // Assert
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(1, result.Value.Field<int>("Id"));
-    //}
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result.Value.To<int>("Id"));
+    }
 
     [TestMethod]
     public void FindT_WithNonExistingValue_ReturnsNull()
@@ -72,76 +72,76 @@ public class RecordQueryTests
         Assert.IsNull(result);
     }
 
-    //[TestMethod]
-    //public void FindAllT_WithExistingValue_ReturnsAllMatches()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void FindAllT_WithExistingValue_ReturnsAllMatches()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var results = record.FindAll<bool>("IsActive", true).ToList();
+        // Act
+        var results = record.FindAll<bool>("IsActive", true).ToList();
 
-    //    // Assert
-    //    Assert.AreEqual(2, results.Count);
-    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
-    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
-    //}
+        // Assert
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(1, results[0].To<int>("Id"));
+        Assert.AreEqual(3, results[1].To<int>("Id"));
+    }
 
-    //[TestMethod]
-    //public void Find_WithValidPredicate_ReturnsFirstMatch()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void Find_WithValidPredicate_ReturnsFirstMatch()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var result = record.Find(r => r.Field<string>("Name") == "Bob");
+        // Act
+        var result = record.Find(r => r.To<string>("Name") == "Bob");
 
-    //    // Assert
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(2, result.Value.Field<int>("Id"));
-    //}
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Value.To<int>("Id"));
+    }
 
-    //[TestMethod]
-    //public void Find_WithInvalidPredicate_ReturnsNull()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void Find_WithInvalidPredicate_ReturnsNull()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var result = record.Find(r => r.Field<int>("Id") > 10);
+        // Act
+        var result = record.Find(r => r.To<int>("Id") > 10);
 
-    //    // Assert
-    //    Assert.IsNull(result);
-    //}
+        // Assert
+        Assert.IsNull(result);
+    }
 
-    //[TestMethod]
-    //public void FindAll_WithValidPredicate_ReturnsAllMatches()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void FindAll_WithValidPredicate_ReturnsAllMatches()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var results = record.FindAll(r => r.Field<bool>("IsActive")).ToList();
+        // Act
+        var results = record.FindAll(r => r.To<bool>("IsActive")).ToList();
 
-    //    // Assert
-    //    Assert.AreEqual(2, results.Count);
-    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
-    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
-    //}
+        // Assert
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(1, results[0].To<int>("Id"));
+        Assert.AreEqual(3, results[1].To<int>("Id"));
+    }
 
-    //[TestMethod]
-    //public void FindByDynamic_WithValidPredicate_ReturnsFirstMatch()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void FindByDynamic_WithValidPredicate_ReturnsFirstMatch()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var result = record.FindByDynamic(d => d.Name == "Charlie");
+        // Act
+        var result = record.FindByDynamic(d => d.Name == "Charlie");
 
-    //    // Assert
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(3, result.Value.Field<int>("Id"));
-    //}
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(3, result.Value.To<int>("Id"));
+    }
 
     [TestMethod]
     public void FindByDynamic_WithInvalidPredicate_ReturnsNull()
@@ -156,18 +156,18 @@ public class RecordQueryTests
         Assert.IsNull(result);
     }
 
-    //[TestMethod]
-    //public void FindAllByDynamic_WithValidPredicate_ReturnsAllMatches()
-    //{
-    //    // Arrange
-    //    var record = CreateTestRecord();
+    [TestMethod]
+    public void FindAllByDynamic_WithValidPredicate_ReturnsAllMatches()
+    {
+        // Arrange
+        var record = CreateTestRecord();
 
-    //    // Act
-    //    var results = record.FindAllByDynamic(d => d.IsActive == true).ToList();
+        // Act
+        var results = record.FindAllByDynamic(d => d.IsActive == true).ToList();
 
-    //    // Assert
-    //    Assert.AreEqual(2, results.Count);
-    //    Assert.AreEqual(1, results[0].Field<int>("Id"));
-    //    Assert.AreEqual(3, results[1].Field<int>("Id"));
-    //}
+        // Assert
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(1, results[0].To<int>("Id"));
+        Assert.AreEqual(3, results[1].To<int>("Id"));
+    }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -15,19 +15,19 @@ public class RecordQueryTests
         record.Columns.Add("IsActive", typeof(bool));
 
         var row1 = record.AddRow();
-        record.Columns["Id"].SetValue(row1, 1);
-        record.Columns["Name"].SetValue(row1, "Alice");
-        record.Columns["IsActive"].SetValue(row1, true);
+        record.Columns["Id"].Set(row1, 1);
+        record.Columns["Name"].Set(row1, "Alice");
+        record.Columns["IsActive"].Set(row1, true);
 
         var row2 = record.AddRow();
-        record.Columns["Id"].SetValue(row2, 2);
-        record.Columns["Name"].SetValue(row2, "Bob");
-        record.Columns["IsActive"].SetValue(row2, false);
+        record.Columns["Id"].Set(row2, 2);
+        record.Columns["Name"].Set(row2, "Bob");
+        record.Columns["IsActive"].Set(row2, false);
 
         var row3 = record.AddRow();
-        record.Columns["Id"].SetValue(row3, 3);
-        record.Columns["Name"].SetValue(row3, "Charlie");
-        record.Columns["IsActive"].SetValue(row3, true);
+        record.Columns["Id"].Set(row3, 3);
+        record.Columns["Name"].Set(row3, "Charlie");
+        record.Columns["IsActive"].Set(row3, true);
 
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
@@ -16,74 +16,65 @@ namespace LuYao.Data;
 [TestClass]
 public class RecordRowSemanticsTests
 {
-    //[TestMethod]
-    //public void Field_ColumnExists_ReturnsTypedValue()
-    //{
-    //    var record = new Record();
-    //    var col = record.Columns.Add<int>("Id");
-    //    var row = record.AddRow();
-    //    col.Set(row.Row, 123);
-    //    Assert.AreEqual(123, row.Field<int>("Id"));
-    //}
+    [TestMethod]
+    public void Field_ColumnExists_ReturnsTypedValue()
+    {
+        var record = new Record();
+        var col = record.Columns.Add<int>("Id");
+        var row = record.AddRow();
+        col.Set(row.Row, 123);
+        Assert.AreEqual(123, row.To<int>("Id"));
+    }
 
-    //[TestMethod]
-    //public void Field_ColumnNotExist_ReturnsDefault()
-    //{
-    //    var record = new Record();
-    //    record.AddRow();
-    //    var row = record[0];
-    //    Assert.AreEqual(0, row.Field<int>("NoSuch"));
-    //    Assert.IsNull(row.Field<string>("NoSuch"));
-    //}
+    [TestMethod]
+    public void Field_ColumnNotExist_ReturnsDefault()
+    {
+        var record = new Record();
+        record.AddRow();
+        var row = record[0];
+        Assert.AreEqual(0, row.To<int>("NoSuch"));
+        Assert.IsNull(row.To<string>("NoSuch"));
+    }
 
-    //[TestMethod]
-    //public void Set_ColumnNotExist_AutoCreatesColumn()
-    //{
-    //    var record = new Record();
-    //    var row = record.AddRow();
-    //    row.Set<int>("Id", 100);
+    [TestMethod]
+    public void Set_ColumnNotExist_AutoCreatesColumn()
+    {
+        var record = new Record();
+        var row = record.AddRow();
+        row["Id"] = 100;
 
-    //    Assert.AreEqual(1, record.Columns.Count);
-    //    var col = record.Columns.Get("Id");
-    //    Assert.AreEqual(typeof(int), col.Type);
-    //    Assert.AreEqual(100, row.Field<int>("Id"));
-    //}
+        Assert.AreEqual(1, record.Columns.Count);
+        var col = record.Columns.Get("Id");
+        Assert.AreEqual(typeof(int), col.Type);
+        Assert.AreEqual(100, row.To<int>("Id"));
+    }
 
-    //[TestMethod]
-    //public void Set_ColumnExistsSameType_WritesValue()
-    //{
-    //    var record = new Record();
-    //    record.Columns.Add<string>("Name");
-    //    var row = record.AddRow();
-    //    row.Set<string>("Name", "abc");
-    //    Assert.AreEqual("abc", row.Field<string>("Name"));
-    //}
+    [TestMethod]
+    public void Set_ColumnExistsSameType_WritesValue()
+    {
+        var record = new Record();
+        record.Columns.Add<string>("Name");
+        var row = record.AddRow();
+        row["Name"] = "abc";
+        Assert.AreEqual("abc", row.To<string>("Name"));
+    }
 
-    //[TestMethod]
-    //public void Set_ColumnExistsDifferentType_Throws()
-    //{
-    //    var record = new Record();
-    //    record.Columns.Add<string>("Id");
-    //    var row = record.AddRow();
-    //    Assert.Throws<InvalidOperationException>(() => row.Set<int>("Id", 1));
-    //}
+    [TestMethod]
+    public void Dynamic_SetMember_AutoCreatesColumnByRuntimeType()
+    {
+        var record = new Record();
+        dynamic dto = record.AddRow();
+        dto.Id = 100;
+        dto.Name = "abc";
 
-    //[TestMethod]
-    //public void Dynamic_SetMember_AutoCreatesColumnByRuntimeType()
-    //{
-    //    var record = new Record();
-    //    dynamic dto = record.AddRow();
-    //    dto.Id = 100;
-    //    dto.Name = "abc";
+        Assert.AreEqual(2, record.Columns.Count);
+        Assert.AreEqual(typeof(int), record.Columns.Get("Id").Type);
+        Assert.AreEqual(typeof(string), record.Columns.Get("Name").Type);
 
-    //    Assert.AreEqual(2, record.Columns.Count);
-    //    Assert.AreEqual(typeof(int), record.Columns.Get("Id").Type);
-    //    Assert.AreEqual(typeof(string), record.Columns.Get("Name").Type);
-
-    //    var row = record[0];
-    //    Assert.AreEqual(100, row.Field<int>("Id"));
-    //    Assert.AreEqual("abc", row.Field<string>("Name"));
-    //}
+        var row = record[0];
+        Assert.AreEqual(100, row.To<int>("Id"));
+        Assert.AreEqual("abc", row.To<string>("Name"));
+    }
 
     [TestMethod]
     public void Dynamic_SetMember_NullAndColumnMissing_IsSkipped()
@@ -94,40 +85,39 @@ public class RecordRowSemanticsTests
         Assert.AreEqual(0, record.Columns.Count);
     }
 
-    //[TestMethod]
-    //public void Dynamic_SetMember_NullOnExistingColumn_IsWritten()
-    //{
-    //    var record = new Record();
-    //    record.Columns.Add<string>("Name");
-    //    dynamic dto = record.AddRow();
-    //    dto.Name = "x";
-    //    dto.Name = null;
-    //    Assert.IsNull(((RecordRow)dto).Field<string>("Name"));
-    //}
+    [TestMethod]
+    public void Dynamic_SetMember_NullOnExistingColumn_IsWritten()
+    {
+        var record = new Record();
+        record.Columns.Add<string>("Name");
+        dynamic dto = record.AddRow();
+        dto.Name = "x";
+        dto.Name = null;
+        Assert.IsNull(((RecordRow)dto).To<string>("Name"));
+    }
 
-    //[TestMethod]
-    //public void Dynamic_SetIndex_AutoCreatesColumn()
-    //{
-    //    var record = new Record();
-    //    dynamic dto = record.AddRow();
-    //    dto["Id"] = 7;
-    //    Assert.AreEqual(1, record.Columns.Count);
-    //    Assert.AreEqual(7, record[0].Field<int>("Id"));
-    //}
+    [TestMethod]
+    public void Dynamic_SetIndex_AutoCreatesColumn()
+    {
+        var record = new Record();
+        dynamic dto = record.AddRow();
+        dto["Id"] = 7;
+        Assert.AreEqual(1, record.Columns.Count);
+        Assert.AreEqual(7, record[0].To<int>("Id"));
+    }
 
+    [TestMethod]
+    public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
+    {
+        // 预期：缺列静默跳过，不建列。
+        var record = new Record();
+        record.Columns.Add<int>("Id"); // 只声明 Id 列；Name 故意不建
+        var row = record.AddRow();
+        row.CopyFrom(new MappingDto { Id = 9, Name = "ignored" });
 
-    //[TestMethod]
-    //public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
-    //{
-    //    // 预期：缺列静默跳过，不建列。
-    //    var record = new Record();
-    //    record.Columns.Add<int>("Id"); // 只声明 Id 列；Name 故意不建
-    //    var row = record.AddRow();
-    //    row.CopyFrom(new MappingDto { Id = 9, Name = "ignored" });
-
-    //    Assert.AreEqual(1, record.Columns.Count);
-    //    Assert.AreEqual(9, row.Field<int>("Id"));
-    //}
+        Assert.AreEqual(1, record.Columns.Count);
+        Assert.AreEqual(9, row.To<int>("Id"));
+    }
 
     private sealed class MappingDto
     {

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
@@ -16,74 +16,74 @@ namespace LuYao.Data;
 [TestClass]
 public class RecordRowSemanticsTests
 {
-    [TestMethod]
-    public void Field_ColumnExists_ReturnsTypedValue()
-    {
-        var record = new Record();
-        var col = record.Columns.Add<int>("Id");
-        var row = record.AddRow();
-        col.Set(row.Row, 123);
-        Assert.AreEqual(123, row.Field<int>("Id"));
-    }
+    //[TestMethod]
+    //public void Field_ColumnExists_ReturnsTypedValue()
+    //{
+    //    var record = new Record();
+    //    var col = record.Columns.Add<int>("Id");
+    //    var row = record.AddRow();
+    //    col.Set(row.Row, 123);
+    //    Assert.AreEqual(123, row.Field<int>("Id"));
+    //}
 
-    [TestMethod]
-    public void Field_ColumnNotExist_ReturnsDefault()
-    {
-        var record = new Record();
-        record.AddRow();
-        var row = record[0];
-        Assert.AreEqual(0, row.Field<int>("NoSuch"));
-        Assert.IsNull(row.Field<string>("NoSuch"));
-    }
+    //[TestMethod]
+    //public void Field_ColumnNotExist_ReturnsDefault()
+    //{
+    //    var record = new Record();
+    //    record.AddRow();
+    //    var row = record[0];
+    //    Assert.AreEqual(0, row.Field<int>("NoSuch"));
+    //    Assert.IsNull(row.Field<string>("NoSuch"));
+    //}
 
-    [TestMethod]
-    public void Set_ColumnNotExist_AutoCreatesColumn()
-    {
-        var record = new Record();
-        var row = record.AddRow();
-        row.Set<int>("Id", 100);
+    //[TestMethod]
+    //public void Set_ColumnNotExist_AutoCreatesColumn()
+    //{
+    //    var record = new Record();
+    //    var row = record.AddRow();
+    //    row.Set<int>("Id", 100);
 
-        Assert.AreEqual(1, record.Columns.Count);
-        var col = record.Columns.Get("Id");
-        Assert.AreEqual(typeof(int), col.Type);
-        Assert.AreEqual(100, row.Field<int>("Id"));
-    }
+    //    Assert.AreEqual(1, record.Columns.Count);
+    //    var col = record.Columns.Get("Id");
+    //    Assert.AreEqual(typeof(int), col.Type);
+    //    Assert.AreEqual(100, row.Field<int>("Id"));
+    //}
 
-    [TestMethod]
-    public void Set_ColumnExistsSameType_WritesValue()
-    {
-        var record = new Record();
-        record.Columns.Add<string>("Name");
-        var row = record.AddRow();
-        row.Set<string>("Name", "abc");
-        Assert.AreEqual("abc", row.Field<string>("Name"));
-    }
+    //[TestMethod]
+    //public void Set_ColumnExistsSameType_WritesValue()
+    //{
+    //    var record = new Record();
+    //    record.Columns.Add<string>("Name");
+    //    var row = record.AddRow();
+    //    row.Set<string>("Name", "abc");
+    //    Assert.AreEqual("abc", row.Field<string>("Name"));
+    //}
 
-    [TestMethod]
-    public void Set_ColumnExistsDifferentType_Throws()
-    {
-        var record = new Record();
-        record.Columns.Add<string>("Id");
-        var row = record.AddRow();
-        Assert.Throws<InvalidOperationException>(() => row.Set<int>("Id", 1));
-    }
+    //[TestMethod]
+    //public void Set_ColumnExistsDifferentType_Throws()
+    //{
+    //    var record = new Record();
+    //    record.Columns.Add<string>("Id");
+    //    var row = record.AddRow();
+    //    Assert.Throws<InvalidOperationException>(() => row.Set<int>("Id", 1));
+    //}
 
-    [TestMethod]
-    public void Dynamic_SetMember_AutoCreatesColumnByRuntimeType()
-    {
-        var record = new Record();
-        dynamic dto = record.AddRow();
-        dto.Id = 100;
-        dto.Name = "abc";
+    //[TestMethod]
+    //public void Dynamic_SetMember_AutoCreatesColumnByRuntimeType()
+    //{
+    //    var record = new Record();
+    //    dynamic dto = record.AddRow();
+    //    dto.Id = 100;
+    //    dto.Name = "abc";
 
-        Assert.AreEqual(2, record.Columns.Count);
-        Assert.AreEqual(typeof(int), record.Columns.Get("Id").Type);
-        Assert.AreEqual(typeof(string), record.Columns.Get("Name").Type);
+    //    Assert.AreEqual(2, record.Columns.Count);
+    //    Assert.AreEqual(typeof(int), record.Columns.Get("Id").Type);
+    //    Assert.AreEqual(typeof(string), record.Columns.Get("Name").Type);
 
-        var row = record[0];
-        Assert.AreEqual(100, row.Field<int>("Id"));
-        Assert.AreEqual("abc", row.Field<string>("Name"));
-    }
+    //    var row = record[0];
+    //    Assert.AreEqual(100, row.Field<int>("Id"));
+    //    Assert.AreEqual("abc", row.Field<string>("Name"));
+    //}
 
     [TestMethod]
     public void Dynamic_SetMember_NullAndColumnMissing_IsSkipped()
@@ -94,40 +94,40 @@ public class RecordRowSemanticsTests
         Assert.AreEqual(0, record.Columns.Count);
     }
 
-    [TestMethod]
-    public void Dynamic_SetMember_NullOnExistingColumn_IsWritten()
-    {
-        var record = new Record();
-        record.Columns.Add<string>("Name");
-        dynamic dto = record.AddRow();
-        dto.Name = "x";
-        dto.Name = null;
-        Assert.IsNull(((RecordRow)dto).Field<string>("Name"));
-    }
+    //[TestMethod]
+    //public void Dynamic_SetMember_NullOnExistingColumn_IsWritten()
+    //{
+    //    var record = new Record();
+    //    record.Columns.Add<string>("Name");
+    //    dynamic dto = record.AddRow();
+    //    dto.Name = "x";
+    //    dto.Name = null;
+    //    Assert.IsNull(((RecordRow)dto).Field<string>("Name"));
+    //}
 
-    [TestMethod]
-    public void Dynamic_SetIndex_AutoCreatesColumn()
-    {
-        var record = new Record();
-        dynamic dto = record.AddRow();
-        dto["Id"] = 7;
-        Assert.AreEqual(1, record.Columns.Count);
-        Assert.AreEqual(7, record[0].Field<int>("Id"));
-    }
+    //[TestMethod]
+    //public void Dynamic_SetIndex_AutoCreatesColumn()
+    //{
+    //    var record = new Record();
+    //    dynamic dto = record.AddRow();
+    //    dto["Id"] = 7;
+    //    Assert.AreEqual(1, record.Columns.Count);
+    //    Assert.AreEqual(7, record[0].Field<int>("Id"));
+    //}
 
 
-    [TestMethod]
-    public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
-    {
-        // 预期：缺列静默跳过，不建列。
-        var record = new Record();
-        record.Columns.Add<int>("Id"); // 只声明 Id 列；Name 故意不建
-        var row = record.AddRow();
-        row.CopyFrom(new MappingDto { Id = 9, Name = "ignored" });
+    //[TestMethod]
+    //public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
+    //{
+    //    // 预期：缺列静默跳过，不建列。
+    //    var record = new Record();
+    //    record.Columns.Add<int>("Id"); // 只声明 Id 列；Name 故意不建
+    //    var row = record.AddRow();
+    //    row.CopyFrom(new MappingDto { Id = 9, Name = "ignored" });
 
-        Assert.AreEqual(1, record.Columns.Count);
-        Assert.AreEqual(9, row.Field<int>("Id"));
-    }
+    //    Assert.AreEqual(1, record.Columns.Count);
+    //    Assert.AreEqual(9, row.Field<int>("Id"));
+    //}
 
     private sealed class MappingDto
     {

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -149,344 +149,345 @@ public class RecordRowTests
     /// <summary>
     /// 按列名读取已存在的布尔列时，应返回正确值。
     /// </summary>
-    //[TestMethod]
-    //public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
-    //{
-    //    // Arrange
-    //    var (record, _, _, boolColumn) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, _, _, boolColumn) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<Boolean>("BoolColumn");
+        // Act
+        var result = recordRow.To<bool>("BoolColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(true, result);
-    //}
+        // Assert
+        Assert.AreEqual(true, result);
+    }
 
     /// <summary>
     /// 按列名读取不存在的布尔列时，应返回默认值。
     /// </summary>
-    //[TestMethod]
-    //public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<Boolean>("NonExistentColumn");
+        // Act
+        var result = recordRow.To<bool>("NonExistentColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(default(bool), result);
-    //}
+        // Assert
+        Assert.AreEqual(default(bool), result);
+    }
 
     /// <summary>
     /// 按列名读取已存在的字符串列时，应返回正确值。
     /// </summary>
-    //[TestMethod]
-    //public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
-    //{
-    //    // Arrange
-    //    var (record, _, stringColumn, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 1);
+    [TestMethod]
+    public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
-    //    // Act
-    //    var result = recordRow.Field<String>("StringColumn");
+        // Act
+        var result = recordRow.To<string>("StringColumn");
 
-    //    // Assert
-    //    Assert.AreEqual("Test2", result);
-    //}
+        // Assert
+        Assert.AreEqual("Test2", result);
+    }
 
     /// <summary>
     /// 按列名读取不存在的字符串列时，应返回默认值。
     /// </summary>
-    //[TestMethod]
-    //public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<String>("NonExistentColumn");
+        // Act
+        var result = recordRow.To<string>("NonExistentColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(default(string), result);
-    //}
+        // Assert
+        Assert.AreEqual(default(string), result);
+    }
 
     /// <summary>
     /// 按列名读取已存在的整型列时，应返回正确值。
     /// </summary>
-    //[TestMethod]
-    //public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 1);
+    [TestMethod]
+    public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
-    //    // Act
-    //    var result = recordRow.Field<Int32>("IntColumn");
+        // Act
+        var result = recordRow.To<int>("IntColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(200, result);
-    //}
+        // Assert
+        Assert.AreEqual(200, result);
+    }
 
     /// <summary>
     /// 按列名读取不存在的整型列时，应返回默认值。
     /// </summary>
-    //[TestMethod]
-    //public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<Int32>("NonExistentColumn");
+        // Act
+        var result = recordRow.To<int>("NonExistentColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(default(int), result);
-    //}
+        // Assert
+        Assert.AreEqual(default(int), result);
+    }
 
     /// <summary>
     /// 泛型按列名读取已存在列时，应返回正确值。
     /// </summary>
-    //[TestMethod]
-    //public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<int>("IntColumn");
+        // Act
+        var result = recordRow.To<int>("IntColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(100, result);
-    //}
+        // Assert
+        Assert.AreEqual(100, result);
+    }
 
     /// <summary>
     /// 泛型按列名读取不存在列时，应返回默认值。
     /// </summary>
-    //[TestMethod]
-    //public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<int>("NonExistentColumn");
+        // Act
+        var result = recordRow.To<int>("NonExistentColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(default(int), result);
-    //}
+        // Assert
+        Assert.AreEqual(default(int), result);
+    }
 
     /// <summary>
     /// 应支持按列名读取字节值。
     /// </summary>
-    //[TestMethod]
-    //public void GetByte_ByName_ShouldWork()
-    //{
-    //    // Arrange
-    //    var record = new Record("TestTable", 1);
-    //    var byteColumn = record.Columns.Add<byte>("ByteColumn");
-    //    var row = record.AddRow();
-    //    byteColumn.Set(row.Row, 255);
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetByte_ByName_ShouldWork()
+    {
+        // Arrange
+        var record = new Record("TestTable", 1);
+        var byteColumn = record.Columns.Add<byte>("ByteColumn");
+        var row = record.AddRow();
+        byteColumn.Set(row.Row, 255);
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<Byte>("ByteColumn");
+        // Act
+        var result = recordRow.To<byte>("ByteColumn");
 
-    //    // Assert
-    //    Assert.AreEqual((byte)255, result);
-    //}
+        // Assert
+        Assert.AreEqual((byte)255, result);
+    }
 
     /// <summary>
     /// 应支持按列名读取双精度浮点值。
     /// </summary>
-    //[TestMethod]
-    //public void GetDouble_ByName_ShouldWork()
-    //{
-    //    // Arrange
-    //    var record = new Record("TestTable", 1);
-    //    var doubleColumn = record.Columns.Add<double>("DoubleColumn");
-    //    var row = record.AddRow();
-    //    doubleColumn.Set(row.Row, 3.14159);
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetDouble_ByName_ShouldWork()
+    {
+        // Arrange
+        var record = new Record("TestTable", 1);
+        var doubleColumn = record.Columns.Add<double>("DoubleColumn");
+        var row = record.AddRow();
+        doubleColumn.Set(row.Row, 3.14159);
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<Double>("DoubleColumn");
+        // Act
+        var result = recordRow.To<double>("DoubleColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(3.14159, result, 0.00001);
-    //}
+        // Assert
+        Assert.AreEqual(3.14159, result, 0.00001);
+    }
 
     /// <summary>
     /// 应支持按列名读取日期时间值。
     /// </summary>
-    //[TestMethod]
-    //public void GetDateTime_ByName_ShouldWork()
-    //{
-    //    // Arrange
-    //    var record = new Record("TestTable", 1);
-    //    var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
-    //    var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
-    //    var row = record.AddRow();
-    //    dateTimeColumn.Set(row.Row, testDate);
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetDateTime_ByName_ShouldWork()
+    {
+        // Arrange
+        var record = new Record("TestTable", 1);
+        var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
+        var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
+        var row = record.AddRow();
+        dateTimeColumn.Set(row.Row, testDate);
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field<DateTime>("DateTimeColumn");
+        // Act
+        var result = recordRow.To<DateTime>("DateTimeColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(testDate, result);
-    //}
+        // Assert
+        Assert.AreEqual(testDate, result);
+    }
 
 
 
     /// <summary>
     /// 当列名为空时，各类型读取方法应返回默认值。
     /// </summary>
-    //[TestMethod]
-    //public void GetMethods_EmptyColumnName_ShouldReturnDefault()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetMethods_EmptyColumnName_ShouldReturnDefault()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act & Assert
-    //    Assert.AreEqual(default(int), recordRow.Field<Int32>(""));
-    //    Assert.AreEqual(default(string), recordRow.Field<String>(""));
-    //    Assert.AreEqual(default(bool), recordRow.Field<Boolean>(""));
-    //}
+        // Act & Assert
+        Assert.AreEqual(default(int), recordRow.To<int>(""));
+        Assert.AreEqual(default(string), recordRow.To<string>(""));
+        Assert.AreEqual(default(bool), recordRow.To<bool>(""));
+    }
 
     /// <summary>
     /// 在多行数据场景下，应能读取到各行的正确值。
     /// </summary>
-    //[TestMethod]
-    //public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
+    [TestMethod]
+    public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
+    {
+        // Arrange
+        var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
 
-    //    var row3 = record.AddRow();
-    //    intColumn.Set(row3.Row, 300);
-    //    stringColumn.Set(row3.Row, "Test3");
-    //    boolColumn.Set(row3.Row, true);
+        var row3 = record.AddRow();
+        intColumn.Set(row3.Row, 300);
+        stringColumn.Set(row3.Row, "Test3");
+        boolColumn.Set(row3.Row, true);
 
-    //    var recordRow0 = new RecordRow(record, 0);
-    //    var recordRow1 = new RecordRow(record, 1);
-    //    var recordRow2 = new RecordRow(record, 2);
+        var recordRow0 = new RecordRow(record, 0);
+        var recordRow1 = new RecordRow(record, 1);
+        var recordRow2 = new RecordRow(record, 2);
 
-    //    // Act & Assert
-    //    Assert.AreEqual(100, recordRow0.Field<Int32>("IntColumn"));
-    //    Assert.AreEqual(200, recordRow1.Field<Int32>("IntColumn"));
-    //    Assert.AreEqual(300, recordRow2.Field<Int32>("IntColumn"));
+        // Act & Assert
+        Assert.AreEqual(100, recordRow0.To<int>("IntColumn"));
+        Assert.AreEqual(200, recordRow1.To<int>("IntColumn"));
+        Assert.AreEqual(300, recordRow2.To<int>("IntColumn"));
 
-    //    Assert.AreEqual("Test1", recordRow0.Field<String>("StringColumn"));
-    //    Assert.AreEqual("Test2", recordRow1.Field<String>("StringColumn"));
-    //    Assert.AreEqual("Test3", recordRow2.Field<String>("StringColumn"));
+        Assert.AreEqual("Test1", recordRow0.To<string>("StringColumn"));
+        Assert.AreEqual("Test2", recordRow1.To<string>("StringColumn"));
+        Assert.AreEqual("Test3", recordRow2.To<string>("StringColumn"));
 
-    //    Assert.AreEqual(true, recordRow0.Field<Boolean>("BoolColumn"));
-    //    Assert.AreEqual(false, recordRow1.Field<Boolean>("BoolColumn"));
-    //    Assert.AreEqual(true, recordRow2.Field<Boolean>("BoolColumn"));
-    //}
+        Assert.AreEqual(true, recordRow0.To<bool>("BoolColumn"));
+        Assert.AreEqual(false, recordRow1.To<bool>("BoolColumn"));
+        Assert.AreEqual(true, recordRow2.To<bool>("BoolColumn"));
+    }
 
 
 
     /// <summary>
     /// 多次访问同一字段时，应保持结果一致。
     /// </summary>
-    //[TestMethod]
-    //public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result1 = recordRow.Field<Int32>("IntColumn");
-    //    var result2 = recordRow.Field<Int32>("IntColumn");
+        // Act
+        var result1 = recordRow.To<int>("IntColumn");
+        var result2 = recordRow.To<int>("IntColumn");
 
-    //    // Assert
-    //    Assert.AreEqual(result1, result2);
-    //    Assert.AreEqual(100, result1);
-    //}
+        // Assert
+        Assert.AreEqual(result1, result2);
+        Assert.AreEqual(100, result1);
+    }
 
 
-
-    /// <summary>
-    /// 调用 <see cref="RecordRow.Set{T}(string, T)"/> 更新已存在的整型列时，应写入成功。
-    /// </summary>
-    //[TestMethod]
-    //public void Set_TypedColumn_ShouldUpdateValue()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
-
-    //    // Act
-    //    recordRow.Set("IntColumn", 999);
-
-    //    // Assert
-    //    Assert.AreEqual(999, recordRow.Field<int>("IntColumn"));
-    //}
 
     /// <summary>
-    /// 调用 <see cref="RecordRow.Set{T}(string, T)"/> 更新已存在的字符串列时，应写入成功。
+    /// 使用索引器更新已存在的整型列时，应写入成功。
     /// </summary>
-    //[TestMethod]
-    //public void Set_StringColumn_ShouldUpdateValue()
-    //{
-    //    // Arrange
-    //    var (record, _, stringColumn, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 1);
+    [TestMethod]
+    public void Set_TypedColumn_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    recordRow.Set("StringColumn", "NewValue");
+        // Act
+        recordRow["IntColumn"] = 999;
 
-    //    // Assert
-    //    Assert.AreEqual("NewValue", recordRow.Field<string>("StringColumn"));
-    //}
+        // Assert
+        Assert.AreEqual(999, recordRow.To<int>("IntColumn"));
+    }
+
+    /// <summary>
+    /// 使用索引器更新已存在的字符串列时，应写入成功。
+    /// </summary>
+    [TestMethod]
+    public void Set_StringColumn_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
+
+        // Act
+        recordRow["StringColumn"] = "NewValue";
+
+        // Assert
+        Assert.AreEqual("NewValue", recordRow.To<string>("StringColumn"));
+    }
 
     /// <summary>
     /// 当列不存在时，<see cref="RecordRow.Set{T}(string, T)"/> 应自动创建对应列。
     /// </summary>
-    //[TestMethod]
-    //public void Set_ColumnNotExists_ShouldAutoCreateColumn()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
-    //    int beforeCount = record.Columns.Count;
+    [TestMethod]
+    public void Set_ColumnNotExists_ShouldAutoCreateColumn()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+        int beforeCount = record.Columns.Count;
 
-    //    // Act
-    //    recordRow.Set("NewColumn", 12345);
+        // Act
+        recordRow["NewColumn"] = 12345;
 
-    //    // Assert
-    //    Assert.AreEqual(beforeCount + 1, record.Columns.Count);
-    //    var col = record.Columns.Get("NewColumn");
-    //    Assert.AreEqual(typeof(int), col.Type);
-    //    Assert.AreEqual(12345, recordRow.Field<int>("NewColumn"));
-    //}
+        // Assert
+        Assert.AreEqual(beforeCount + 1, record.Columns.Count);
+        var col = record.Columns.Find("NewColumn");
+        Assert.IsNotNull(col);
+        Assert.AreEqual(typeof(int), col.Type);
+        Assert.AreEqual(12345, recordRow.To<int>("NewColumn"));
+    }
 
     /// <summary>
     /// 写入后再读取时，应得到与写入一致的值。
     /// </summary>
-    //[TestMethod]
-    //public void Set_ThenReadViaIndexer_ShouldBeConsistent()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void Set_ThenReadViaIndexer_ShouldBeConsistent()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    recordRow.Set("IntColumn", 42);
+        // Act
+        recordRow["IntColumn"] = 42;
 
-    //    // Assert
-    //    Assert.AreEqual(42, recordRow.Field<int>("IntColumn"));
-    //}
+        // Assert
+        Assert.AreEqual(42, recordRow.To<int>("IntColumn"));
+    }
 
 
 
@@ -510,20 +511,20 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 按成员名写入时，应更新底层记录值。
     /// </summary>
-    //[TestMethod]
-    //public void Dynamic_SetMember_ShouldUpdateValue()
-    //{
-    //    // Arrange
-    //    var (record, _, stringColumn, _) = CreateTestRecord();
-    //    dynamic row = new RecordRow(record, 0);
+    [TestMethod]
+    public void Dynamic_SetMember_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
-    //    // Act
-    //    row.StringColumn = "DynValue";
+        // Act
+        row.StringColumn = "DynValue";
 
-    //    // Assert
-    //    var recordRow = new RecordRow(record, 0);
-    //    Assert.AreEqual("DynValue", recordRow.Field<string>("StringColumn"));
-    //}
+        // Assert
+        var recordRow = new RecordRow(record, 0);
+        Assert.AreEqual("DynValue", recordRow.To<string>("StringColumn"));
+    }
 
     /// <summary>
     /// dynamic 按索引器读取时，应返回正确值。
@@ -545,20 +546,20 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 按索引器写入时，应更新底层记录值。
     /// </summary>
-    //[TestMethod]
-    //public void Dynamic_SetIndex_ShouldUpdateValue()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, _) = CreateTestRecord();
-    //    dynamic row = new RecordRow(record, 0);
+    [TestMethod]
+    public void Dynamic_SetIndex_ShouldUpdateValue()
+    {
+        // Arrange
+        var (record, intColumn, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
-    //    // Act - dynamic 索引写入
-    //    row["IntColumn"] = 777;
+        // Act - dynamic 索引写入
+        row["IntColumn"] = 777;
 
-    //    // Assert
-    //    var recordRow = new RecordRow(record, 0);
-    //    Assert.AreEqual(777, recordRow.Field<int>("IntColumn"));
-    //}
+        // Assert
+        var recordRow = new RecordRow(record, 0);
+        Assert.AreEqual(777, recordRow.To<int>("IntColumn"));
+    }
 
     /// <summary>
     /// dynamic 读取不存在的成员时，应返回 null。
@@ -594,53 +595,53 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 成员读取结果应与显式调用字段读取方法一致。
     /// </summary>
-    //[TestMethod]
-    //public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
-    //{
-    //    // Arrange
-    //    var (record, intColumn, _, boolColumn) = CreateTestRecord();
-    //    dynamic row = new RecordRow(record, 0);
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
+    {
+        // Arrange
+        var (record, intColumn, _, boolColumn) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act & Assert
-    //    Assert.AreEqual(recordRow.Field<int>("IntColumn"), (int)row.IntColumn!);
-    //    Assert.AreEqual(recordRow.Field<bool>("BoolColumn"), (bool)row.BoolColumn!);
-    //}
-
-    /// <summary>
-    /// <see cref="RecordRow.Field(string)"/> 按列名读取已存在列时，应返回对应对象值。
-    /// </summary>
-    //[TestMethod]
-    //public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
-
-    //    // Act
-    //    var result = recordRow.Field("IntColumn");
-
-    //    // Assert
-    //    Assert.IsNotNull(result);
-    //    Assert.AreEqual(100, (int)result!);
-    //}
+        // Act & Assert
+        Assert.AreEqual(recordRow.To<int>("IntColumn"), (int)row.IntColumn!);
+        Assert.AreEqual(recordRow.To<bool>("BoolColumn"), (bool)row.BoolColumn!);
+    }
 
     /// <summary>
-    /// <see cref="RecordRow.Field(string)"/> 按列名读取不存在列时，应返回 null。
+    /// 索引器按列名读取已存在列时，应返回对应对象值。
     /// </summary>
-    //[TestMethod]
-    //public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
-    //{
-    //    // Arrange
-    //    var (record, _, _, _) = CreateTestRecord();
-    //    var recordRow = new RecordRow(record, 0);
+    [TestMethod]
+    public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
-    //    // Act
-    //    var result = recordRow.Field("NonExistentColumn");
+        // Act
+        var result = recordRow["IntColumn"];
 
-    //    // Assert
-    //    Assert.IsNull(result);
-    //}
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(100, (int)result!);
+    }
+
+    /// <summary>
+    /// 按列名读取不存在列时，索引器应返回 null。
+    /// </summary>
+    [TestMethod]
+    public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
+    {
+        // Arrange
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
+
+        // Act
+        var result = recordRow["NonExistentColumn"];
+
+        // Assert
+        Assert.IsNull(result);
+    }
 
     /// <summary>
     /// <see cref="RecordRow.ToDictionary"/> 应返回当前行的全部列与对应值。

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -24,12 +24,12 @@ public class RecordRowTests
         var row1 = record.AddRow();
         var row2 = record.AddRow();
 
-        intColumn.Set(0, 100);
-        intColumn.Set(1, 200);
-        stringColumn.Set(0, "Test1");
-        stringColumn.Set(1, "Test2");
-        boolColumn.Set(0, true);
-        boolColumn.Set(1, false);
+        intColumn.SetField(0, 100);
+        intColumn.SetField(1, 200);
+        stringColumn.SetField(0, "Test1");
+        stringColumn.SetField(1, "Test2");
+        boolColumn.SetField(0, true);
+        boolColumn.SetField(1, false);
 
         return (record, intColumn, stringColumn, boolColumn);
     }
@@ -672,7 +672,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
-        nullableColumn.Set(0, null);
+        nullableColumn.SetField(0, null);
         var recordRow = new RecordRow(record, 0);
 
         // Act
@@ -711,7 +711,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
-        nullableColumn.Set(0, null);
+        nullableColumn.SetField(0, null);
         var recordRow = new RecordRow(record, 0);
 
         // Act

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -149,344 +149,344 @@ public class RecordRowTests
     /// <summary>
     /// 按列名读取已存在的布尔列时，应返回正确值。
     /// </summary>
-    [TestMethod]
-    public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
-    {
-        // Arrange
-        var (record, _, _, boolColumn) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
+    //{
+    //    // Arrange
+    //    var (record, _, _, boolColumn) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<Boolean>("BoolColumn");
+    //    // Act
+    //    var result = recordRow.Field<Boolean>("BoolColumn");
 
-        // Assert
-        Assert.AreEqual(true, result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(true, result);
+    //}
 
     /// <summary>
     /// 按列名读取不存在的布尔列时，应返回默认值。
     /// </summary>
-    [TestMethod]
-    public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<Boolean>("NonExistentColumn");
+    //    // Act
+    //    var result = recordRow.Field<Boolean>("NonExistentColumn");
 
-        // Assert
-        Assert.AreEqual(default(bool), result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(default(bool), result);
+    //}
 
     /// <summary>
     /// 按列名读取已存在的字符串列时，应返回正确值。
     /// </summary>
-    [TestMethod]
-    public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
-    {
-        // Arrange
-        var (record, _, stringColumn, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 1);
+    //[TestMethod]
+    //public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
+    //{
+    //    // Arrange
+    //    var (record, _, stringColumn, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 1);
 
-        // Act
-        var result = recordRow.Field<String>("StringColumn");
+    //    // Act
+    //    var result = recordRow.Field<String>("StringColumn");
 
-        // Assert
-        Assert.AreEqual("Test2", result);
-    }
+    //    // Assert
+    //    Assert.AreEqual("Test2", result);
+    //}
 
     /// <summary>
     /// 按列名读取不存在的字符串列时，应返回默认值。
     /// </summary>
-    [TestMethod]
-    public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<String>("NonExistentColumn");
+    //    // Act
+    //    var result = recordRow.Field<String>("NonExistentColumn");
 
-        // Assert
-        Assert.AreEqual(default(string), result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(default(string), result);
+    //}
 
     /// <summary>
     /// 按列名读取已存在的整型列时，应返回正确值。
     /// </summary>
-    [TestMethod]
-    public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
-    {
-        // Arrange
-        var (record, intColumn, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 1);
+    //[TestMethod]
+    //public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 1);
 
-        // Act
-        var result = recordRow.Field<Int32>("IntColumn");
+    //    // Act
+    //    var result = recordRow.Field<Int32>("IntColumn");
 
-        // Assert
-        Assert.AreEqual(200, result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(200, result);
+    //}
 
     /// <summary>
     /// 按列名读取不存在的整型列时，应返回默认值。
     /// </summary>
-    [TestMethod]
-    public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<Int32>("NonExistentColumn");
+    //    // Act
+    //    var result = recordRow.Field<Int32>("NonExistentColumn");
 
-        // Assert
-        Assert.AreEqual(default(int), result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(default(int), result);
+    //}
 
     /// <summary>
     /// 泛型按列名读取已存在列时，应返回正确值。
     /// </summary>
-    [TestMethod]
-    public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
-    {
-        // Arrange
-        var (record, intColumn, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<int>("IntColumn");
+    //    // Act
+    //    var result = recordRow.Field<int>("IntColumn");
 
-        // Assert
-        Assert.AreEqual(100, result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(100, result);
+    //}
 
     /// <summary>
     /// 泛型按列名读取不存在列时，应返回默认值。
     /// </summary>
-    [TestMethod]
-    public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<int>("NonExistentColumn");
+    //    // Act
+    //    var result = recordRow.Field<int>("NonExistentColumn");
 
-        // Assert
-        Assert.AreEqual(default(int), result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(default(int), result);
+    //}
 
     /// <summary>
     /// 应支持按列名读取字节值。
     /// </summary>
-    [TestMethod]
-    public void GetByte_ByName_ShouldWork()
-    {
-        // Arrange
-        var record = new Record("TestTable", 1);
-        var byteColumn = record.Columns.Add<byte>("ByteColumn");
-        var row = record.AddRow();
-        byteColumn.Set(row.Row, 255);
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetByte_ByName_ShouldWork()
+    //{
+    //    // Arrange
+    //    var record = new Record("TestTable", 1);
+    //    var byteColumn = record.Columns.Add<byte>("ByteColumn");
+    //    var row = record.AddRow();
+    //    byteColumn.Set(row.Row, 255);
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<Byte>("ByteColumn");
+    //    // Act
+    //    var result = recordRow.Field<Byte>("ByteColumn");
 
-        // Assert
-        Assert.AreEqual((byte)255, result);
-    }
+    //    // Assert
+    //    Assert.AreEqual((byte)255, result);
+    //}
 
     /// <summary>
     /// 应支持按列名读取双精度浮点值。
     /// </summary>
-    [TestMethod]
-    public void GetDouble_ByName_ShouldWork()
-    {
-        // Arrange
-        var record = new Record("TestTable", 1);
-        var doubleColumn = record.Columns.Add<double>("DoubleColumn");
-        var row = record.AddRow();
-        doubleColumn.Set(row.Row, 3.14159);
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetDouble_ByName_ShouldWork()
+    //{
+    //    // Arrange
+    //    var record = new Record("TestTable", 1);
+    //    var doubleColumn = record.Columns.Add<double>("DoubleColumn");
+    //    var row = record.AddRow();
+    //    doubleColumn.Set(row.Row, 3.14159);
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<Double>("DoubleColumn");
+    //    // Act
+    //    var result = recordRow.Field<Double>("DoubleColumn");
 
-        // Assert
-        Assert.AreEqual(3.14159, result, 0.00001);
-    }
+    //    // Assert
+    //    Assert.AreEqual(3.14159, result, 0.00001);
+    //}
 
     /// <summary>
     /// 应支持按列名读取日期时间值。
     /// </summary>
-    [TestMethod]
-    public void GetDateTime_ByName_ShouldWork()
-    {
-        // Arrange
-        var record = new Record("TestTable", 1);
-        var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
-        var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
-        var row = record.AddRow();
-        dateTimeColumn.Set(row.Row, testDate);
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetDateTime_ByName_ShouldWork()
+    //{
+    //    // Arrange
+    //    var record = new Record("TestTable", 1);
+    //    var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
+    //    var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
+    //    var row = record.AddRow();
+    //    dateTimeColumn.Set(row.Row, testDate);
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field<DateTime>("DateTimeColumn");
+    //    // Act
+    //    var result = recordRow.Field<DateTime>("DateTimeColumn");
 
-        // Assert
-        Assert.AreEqual(testDate, result);
-    }
+    //    // Assert
+    //    Assert.AreEqual(testDate, result);
+    //}
 
 
 
     /// <summary>
     /// 当列名为空时，各类型读取方法应返回默认值。
     /// </summary>
-    [TestMethod]
-    public void GetMethods_EmptyColumnName_ShouldReturnDefault()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetMethods_EmptyColumnName_ShouldReturnDefault()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act & Assert
-        Assert.AreEqual(default(int), recordRow.Field<Int32>(""));
-        Assert.AreEqual(default(string), recordRow.Field<String>(""));
-        Assert.AreEqual(default(bool), recordRow.Field<Boolean>(""));
-    }
+    //    // Act & Assert
+    //    Assert.AreEqual(default(int), recordRow.Field<Int32>(""));
+    //    Assert.AreEqual(default(string), recordRow.Field<String>(""));
+    //    Assert.AreEqual(default(bool), recordRow.Field<Boolean>(""));
+    //}
 
     /// <summary>
     /// 在多行数据场景下，应能读取到各行的正确值。
     /// </summary>
-    [TestMethod]
-    public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
-    {
-        // Arrange
-        var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
+    //[TestMethod]
+    //public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
 
-        var row3 = record.AddRow();
-        intColumn.Set(row3.Row, 300);
-        stringColumn.Set(row3.Row, "Test3");
-        boolColumn.Set(row3.Row, true);
+    //    var row3 = record.AddRow();
+    //    intColumn.Set(row3.Row, 300);
+    //    stringColumn.Set(row3.Row, "Test3");
+    //    boolColumn.Set(row3.Row, true);
 
-        var recordRow0 = new RecordRow(record, 0);
-        var recordRow1 = new RecordRow(record, 1);
-        var recordRow2 = new RecordRow(record, 2);
+    //    var recordRow0 = new RecordRow(record, 0);
+    //    var recordRow1 = new RecordRow(record, 1);
+    //    var recordRow2 = new RecordRow(record, 2);
 
-        // Act & Assert
-        Assert.AreEqual(100, recordRow0.Field<Int32>("IntColumn"));
-        Assert.AreEqual(200, recordRow1.Field<Int32>("IntColumn"));
-        Assert.AreEqual(300, recordRow2.Field<Int32>("IntColumn"));
+    //    // Act & Assert
+    //    Assert.AreEqual(100, recordRow0.Field<Int32>("IntColumn"));
+    //    Assert.AreEqual(200, recordRow1.Field<Int32>("IntColumn"));
+    //    Assert.AreEqual(300, recordRow2.Field<Int32>("IntColumn"));
 
-        Assert.AreEqual("Test1", recordRow0.Field<String>("StringColumn"));
-        Assert.AreEqual("Test2", recordRow1.Field<String>("StringColumn"));
-        Assert.AreEqual("Test3", recordRow2.Field<String>("StringColumn"));
+    //    Assert.AreEqual("Test1", recordRow0.Field<String>("StringColumn"));
+    //    Assert.AreEqual("Test2", recordRow1.Field<String>("StringColumn"));
+    //    Assert.AreEqual("Test3", recordRow2.Field<String>("StringColumn"));
 
-        Assert.AreEqual(true, recordRow0.Field<Boolean>("BoolColumn"));
-        Assert.AreEqual(false, recordRow1.Field<Boolean>("BoolColumn"));
-        Assert.AreEqual(true, recordRow2.Field<Boolean>("BoolColumn"));
-    }
+    //    Assert.AreEqual(true, recordRow0.Field<Boolean>("BoolColumn"));
+    //    Assert.AreEqual(false, recordRow1.Field<Boolean>("BoolColumn"));
+    //    Assert.AreEqual(true, recordRow2.Field<Boolean>("BoolColumn"));
+    //}
 
 
 
     /// <summary>
     /// 多次访问同一字段时，应保持结果一致。
     /// </summary>
-    [TestMethod]
-    public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result1 = recordRow.Field<Int32>("IntColumn");
-        var result2 = recordRow.Field<Int32>("IntColumn");
+    //    // Act
+    //    var result1 = recordRow.Field<Int32>("IntColumn");
+    //    var result2 = recordRow.Field<Int32>("IntColumn");
 
-        // Assert
-        Assert.AreEqual(result1, result2);
-        Assert.AreEqual(100, result1);
-    }
+    //    // Assert
+    //    Assert.AreEqual(result1, result2);
+    //    Assert.AreEqual(100, result1);
+    //}
 
 
 
     /// <summary>
     /// 调用 <see cref="RecordRow.Set{T}(string, T)"/> 更新已存在的整型列时，应写入成功。
     /// </summary>
-    [TestMethod]
-    public void Set_TypedColumn_ShouldUpdateValue()
-    {
-        // Arrange
-        var (record, intColumn, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void Set_TypedColumn_ShouldUpdateValue()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        recordRow.Set("IntColumn", 999);
+    //    // Act
+    //    recordRow.Set("IntColumn", 999);
 
-        // Assert
-        Assert.AreEqual(999, recordRow.Field<int>("IntColumn"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(999, recordRow.Field<int>("IntColumn"));
+    //}
 
     /// <summary>
     /// 调用 <see cref="RecordRow.Set{T}(string, T)"/> 更新已存在的字符串列时，应写入成功。
     /// </summary>
-    [TestMethod]
-    public void Set_StringColumn_ShouldUpdateValue()
-    {
-        // Arrange
-        var (record, _, stringColumn, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 1);
+    //[TestMethod]
+    //public void Set_StringColumn_ShouldUpdateValue()
+    //{
+    //    // Arrange
+    //    var (record, _, stringColumn, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 1);
 
-        // Act
-        recordRow.Set("StringColumn", "NewValue");
+    //    // Act
+    //    recordRow.Set("StringColumn", "NewValue");
 
-        // Assert
-        Assert.AreEqual("NewValue", recordRow.Field<string>("StringColumn"));
-    }
+    //    // Assert
+    //    Assert.AreEqual("NewValue", recordRow.Field<string>("StringColumn"));
+    //}
 
     /// <summary>
     /// 当列不存在时，<see cref="RecordRow.Set{T}(string, T)"/> 应自动创建对应列。
     /// </summary>
-    [TestMethod]
-    public void Set_ColumnNotExists_ShouldAutoCreateColumn()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
-        int beforeCount = record.Columns.Count;
+    //[TestMethod]
+    //public void Set_ColumnNotExists_ShouldAutoCreateColumn()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
+    //    int beforeCount = record.Columns.Count;
 
-        // Act
-        recordRow.Set("NewColumn", 12345);
+    //    // Act
+    //    recordRow.Set("NewColumn", 12345);
 
-        // Assert
-        Assert.AreEqual(beforeCount + 1, record.Columns.Count);
-        var col = record.Columns.Get("NewColumn");
-        Assert.AreEqual(typeof(int), col.Type);
-        Assert.AreEqual(12345, recordRow.Field<int>("NewColumn"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(beforeCount + 1, record.Columns.Count);
+    //    var col = record.Columns.Get("NewColumn");
+    //    Assert.AreEqual(typeof(int), col.Type);
+    //    Assert.AreEqual(12345, recordRow.Field<int>("NewColumn"));
+    //}
 
     /// <summary>
     /// 写入后再读取时，应得到与写入一致的值。
     /// </summary>
-    [TestMethod]
-    public void Set_ThenReadViaIndexer_ShouldBeConsistent()
-    {
-        // Arrange
-        var (record, intColumn, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void Set_ThenReadViaIndexer_ShouldBeConsistent()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        recordRow.Set("IntColumn", 42);
+    //    // Act
+    //    recordRow.Set("IntColumn", 42);
 
-        // Assert
-        Assert.AreEqual(42, recordRow.Field<int>("IntColumn"));
-    }
+    //    // Assert
+    //    Assert.AreEqual(42, recordRow.Field<int>("IntColumn"));
+    //}
 
 
 
@@ -510,20 +510,20 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 按成员名写入时，应更新底层记录值。
     /// </summary>
-    [TestMethod]
-    public void Dynamic_SetMember_ShouldUpdateValue()
-    {
-        // Arrange
-        var (record, _, stringColumn, _) = CreateTestRecord();
-        dynamic row = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void Dynamic_SetMember_ShouldUpdateValue()
+    //{
+    //    // Arrange
+    //    var (record, _, stringColumn, _) = CreateTestRecord();
+    //    dynamic row = new RecordRow(record, 0);
 
-        // Act
-        row.StringColumn = "DynValue";
+    //    // Act
+    //    row.StringColumn = "DynValue";
 
-        // Assert
-        var recordRow = new RecordRow(record, 0);
-        Assert.AreEqual("DynValue", recordRow.Field<string>("StringColumn"));
-    }
+    //    // Assert
+    //    var recordRow = new RecordRow(record, 0);
+    //    Assert.AreEqual("DynValue", recordRow.Field<string>("StringColumn"));
+    //}
 
     /// <summary>
     /// dynamic 按索引器读取时，应返回正确值。
@@ -545,20 +545,20 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 按索引器写入时，应更新底层记录值。
     /// </summary>
-    [TestMethod]
-    public void Dynamic_SetIndex_ShouldUpdateValue()
-    {
-        // Arrange
-        var (record, intColumn, _, _) = CreateTestRecord();
-        dynamic row = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void Dynamic_SetIndex_ShouldUpdateValue()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, _) = CreateTestRecord();
+    //    dynamic row = new RecordRow(record, 0);
 
-        // Act - dynamic 索引写入
-        row["IntColumn"] = 777;
+    //    // Act - dynamic 索引写入
+    //    row["IntColumn"] = 777;
 
-        // Assert
-        var recordRow = new RecordRow(record, 0);
-        Assert.AreEqual(777, recordRow.Field<int>("IntColumn"));
-    }
+    //    // Assert
+    //    var recordRow = new RecordRow(record, 0);
+    //    Assert.AreEqual(777, recordRow.Field<int>("IntColumn"));
+    //}
 
     /// <summary>
     /// dynamic 读取不存在的成员时，应返回 null。
@@ -594,53 +594,53 @@ public class RecordRowTests
     /// <summary>
     /// dynamic 成员读取结果应与显式调用字段读取方法一致。
     /// </summary>
-    [TestMethod]
-    public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
-    {
-        // Arrange
-        var (record, intColumn, _, boolColumn) = CreateTestRecord();
-        dynamic row = new RecordRow(record, 0);
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
+    //{
+    //    // Arrange
+    //    var (record, intColumn, _, boolColumn) = CreateTestRecord();
+    //    dynamic row = new RecordRow(record, 0);
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act & Assert
-        Assert.AreEqual(recordRow.Field<int>("IntColumn"), (int)row.IntColumn!);
-        Assert.AreEqual(recordRow.Field<bool>("BoolColumn"), (bool)row.BoolColumn!);
-    }
+    //    // Act & Assert
+    //    Assert.AreEqual(recordRow.Field<int>("IntColumn"), (int)row.IntColumn!);
+    //    Assert.AreEqual(recordRow.Field<bool>("BoolColumn"), (bool)row.BoolColumn!);
+    //}
 
     /// <summary>
     /// <see cref="RecordRow.Field(string)"/> 按列名读取已存在列时，应返回对应对象值。
     /// </summary>
-    [TestMethod]
-    public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field("IntColumn");
+    //    // Act
+    //    var result = recordRow.Field("IntColumn");
 
-        // Assert
-        Assert.IsNotNull(result);
-        Assert.AreEqual(100, (int)result!);
-    }
+    //    // Assert
+    //    Assert.IsNotNull(result);
+    //    Assert.AreEqual(100, (int)result!);
+    //}
 
     /// <summary>
     /// <see cref="RecordRow.Field(string)"/> 按列名读取不存在列时，应返回 null。
     /// </summary>
-    [TestMethod]
-    public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
-    {
-        // Arrange
-        var (record, _, _, _) = CreateTestRecord();
-        var recordRow = new RecordRow(record, 0);
+    //[TestMethod]
+    //public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
+    //{
+    //    // Arrange
+    //    var (record, _, _, _) = CreateTestRecord();
+    //    var recordRow = new RecordRow(record, 0);
 
-        // Act
-        var result = recordRow.Field("NonExistentColumn");
+    //    // Act
+    //    var result = recordRow.Field("NonExistentColumn");
 
-        // Assert
-        Assert.IsNull(result);
-    }
+    //    // Assert
+    //    Assert.IsNull(result);
+    //}
 
     /// <summary>
     /// <see cref="RecordRow.ToDictionary"/> 应返回当前行的全部列与对应值。

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -24,12 +24,12 @@ public class RecordRowTests
         var row1 = record.AddRow();
         var row2 = record.AddRow();
 
-        intColumn.SetField(0, 100);
-        intColumn.SetField(1, 200);
-        stringColumn.SetField(0, "Test1");
-        stringColumn.SetField(1, "Test2");
-        boolColumn.SetField(0, true);
-        boolColumn.SetField(1, false);
+        intColumn.SetValue(0, 100);
+        intColumn.SetValue(1, 200);
+        stringColumn.SetValue(0, "Test1");
+        stringColumn.SetValue(1, "Test2");
+        boolColumn.SetValue(0, true);
+        boolColumn.SetValue(1, false);
 
         return (record, intColumn, stringColumn, boolColumn);
     }
@@ -673,7 +673,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
-        nullableColumn.SetField(0, null);
+        nullableColumn.SetValue(0, null);
         var recordRow = new RecordRow(record, 0);
 
         // Act
@@ -712,7 +712,7 @@ public class RecordRowTests
         var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
-        nullableColumn.SetField(0, null);
+        nullableColumn.SetValue(0, null);
         var recordRow = new RecordRow(record, 0);
 
         // Act

--- a/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
@@ -17,9 +17,9 @@ public class RecordSchemaOperationsTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.Set(row.Row, i + 1);
-            nameCol.Set(row.Row, $"Person{i + 1}");
-            ageCol.Set(row.Row, 20 + i);
+            idCol.SetField(row.Row, i + 1);
+            nameCol.SetField(row.Row, $"Person{i + 1}");
+            ageCol.SetField(row.Row, 20 + i);
         }
         return record;
     }
@@ -35,7 +35,7 @@ public class RecordSchemaOperationsTests
 
         Assert.IsNotNull(record.Columns.Find("FullName"));
         Assert.IsNull(record.Columns.Find("Name"));
-        Assert.AreEqual("Person1", record.Columns.Find("FullName")!.GetValue(0));
+        Assert.AreEqual("Person1", record.Columns.Find("FullName")!.Get(0));
     }
 
     [TestMethod]
@@ -81,9 +81,9 @@ public class RecordSchemaOperationsTests
 
         var col = record.Columns.Find("RecordId");
         Assert.IsNotNull(col);
-        Assert.AreEqual(1, col!.GetValue(0));
-        Assert.AreEqual(2, col.GetValue(1));
-        Assert.AreEqual(3, col.GetValue(2));
+        Assert.AreEqual(1, col!.Get(0));
+        Assert.AreEqual(2, col.Get(1));
+        Assert.AreEqual(3, col.Get(2));
     }
 
     #endregion
@@ -110,9 +110,9 @@ public class RecordSchemaOperationsTests
         record.CastColumn("Id", typeof(string));
 
         var col = record.Columns.Find("Id");
-        Assert.AreEqual("1", col!.GetValue(0));
-        Assert.AreEqual("2", col.GetValue(1));
-        Assert.AreEqual("3", col.GetValue(2));
+        Assert.AreEqual("1", col!.Get(0));
+        Assert.AreEqual("2", col.Get(1));
+        Assert.AreEqual("3", col.Get(2));
     }
 
     [TestMethod]
@@ -231,9 +231,9 @@ public class RecordSchemaOperationsTests
 
         Assert.AreEqual(3, clone.Columns.Count);
         Assert.AreEqual(3, clone.Count);
-        Assert.AreEqual(1, clone.Columns[0].GetValue(0));
-        Assert.AreEqual("Person2", clone.Columns[1].GetValue(1));
-        Assert.AreEqual(22, clone.Columns[2].GetValue(2));
+        Assert.AreEqual(1, clone.Columns[0].Get(0));
+        Assert.AreEqual("Person2", clone.Columns[1].Get(1));
+        Assert.AreEqual(22, clone.Columns[2].Get(2));
     }
 
     [TestMethod]
@@ -242,10 +242,10 @@ public class RecordSchemaOperationsTests
         var record = CreateTestRecord();
 
         var clone = record.Clone();
-        clone.Columns[0].SetValue(0, 999);
+        clone.Columns[0].Set(0, 999);
 
-        Assert.AreEqual(1, record.Columns[0].GetValue(0));
-        Assert.AreEqual(999, clone.Columns[0].GetValue(0));
+        Assert.AreEqual(1, record.Columns[0].Get(0));
+        Assert.AreEqual(999, clone.Columns[0].Get(0));
     }
 
     [TestMethod]

--- a/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
@@ -17,9 +17,9 @@ public class RecordSchemaOperationsTests
         for (int i = 0; i < 3; i++)
         {
             var row = record.AddRow();
-            idCol.SetField(row.Row, i + 1);
-            nameCol.SetField(row.Row, $"Person{i + 1}");
-            ageCol.SetField(row.Row, 20 + i);
+            idCol.SetValue(row.Row, i + 1);
+            nameCol.SetValue(row.Row, $"Person{i + 1}");
+            ageCol.SetValue(row.Row, 20 + i);
         }
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -22,12 +22,12 @@ public class RecordSerializationTests
         record.MaxCount = 50;
 
         var row1 = record.AddRow();
-        idCol.SetField(row1.Row, 1);
-        nameCol.SetField(row1.Row, "Order-1");
+        idCol.SetValue(row1.Row, 1);
+        nameCol.SetValue(row1.Row, "Order-1");
 
         var row2 = record.AddRow();
-        idCol.SetField(row2.Row, 2);
-        nameCol.SetField(row2.Row, "Order-2");
+        idCol.SetValue(row2.Row, 2);
+        nameCol.SetValue(row2.Row, "Order-2");
 
         return record;
     }
@@ -94,12 +94,12 @@ public class RecordSerializationTests
         var record = new Record("Binary", 1);
         var col = record.Columns.Add<byte[]>("Data");
         var row = record.AddRow();
-        col.SetField(row.Row, new byte[] { 1, 2, 3, 4, 5 });
+        col.SetValue(row.Row, new byte[] { 1, 2, 3, 4, 5 });
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);
 
-        var data = deserialized.Columns.Find<byte[]>("Data")!.Field(0);
+        var data = deserialized.Columns.Find<byte[]>("Data")!.GetValue(0);
         CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, data);
     }
 
@@ -127,27 +127,27 @@ public class RecordSerializationTests
         record.Columns.Add<Guid>("Guid");
 
         var r = record.AddRow();
-        record.Columns.Find<bool>("Bool")!.SetField(r.Row, true);
-        record.Columns.Find<sbyte>("SByte")!.SetField(r.Row, -1);
-        record.Columns.Find<short>("Short")!.SetField(r.Row, short.MaxValue);
-        record.Columns.Find<int>("Int")!.SetField(r.Row, 42);
-        record.Columns.Find<long>("Long")!.SetField(r.Row, long.MaxValue);
-        record.Columns.Find<byte>("Byte")!.SetField(r.Row, 255);
-        record.Columns.Find<ushort>("UShort")!.SetField(r.Row, ushort.MaxValue);
-        record.Columns.Find<uint>("UInt")!.SetField(r.Row, uint.MaxValue);
-        record.Columns.Find<ulong>("ULong")!.SetField(r.Row, ulong.MaxValue);
-        record.Columns.Find<float>("Float")!.SetField(r.Row, 3.14f);
-        record.Columns.Find<double>("Double")!.SetField(r.Row, 3.14159265);
-        record.Columns.Find<decimal>("Decimal")!.SetField(r.Row, 99.99m);
-        record.Columns.Find<char>("Char")!.SetField(r.Row, 'A');
-        record.Columns.Find<string>("String")!.SetField(r.Row, "Hello");
+        record.Columns.Find<bool>("Bool")!.SetValue(r.Row, true);
+        record.Columns.Find<sbyte>("SByte")!.SetValue(r.Row, -1);
+        record.Columns.Find<short>("Short")!.SetValue(r.Row, short.MaxValue);
+        record.Columns.Find<int>("Int")!.SetValue(r.Row, 42);
+        record.Columns.Find<long>("Long")!.SetValue(r.Row, long.MaxValue);
+        record.Columns.Find<byte>("Byte")!.SetValue(r.Row, 255);
+        record.Columns.Find<ushort>("UShort")!.SetValue(r.Row, ushort.MaxValue);
+        record.Columns.Find<uint>("UInt")!.SetValue(r.Row, uint.MaxValue);
+        record.Columns.Find<ulong>("ULong")!.SetValue(r.Row, ulong.MaxValue);
+        record.Columns.Find<float>("Float")!.SetValue(r.Row, 3.14f);
+        record.Columns.Find<double>("Double")!.SetValue(r.Row, 3.14159265);
+        record.Columns.Find<decimal>("Decimal")!.SetValue(r.Row, 99.99m);
+        record.Columns.Find<char>("Char")!.SetValue(r.Row, 'A');
+        record.Columns.Find<string>("String")!.SetValue(r.Row, "Hello");
         var dt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
-        record.Columns.Find<DateTime>("DateTime")!.SetField(r.Row, dt);
+        record.Columns.Find<DateTime>("DateTime")!.SetValue(r.Row, dt);
         var dto = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(8));
-        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.SetField(r.Row, dto);
-        record.Columns.Find<TimeSpan>("TimeSpan")!.SetField(r.Row, TimeSpan.FromHours(2.5));
+        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.SetValue(r.Row, dto);
+        record.Columns.Find<TimeSpan>("TimeSpan")!.SetValue(r.Row, TimeSpan.FromHours(2.5));
         var guid = Guid.NewGuid();
-        record.Columns.Find<Guid>("Guid")!.SetField(r.Row, guid);
+        record.Columns.Find<Guid>("Guid")!.SetValue(r.Row, guid);
 
         var bytes = record.ToBytes();
         var d = Record.FromBytes(bytes);
@@ -179,8 +179,8 @@ public class RecordSerializationTests
         var favoriteCol = record.Columns.Add<FavoriteType>("Favorite");
         var nullableFavoriteCol = record.Columns.Add<FavoriteType?>("NullableFavorite");
         var row = record.AddRow();
-        favoriteCol.SetField(row.Row, FavoriteType.Chat);
-        nullableFavoriteCol.SetField(row.Row, FavoriteType.Common);
+        favoriteCol.SetValue(row.Row, FavoriteType.Chat);
+        nullableFavoriteCol.SetValue(row.Row, FavoriteType.Common);
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -22,12 +22,12 @@ public class RecordSerializationTests
         record.MaxCount = 50;
 
         var row1 = record.AddRow();
-        idCol.Set(row1.Row, 1);
-        nameCol.Set(row1.Row, "Order-1");
+        idCol.SetField(row1.Row, 1);
+        nameCol.SetField(row1.Row, "Order-1");
 
         var row2 = record.AddRow();
-        idCol.Set(row2.Row, 2);
-        nameCol.Set(row2.Row, "Order-2");
+        idCol.SetField(row2.Row, 2);
+        nameCol.SetField(row2.Row, "Order-2");
 
         return record;
     }
@@ -84,8 +84,8 @@ public class RecordSerializationTests
         var deserialized = Record.FromBytes(bytes);
 
         Assert.AreEqual(1, deserialized.Count);
-        Assert.IsNull(deserialized.Columns[0].GetValue(0));
-        Assert.IsNull(deserialized.Columns[1].GetValue(0));
+        Assert.IsNull(deserialized.Columns[0].Get(0));
+        Assert.IsNull(deserialized.Columns[1].Get(0));
     }
 
     [TestMethod]
@@ -94,12 +94,12 @@ public class RecordSerializationTests
         var record = new Record("Binary", 1);
         var col = record.Columns.Add<byte[]>("Data");
         var row = record.AddRow();
-        col.Set(row.Row, new byte[] { 1, 2, 3, 4, 5 });
+        col.SetField(row.Row, new byte[] { 1, 2, 3, 4, 5 });
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);
 
-        var data = deserialized.Columns.Find<byte[]>("Data")!.Get(0);
+        var data = deserialized.Columns.Find<byte[]>("Data")!.Field(0);
         CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, data);
     }
 
@@ -127,27 +127,27 @@ public class RecordSerializationTests
         record.Columns.Add<Guid>("Guid");
 
         var r = record.AddRow();
-        record.Columns.Find<bool>("Bool")!.Set(r.Row, true);
-        record.Columns.Find<sbyte>("SByte")!.Set(r.Row, -1);
-        record.Columns.Find<short>("Short")!.Set(r.Row, short.MaxValue);
-        record.Columns.Find<int>("Int")!.Set(r.Row, 42);
-        record.Columns.Find<long>("Long")!.Set(r.Row, long.MaxValue);
-        record.Columns.Find<byte>("Byte")!.Set(r.Row, 255);
-        record.Columns.Find<ushort>("UShort")!.Set(r.Row, ushort.MaxValue);
-        record.Columns.Find<uint>("UInt")!.Set(r.Row, uint.MaxValue);
-        record.Columns.Find<ulong>("ULong")!.Set(r.Row, ulong.MaxValue);
-        record.Columns.Find<float>("Float")!.Set(r.Row, 3.14f);
-        record.Columns.Find<double>("Double")!.Set(r.Row, 3.14159265);
-        record.Columns.Find<decimal>("Decimal")!.Set(r.Row, 99.99m);
-        record.Columns.Find<char>("Char")!.Set(r.Row, 'A');
-        record.Columns.Find<string>("String")!.Set(r.Row, "Hello");
+        record.Columns.Find<bool>("Bool")!.SetField(r.Row, true);
+        record.Columns.Find<sbyte>("SByte")!.SetField(r.Row, -1);
+        record.Columns.Find<short>("Short")!.SetField(r.Row, short.MaxValue);
+        record.Columns.Find<int>("Int")!.SetField(r.Row, 42);
+        record.Columns.Find<long>("Long")!.SetField(r.Row, long.MaxValue);
+        record.Columns.Find<byte>("Byte")!.SetField(r.Row, 255);
+        record.Columns.Find<ushort>("UShort")!.SetField(r.Row, ushort.MaxValue);
+        record.Columns.Find<uint>("UInt")!.SetField(r.Row, uint.MaxValue);
+        record.Columns.Find<ulong>("ULong")!.SetField(r.Row, ulong.MaxValue);
+        record.Columns.Find<float>("Float")!.SetField(r.Row, 3.14f);
+        record.Columns.Find<double>("Double")!.SetField(r.Row, 3.14159265);
+        record.Columns.Find<decimal>("Decimal")!.SetField(r.Row, 99.99m);
+        record.Columns.Find<char>("Char")!.SetField(r.Row, 'A');
+        record.Columns.Find<string>("String")!.SetField(r.Row, "Hello");
         var dt = new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc);
-        record.Columns.Find<DateTime>("DateTime")!.Set(r.Row, dt);
+        record.Columns.Find<DateTime>("DateTime")!.SetField(r.Row, dt);
         var dto = new DateTimeOffset(2024, 1, 15, 10, 30, 0, TimeSpan.FromHours(8));
-        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.Set(r.Row, dto);
-        record.Columns.Find<TimeSpan>("TimeSpan")!.Set(r.Row, TimeSpan.FromHours(2.5));
+        record.Columns.Find<DateTimeOffset>("DateTimeOffset")!.SetField(r.Row, dto);
+        record.Columns.Find<TimeSpan>("TimeSpan")!.SetField(r.Row, TimeSpan.FromHours(2.5));
         var guid = Guid.NewGuid();
-        record.Columns.Find<Guid>("Guid")!.Set(r.Row, guid);
+        record.Columns.Find<Guid>("Guid")!.SetField(r.Row, guid);
 
         var bytes = record.ToBytes();
         var d = Record.FromBytes(bytes);
@@ -179,8 +179,8 @@ public class RecordSerializationTests
         var favoriteCol = record.Columns.Add<FavoriteType>("Favorite");
         var nullableFavoriteCol = record.Columns.Add<FavoriteType?>("NullableFavorite");
         var row = record.AddRow();
-        favoriteCol.Set(row.Row, FavoriteType.Chat);
-        nullableFavoriteCol.Set(row.Row, FavoriteType.Common);
+        favoriteCol.SetField(row.Row, FavoriteType.Chat);
+        nullableFavoriteCol.SetField(row.Row, FavoriteType.Common);
 
         var bytes = record.ToBytes();
         var deserialized = Record.FromBytes(bytes);
@@ -248,13 +248,13 @@ public class RecordSetSerializationTests
         var orders = new Record("Orders", 1);
         orders.Columns.Add<int>("Id");
         var row = orders.AddRow();
-        orders.Columns[0].SetValue(row.Row, 1);
+        orders.Columns[0].Set(row.Row, 1);
         set.Add("Orders", orders);
 
         var customers = new Record("Customers", 1);
         customers.Columns.Add<string>("Name");
         var row2 = customers.AddRow();
-        customers.Columns[0].SetValue(row2.Row, "Alice");
+        customers.Columns[0].Set(row2.Row, "Alice");
         set.Add("Customers", customers);
 
         var bytes = set.ToBytes();

--- a/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
@@ -15,8 +15,8 @@ public class RecordSetTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            idCol.Set(row.Row, i + 1);
-            nameCol.Set(row.Row, $"Item{i + 1}");
+            idCol.SetField(row.Row, i + 1);
+            nameCol.SetField(row.Row, $"Item{i + 1}");
         }
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
@@ -15,8 +15,8 @@ public class RecordSetTests
         for (int i = 0; i < rowCount; i++)
         {
             var row = record.AddRow();
-            idCol.SetField(row.Row, i + 1);
-            nameCol.SetField(row.Row, $"Item{i + 1}");
+            idCol.SetValue(row.Row, i + 1);
+            nameCol.SetValue(row.Row, $"Item{i + 1}");
         }
         return record;
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -32,8 +32,8 @@ public class RecordTests
 
         // Act
         var row = table.AddRow();
-        colId.SetField(row.Row, 1);
-        colName.SetField(row.Row, "Test");
+        colId.SetValue(row.Row, 1);
+        colName.SetValue(row.Row, "Test");
 
         // Assert
         Assert.AreEqual(1, table.Count);
@@ -66,14 +66,14 @@ public class RecordTests
 
         // Act
         var row1 = table.AddRow();
-        colId.SetField(row1.Row, 1);
-        colName.SetField(row1.Row, "Alice");
-        colAge.SetField(row1.Row, 25);
+        colId.SetValue(row1.Row, 1);
+        colName.SetValue(row1.Row, "Alice");
+        colAge.SetValue(row1.Row, 25);
 
         var row2 = table.AddRow();
-        colId.SetField(row2.Row, 2);
-        colName.SetField(row2.Row, "Bob");
-        colAge.SetField(row2.Row, 30);
+        colId.SetValue(row2.Row, 2);
+        colName.SetValue(row2.Row, "Bob");
+        colAge.SetValue(row2.Row, 30);
 
         // Assert
         Assert.AreEqual(2, table.Count);
@@ -98,8 +98,8 @@ public class RecordTests
         table.AddRow();
 
         // Act
-        idCol.SetField(0, 42);
-        nameCol.SetField(0, "TestUser");
+        idCol.SetValue(0, 42);
+        nameCol.SetValue(0, "TestUser");
 
         // Assert
         Assert.AreEqual(42, idCol.To<int>(0));
@@ -114,8 +114,8 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         var colName = table.Columns.Add<string>("Name");
         var row = table.AddRow();
-        colId.SetField(row.Row, 123);
-        colName.SetField(row.Row, "TestValue");
+        colId.SetValue(row.Row, 123);
+        colName.SetValue(row.Row, "TestValue");
 
         // Act & Assert
         Assert.AreEqual(123, colId.To<int>(0));
@@ -168,8 +168,8 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         table.AddRow();
         table.AddRow();
-        colId.SetField(0, 10);
-        colId.SetField(1, 20);
+        colId.SetValue(0, 10);
+        colId.SetValue(1, 20);
 
         // Act
         var rows = table.ToArray();
@@ -204,9 +204,9 @@ public class RecordTests
         table.AddRow();
         table.AddRow();
         table.AddRow();
-        colId.SetField(0, 1);
-        colId.SetField(1, 2);
-        colId.SetField(2, 3);
+        colId.SetValue(0, 1);
+        colId.SetValue(1, 2);
+        colId.SetValue(2, 3);
 
         // Act
         var rows = new List<RecordRow>();
@@ -244,15 +244,15 @@ public class RecordTests
         var testDate = new DateTime(2023, 12, 25);
 
         // Act
-        colBool.SetField(row.Row, true);
-        colByte.SetField(row.Row, (byte)255);
-        colDateTime.SetField(row.Row, testDate);
-        colDecimal.SetField(row.Row, 123.45m);
-        colDouble.SetField(row.Row, 123.456);
-        colInt16.SetField(row.Row, (short)1000);
-        colInt32.SetField(row.Row, 100000);
-        colInt64.SetField(row.Row, 10000000000L);
-        colString.SetField(row.Row, "Hello World");
+        colBool.SetValue(row.Row, true);
+        colByte.SetValue(row.Row, (byte)255);
+        colDateTime.SetValue(row.Row, testDate);
+        colDecimal.SetValue(row.Row, 123.45m);
+        colDouble.SetValue(row.Row, 123.456);
+        colInt16.SetValue(row.Row, (short)1000);
+        colInt32.SetValue(row.Row, 100000);
+        colInt64.SetValue(row.Row, 10000000000L);
+        colString.SetValue(row.Row, "Hello World");
 
         // Assert
         Assert.AreEqual(true, (object?)colBool.Get(row.Row));
@@ -294,13 +294,13 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colInt.SetField(row.Row, 42);
+        colInt.SetValue(row.Row, 42);
         Assert.AreEqual(42, colInt.To<Int32>(row.Row));
 
-        colString.SetField(row.Row, "Test");
+        colString.SetValue(row.Row, "Test");
         Assert.AreEqual("Test", colString.To<String>(row.Row));
 
-        colBool.SetField(row.Row, true);
+        colBool.SetValue(row.Row, true);
         Assert.AreEqual(true, colBool.To<Boolean>(row.Row));
     }
 
@@ -359,7 +359,7 @@ public class RecordTests
         var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         var row = table.AddRow();
-        col.SetField(row.Row, "TestValue");
+        col.SetValue(row.Row, "TestValue");
 
         // Verify data exists
         Assert.AreEqual("TestValue", (object?)col.Get(row.Row));
@@ -415,22 +415,22 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colChar.SetField(row.Row, 'A');
+        colChar.SetValue(row.Row, 'A');
         Assert.AreEqual('A', colChar.To<Char>(row.Row));
 
-        colSByte.SetField(row.Row, (sbyte)-100);
+        colSByte.SetValue(row.Row, (sbyte)-100);
         Assert.AreEqual((sbyte)-100, colSByte.To<SByte>(row.Row));
 
-        colSingle.SetField(row.Row, 3.14f);
+        colSingle.SetValue(row.Row, 3.14f);
         Assert.AreEqual(3.14f, colSingle.To<Single>(row.Row));
 
-        colUInt16.SetField(row.Row, (ushort)65535);
+        colUInt16.SetValue(row.Row, (ushort)65535);
         Assert.AreEqual((ushort)65535, colUInt16.To<UInt16>(row.Row));
 
-        colUInt32.SetField(row.Row, 4294967295u);
+        colUInt32.SetValue(row.Row, 4294967295u);
         Assert.AreEqual(4294967295u, colUInt32.To<UInt32>(row.Row));
 
-        colUInt64.SetField(row.Row, 18446744073709551615ul);
+        colUInt64.SetValue(row.Row, 18446744073709551615ul);
         Assert.AreEqual(18446744073709551615ul, colUInt64.To<UInt64>(row.Row));
     }
 
@@ -492,7 +492,7 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert - Test null value
-        col.SetField(row.Row, (string?)null);
+        col.SetValue(row.Row, (string?)null);
         Assert.IsNull(col.Get(row.Row));
     }
 
@@ -586,11 +586,11 @@ public class RecordTests
         var idCol = record.Columns.Add<Int32>("Id");
         var nameCol = record.Columns.Add<String>("Name");
         record.AddRow();
-        idCol.SetField(0, 1);
-        nameCol.SetField(0, "A");
+        idCol.SetValue(0, 1);
+        nameCol.SetValue(0, "A");
         record.AddRow();
-        idCol.SetField(1, 2);
-        nameCol.SetField(1, "B");
+        idCol.SetValue(1, 2);
+        nameCol.SetValue(1, "B");
 
         var result = record.Delete(0);
 
@@ -606,9 +606,9 @@ public class RecordTests
         var record = new Record("Test", 0);
         var idCol = record.Columns.Add<Int32>("Id");
         record.AddRow();
-        idCol.SetField(0, 1);
+        idCol.SetValue(0, 1);
         record.AddRow();
-        idCol.SetField(1, 2);
+        idCol.SetValue(1, 2);
 
         var result = record.Delete(1);
 
@@ -632,8 +632,8 @@ public class RecordTests
         var nameCol = record.Columns.Add<String>("Name");
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
-        nameCol.SetField(0, "Alice");
-        ageCol.SetField(0, 30);
+        nameCol.SetValue(0, "Alice");
+        ageCol.SetValue(0, 30);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("TestTable"));
@@ -651,10 +651,10 @@ public class RecordTests
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
         record.AddRow();
-        nameCol.SetField(0, "Bob");
-        ageCol.SetField(0, 25);
-        nameCol.SetField(1, "Carol");
-        ageCol.SetField(1, 28);
+        nameCol.SetValue(0, "Bob");
+        ageCol.SetValue(0, 25);
+        nameCol.SetValue(1, "Carol");
+        ageCol.SetValue(1, 28);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("People"));
@@ -675,7 +675,7 @@ public class RecordTests
         record.AddRow();
         record.AddRow();
         string longValue = new string('A', 100);
-        descCol.SetField(0, longValue);
+        descCol.SetValue(0, longValue);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("..") || result.Contains("LongStringTest"));
@@ -770,7 +770,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(-1, true));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(-1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -783,7 +783,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(1, true));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -796,7 +796,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(5, 42));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(5, 42));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -909,21 +909,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all Set methods with invalid index
-        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.SetField(1, true));
-        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.SetField(1, (byte)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.SetField(1, 'A'));
-        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.SetField(1, DateTime.Now));
-        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.SetField(1, 1.0m));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.SetField(1, 1.0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.SetField(1, (short)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.SetField(1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.SetField(1, 1L));
-        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.SetField(1, (sbyte)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.SetField(1, 1.0f));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.SetField(1, "test"));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.SetField(1, (ushort)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.SetField(1, 1u));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.SetField(1, 1ul));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.SetValue(1, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.SetValue(1, (byte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.SetValue(1, 'A'));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.SetValue(1, DateTime.Now));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.SetValue(1, 1.0m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.SetValue(1, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.SetValue(1, (short)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.SetValue(1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.SetValue(1, 1L));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.SetValue(1, (sbyte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.SetValue(1, 1.0f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.SetValue(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.SetValue(1, (ushort)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.SetValue(1, 1u));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.SetValue(1, 1ul));
     }
 
     [TestMethod]
@@ -1002,8 +1002,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Indices > 0 should throw even with auto-row creation
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(1, "test"));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(2, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(2, "test"));
     }
 
     [TestMethod]
@@ -1047,7 +1047,7 @@ public class RecordTests
 
         var row = re.AddRow();
         name.Set(row.Row, (object)"John Doe");
-        id.SetField(row.Row, 1);
+        id.SetValue(row.Row, 1);
 
         // Assert
         Assert.AreEqual("John Doe", name.Get(row.Row));

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -32,14 +32,14 @@ public class RecordTests
 
         // Act
         var row = table.AddRow();
-        colId.Set(row.Row, 1);
-        colName.Set(row.Row, "Test");
+        colId.SetField(row.Row, 1);
+        colName.SetField(row.Row, "Test");
 
         // Assert
         Assert.AreEqual(1, table.Count);
         Assert.AreEqual(2, table.Columns.Count);
-        Assert.AreEqual(1, colId.Get<int>(row.Row)); // 替换 GetValue 为 Get<T>
-        Assert.AreEqual("Test", colName.Get<string>(row.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual(1, colId.To<int>(row.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual("Test", colName.To<string>(row.Row)); // 替换 GetValue 为 Get<T>
     }
 
     [TestMethod]
@@ -66,26 +66,26 @@ public class RecordTests
 
         // Act
         var row1 = table.AddRow();
-        colId.Set(row1.Row, 1);
-        colName.Set(row1.Row, "Alice");
-        colAge.Set(row1.Row, 25);
+        colId.SetField(row1.Row, 1);
+        colName.SetField(row1.Row, "Alice");
+        colAge.SetField(row1.Row, 25);
 
         var row2 = table.AddRow();
-        colId.Set(row2.Row, 2);
-        colName.Set(row2.Row, "Bob");
-        colAge.Set(row2.Row, 30);
+        colId.SetField(row2.Row, 2);
+        colName.SetField(row2.Row, "Bob");
+        colAge.SetField(row2.Row, 30);
 
         // Assert
         Assert.AreEqual(2, table.Count);
         Assert.AreEqual(3, table.Columns.Count);
 
-        Assert.AreEqual(1, colId.Get<int>(row1.Row)); // 替换 GetValue 为 Get<T>
-        Assert.AreEqual("Alice", colName.Get<string>(row1.Row)); // 替换 GetValue 为 Get<T>
-        Assert.AreEqual(25, colAge.Get<int>(row1.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual(1, colId.To<int>(row1.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual("Alice", colName.To<string>(row1.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual(25, colAge.To<int>(row1.Row)); // 替换 GetValue 为 Get<T>
 
-        Assert.AreEqual(2, colId.Get<int>(row2.Row)); // 替换 GetValue 为 Get<T>
-        Assert.AreEqual("Bob", colName.Get<string>(row2.Row)); // 替换 GetValue 为 Get<T>
-        Assert.AreEqual(30, colAge.Get<int>(row2.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual(2, colId.To<int>(row2.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual("Bob", colName.To<string>(row2.Row)); // 替换 GetValue 为 Get<T>
+        Assert.AreEqual(30, colAge.To<int>(row2.Row)); // 替换 GetValue 为 Get<T>
     }
 
     [TestMethod]
@@ -98,12 +98,12 @@ public class RecordTests
         table.AddRow();
 
         // Act
-        idCol.Set(0, 42);
-        nameCol.Set(0, "TestUser");
+        idCol.SetField(0, 42);
+        nameCol.SetField(0, "TestUser");
 
         // Assert
-        Assert.AreEqual(42, idCol.Get<int>(0));
-        Assert.AreEqual("TestUser", nameCol.Get<string>(0));
+        Assert.AreEqual(42, idCol.To<int>(0));
+        Assert.AreEqual("TestUser", nameCol.To<string>(0));
     }
 
     [TestMethod]
@@ -114,12 +114,12 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         var colName = table.Columns.Add<string>("Name");
         var row = table.AddRow();
-        colId.Set(row.Row, 123);
-        colName.Set(row.Row, "TestValue");
+        colId.SetField(row.Row, 123);
+        colName.SetField(row.Row, "TestValue");
 
         // Act & Assert
-        Assert.AreEqual(123, colId.Get<int>(0));
-        Assert.AreEqual("TestValue", colName.Get<string>(0));
+        Assert.AreEqual(123, colId.To<int>(0));
+        Assert.AreEqual("TestValue", colName.To<string>(0));
     }
 
     [TestMethod]
@@ -168,8 +168,8 @@ public class RecordTests
         var colId = table.Columns.Add<int>("Id");
         table.AddRow();
         table.AddRow();
-        colId.Set(0, 10);
-        colId.Set(1, 20);
+        colId.SetField(0, 10);
+        colId.SetField(1, 20);
 
         // Act
         var rows = table.ToArray();
@@ -179,8 +179,8 @@ public class RecordTests
         // Assert
         Assert.AreEqual(0, row0.Row);
         Assert.AreEqual(1, row1.Row);
-        Assert.AreEqual(10, colId.Get<int>(row0.Row));
-        Assert.AreEqual(20, colId.Get<int>(row1.Row));
+        Assert.AreEqual(10, colId.To<int>(row0.Row));
+        Assert.AreEqual(20, colId.To<int>(row1.Row));
     }
 
     [TestMethod]
@@ -204,9 +204,9 @@ public class RecordTests
         table.AddRow();
         table.AddRow();
         table.AddRow();
-        colId.Set(0, 1);
-        colId.Set(1, 2);
-        colId.Set(2, 3);
+        colId.SetField(0, 1);
+        colId.SetField(1, 2);
+        colId.SetField(2, 3);
 
         // Act
         var rows = new List<RecordRow>();
@@ -220,9 +220,9 @@ public class RecordTests
         Assert.AreEqual(0, rows[0].Row);
         Assert.AreEqual(1, rows[1].Row);
         Assert.AreEqual(2, rows[2].Row);
-        Assert.AreEqual(1, colId.Get<int>(rows[0].Row));
-        Assert.AreEqual(2, colId.Get<int>(rows[1].Row));
-        Assert.AreEqual(3, colId.Get<int>(rows[2].Row));
+        Assert.AreEqual(1, colId.To<int>(rows[0].Row));
+        Assert.AreEqual(2, colId.To<int>(rows[1].Row));
+        Assert.AreEqual(3, colId.To<int>(rows[2].Row));
     }
 
     [TestMethod]
@@ -244,26 +244,26 @@ public class RecordTests
         var testDate = new DateTime(2023, 12, 25);
 
         // Act
-        colBool.Set(row.Row, true);
-        colByte.Set(row.Row, (byte)255);
-        colDateTime.Set(row.Row, testDate);
-        colDecimal.Set(row.Row, 123.45m);
-        colDouble.Set(row.Row, 123.456);
-        colInt16.Set(row.Row, (short)1000);
-        colInt32.Set(row.Row, 100000);
-        colInt64.Set(row.Row, 10000000000L);
-        colString.Set(row.Row, "Hello World");
+        colBool.SetField(row.Row, true);
+        colByte.SetField(row.Row, (byte)255);
+        colDateTime.SetField(row.Row, testDate);
+        colDecimal.SetField(row.Row, 123.45m);
+        colDouble.SetField(row.Row, 123.456);
+        colInt16.SetField(row.Row, (short)1000);
+        colInt32.SetField(row.Row, 100000);
+        colInt64.SetField(row.Row, 10000000000L);
+        colString.SetField(row.Row, "Hello World");
 
         // Assert
-        Assert.AreEqual(true, colBool.GetValue(row.Row));
-        Assert.AreEqual((byte)255, colByte.GetValue(row.Row));
-        Assert.AreEqual(testDate, colDateTime.GetValue(row.Row));
-        Assert.AreEqual(123.45m, colDecimal.GetValue(row.Row));
-        Assert.AreEqual(123.456, colDouble.GetValue(row.Row));
-        Assert.AreEqual((short)1000, colInt16.GetValue(row.Row));
-        Assert.AreEqual(100000, colInt32.GetValue(row.Row));
-        Assert.AreEqual(10000000000L, colInt64.GetValue(row.Row));
-        Assert.AreEqual("Hello World", colString.GetValue(row.Row));
+        Assert.AreEqual(true, (object?)colBool.Get(row.Row));
+        Assert.AreEqual((byte)255, (object?)colByte.Get(row.Row));
+        Assert.AreEqual(testDate, (object?)colDateTime.Get(row.Row));
+        Assert.AreEqual(123.45m, (object?)colDecimal.Get(row.Row));
+        Assert.AreEqual(123.456, (object?)colDouble.Get(row.Row));
+        Assert.AreEqual((short)1000, (object?)colInt16.Get(row.Row));
+        Assert.AreEqual(100000, (object?)colInt32.Get(row.Row));
+        Assert.AreEqual(10000000000L, (object?)colInt64.Get(row.Row));
+        Assert.AreEqual("Hello World", (object?)colString.Get(row.Row));
     }
 
     [TestMethod]
@@ -294,14 +294,14 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colInt.Set(row.Row, 42);
-        Assert.AreEqual(42, colInt.Get<Int32>(row.Row));
+        colInt.SetField(row.Row, 42);
+        Assert.AreEqual(42, colInt.To<Int32>(row.Row));
 
-        colString.Set(row.Row, "Test");
-        Assert.AreEqual("Test", colString.Get<String>(row.Row));
+        colString.SetField(row.Row, "Test");
+        Assert.AreEqual("Test", colString.To<String>(row.Row));
 
-        colBool.Set(row.Row, true);
-        Assert.AreEqual(true, colBool.Get<Boolean>(row.Row));
+        colBool.SetField(row.Row, true);
+        Assert.AreEqual(true, colBool.To<Boolean>(row.Row));
     }
 
     [TestMethod]
@@ -359,16 +359,16 @@ public class RecordTests
         var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         var row = table.AddRow();
-        col.Set(row.Row, "TestValue");
+        col.SetField(row.Row, "TestValue");
 
         // Verify data exists
-        Assert.AreEqual("TestValue", col.GetValue(row.Row));
+        Assert.AreEqual("TestValue", (object?)col.Get(row.Row));
 
         // Act
         col.Clear();
 
         // Assert - After clear, should return null or default value
-        var value = col.GetValue(row.Row);
+        var value = col.Get(row.Row);
         Assert.IsNull(value);
     }
 
@@ -382,12 +382,12 @@ public class RecordTests
         var row2 = table.AddRow();
 
         // Act
-        col.SetValue(row1.Row, 100);
-        col.SetValue(row2.Row, 200);
+        col.Set(row1.Row, (object)100);
+        col.Set(row2.Row, (object)200);
 
         // Assert
-        Assert.AreEqual(100, col.GetValue(row1.Row));
-        Assert.AreEqual(200, col.GetValue(row2.Row));
+        Assert.AreEqual(100, (object?)col.Get(row1.Row));
+        Assert.AreEqual(200, (object?)col.Get(row2.Row));
     }
 
     [TestMethod]
@@ -415,23 +415,23 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert
-        colChar.Set(row.Row, 'A');
-        Assert.AreEqual('A', colChar.Get<Char>(row.Row));
+        colChar.SetField(row.Row, 'A');
+        Assert.AreEqual('A', colChar.To<Char>(row.Row));
 
-        colSByte.Set(row.Row, (sbyte)-100);
-        Assert.AreEqual((sbyte)-100, colSByte.Get<SByte>(row.Row));
+        colSByte.SetField(row.Row, (sbyte)-100);
+        Assert.AreEqual((sbyte)-100, colSByte.To<SByte>(row.Row));
 
-        colSingle.Set(row.Row, 3.14f);
-        Assert.AreEqual(3.14f, colSingle.Get<Single>(row.Row));
+        colSingle.SetField(row.Row, 3.14f);
+        Assert.AreEqual(3.14f, colSingle.To<Single>(row.Row));
 
-        colUInt16.Set(row.Row, (ushort)65535);
-        Assert.AreEqual((ushort)65535, colUInt16.Get<UInt16>(row.Row));
+        colUInt16.SetField(row.Row, (ushort)65535);
+        Assert.AreEqual((ushort)65535, colUInt16.To<UInt16>(row.Row));
 
-        colUInt32.Set(row.Row, 4294967295u);
-        Assert.AreEqual(4294967295u, colUInt32.Get<UInt32>(row.Row));
+        colUInt32.SetField(row.Row, 4294967295u);
+        Assert.AreEqual(4294967295u, colUInt32.To<UInt32>(row.Row));
 
-        colUInt64.Set(row.Row, 18446744073709551615ul);
-        Assert.AreEqual(18446744073709551615ul, colUInt64.Get<UInt64>(row.Row));
+        colUInt64.SetField(row.Row, 18446744073709551615ul);
+        Assert.AreEqual(18446744073709551615ul, colUInt64.To<UInt64>(row.Row));
     }
 
     [TestMethod]
@@ -492,8 +492,8 @@ public class RecordTests
         var row = table.AddRow();
 
         // Act & Assert - Test null value
-        col.Set(row.Row, (string?)null);
-        Assert.IsNull(col.GetValue(row.Row));
+        col.SetField(row.Row, (string?)null);
+        Assert.IsNull(col.Get(row.Row));
     }
 
     [TestMethod]
@@ -586,18 +586,18 @@ public class RecordTests
         var idCol = record.Columns.Add<Int32>("Id");
         var nameCol = record.Columns.Add<String>("Name");
         record.AddRow();
-        idCol.Set(0, 1);
-        nameCol.Set(0, "A");
+        idCol.SetField(0, 1);
+        nameCol.SetField(0, "A");
         record.AddRow();
-        idCol.Set(1, 2);
-        nameCol.Set(1, "B");
+        idCol.SetField(1, 2);
+        nameCol.SetField(1, "B");
 
         var result = record.Delete(0);
 
         Assert.IsTrue(result);
         Assert.AreEqual(1, record.Count);
-        Assert.AreEqual(2, idCol.GetValue(0));
-        Assert.AreEqual("B", nameCol.GetValue(0));
+        Assert.AreEqual(2, (object?)idCol.Get(0));
+        Assert.AreEqual("B", (object?)nameCol.Get(0));
     }
 
     [TestMethod]
@@ -606,15 +606,15 @@ public class RecordTests
         var record = new Record("Test", 0);
         var idCol = record.Columns.Add<Int32>("Id");
         record.AddRow();
-        idCol.Set(0, 1);
+        idCol.SetField(0, 1);
         record.AddRow();
-        idCol.Set(1, 2);
+        idCol.SetField(1, 2);
 
         var result = record.Delete(1);
 
         Assert.IsTrue(result);
         Assert.AreEqual(1, record.Count);
-        Assert.AreEqual(1, idCol.GetValue(0));
+        Assert.AreEqual(1, (object?)idCol.Get(0));
     }
 
     [TestMethod]
@@ -632,8 +632,8 @@ public class RecordTests
         var nameCol = record.Columns.Add<String>("Name");
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
-        nameCol.Set(0, "Alice");
-        ageCol.Set(0, 30);
+        nameCol.SetField(0, "Alice");
+        ageCol.SetField(0, 30);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("TestTable"));
@@ -651,10 +651,10 @@ public class RecordTests
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
         record.AddRow();
-        nameCol.Set(0, "Bob");
-        ageCol.Set(0, 25);
-        nameCol.Set(1, "Carol");
-        ageCol.Set(1, 28);
+        nameCol.SetField(0, "Bob");
+        ageCol.SetField(0, 25);
+        nameCol.SetField(1, "Carol");
+        ageCol.SetField(1, 28);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("People"));
@@ -675,7 +675,7 @@ public class RecordTests
         record.AddRow();
         record.AddRow();
         string longValue = new string('A', 100);
-        descCol.Set(0, longValue);
+        descCol.SetField(0, longValue);
 
         var result = record.ToString();
         Assert.IsTrue(result.Contains("..") || result.Contains("LongStringTest"));
@@ -692,7 +692,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(-1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(-1));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -705,7 +705,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(1));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -718,7 +718,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(5));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(5));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -731,7 +731,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(-1, "test"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(-1, (object)"test"));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -744,7 +744,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(1, "test"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(1, (object)"test"));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -757,7 +757,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(5, "test"));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(5, (object)"test"));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -770,7 +770,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(-1, true));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(-1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -783,7 +783,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(1, true));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(1, true));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -796,7 +796,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(5, 42));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(5, 42));
         Assert.IsTrue(exception.Message.Contains("行索引 5 超出有效范围"));
     }
 
@@ -809,7 +809,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Boolean>(-1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.To<Boolean>(-1));
         Assert.IsTrue(exception.Message.Contains("行索引 -1 超出有效范围"));
     }
 
@@ -822,7 +822,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Int32>(1));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.To<Int32>(1));
         Assert.IsTrue(exception.Message.Contains("行索引 1 超出有效范围"));
     }
 
@@ -835,7 +835,7 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<String>(10));
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => col.To<String>(10));
         Assert.IsTrue(exception.Message.Contains("行索引 10 超出有效范围"));
     }
 
@@ -850,13 +850,13 @@ public class RecordTests
         table.AddRow();
 
         // Act & Assert - Valid indices should work
-        col.SetValue(0, "value0");
-        col.SetValue(1, "value1");
-        col.SetValue(2, "value2");
+        col.Set(0, (object)"value0");
+        col.Set(1, (object)"value1");
+        col.Set(2, (object)"value2");
 
-        Assert.AreEqual("value0", col.GetValue(0));
-        Assert.AreEqual("value1", col.GetValue(1));
-        Assert.AreEqual("value2", col.GetValue(2));
+        Assert.AreEqual("value0", (object?)col.Get(0));
+        Assert.AreEqual("value1", (object?)col.Get(1));
+        Assert.AreEqual("value2", (object?)col.Get(2));
     }
 
     [TestMethod]
@@ -872,17 +872,17 @@ public class RecordTests
         table.AddRow(); // Index 2 - should trigger expansion
 
         // Act & Assert - Valid indices work
-        col.SetValue(0, "test0");
-        col.SetValue(1, "test1");
-        col.SetValue(2, "test2");
+        col.Set(0, (object)"test0");
+        col.Set(1, (object)"test1");
+        col.Set(2, (object)"test2");
 
-        Assert.AreEqual("test0", col.GetValue(0));
-        Assert.AreEqual("test1", col.GetValue(1));
-        Assert.AreEqual("test2", col.GetValue(2));
+        Assert.AreEqual("test0", (object?)col.Get(0));
+        Assert.AreEqual("test1", (object?)col.Get(1));
+        Assert.AreEqual("test2", (object?)col.Get(2));
 
         // Invalid indices should still throw
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(3));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(4, "invalid"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(3));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(4, (object)"invalid"));
     }
 
     [TestMethod]
@@ -909,21 +909,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all Set methods with invalid index
-        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Set(1, true));
-        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Set(1, (byte)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Set(1, 'A'));
-        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Set(1, DateTime.Now));
-        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Set(1, 1.0m));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Set(1, 1.0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Set(1, (short)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.Set(1, 1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Set(1, 1L));
-        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Set(1, (sbyte)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Set(1, 1.0f));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Set(1, "test"));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Set(1, (ushort)1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Set(1, 1u));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Set(1, 1ul));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.SetField(1, true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.SetField(1, (byte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.SetField(1, 'A'));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.SetField(1, DateTime.Now));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.SetField(1, 1.0m));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.SetField(1, 1.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.SetField(1, (short)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.SetField(1, 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.SetField(1, 1L));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.SetField(1, (sbyte)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.SetField(1, 1.0f));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.SetField(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.SetField(1, (ushort)1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.SetField(1, 1u));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.SetField(1, 1ul));
     }
 
     [TestMethod]
@@ -950,21 +950,21 @@ public class RecordTests
         table.AddRow(); // Only one row, valid index is 0
 
         // Act & Assert - Test all To methods with invalid index
-        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.Get<Boolean>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.Get<Byte>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.Get<Char>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.Get<DateTime>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.Get<Decimal>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.Get<Double>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.Get<Int16>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.Get<Int32>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.Get<Int64>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.Get<SByte>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.Get<Single>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.Get<String>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.Get<UInt16>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.Get<UInt32>(1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.Get<UInt64>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => boolCol.To<Boolean>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => byteCol.To<Byte>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => charCol.To<Char>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => dateTimeCol.To<DateTime>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => decimalCol.To<Decimal>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => doubleCol.To<Double>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int16Col.To<Int16>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int32Col.To<Int32>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => int64Col.To<Int64>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => sbyteCol.To<SByte>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => singleCol.To<Single>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => stringCol.To<String>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint16Col.To<UInt16>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint32Col.To<UInt32>(1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => uint64Col.To<UInt64>(1));
     }
 
     [TestMethod]
@@ -976,8 +976,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.Get<Boolean>(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.To<Boolean>(0));
     }
 
     [TestMethod]
@@ -989,8 +989,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Negative indices should always throw
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.GetValue(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetValue(-1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Get(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(-1, (object)"test"));
     }
 
     [TestMethod]
@@ -1002,8 +1002,8 @@ public class RecordTests
         // No rows added, Count = 0
 
         // Act & Assert - Indices > 0 should throw even with auto-row creation
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(1, "test"));
-        Assert.Throws<ArgumentOutOfRangeException>(() => col.Set(2, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(1, "test"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => col.SetField(2, "test"));
     }
 
     [TestMethod]
@@ -1046,12 +1046,12 @@ public class RecordTests
         var id = re.Columns.Add<Int32>("Id");
 
         var row = re.AddRow();
-        name.SetValue(row.Row, "John Doe");
-        id.Set(row.Row, 1);
+        name.Set(row.Row, (object)"John Doe");
+        id.SetField(row.Row, 1);
 
         // Assert
         Assert.AreEqual("John Doe", name.Get(row.Row));
-        Assert.AreEqual(1, id.Get<Int32>(row.Row));
+        Assert.AreEqual(1, id.To<Int32>(row.Row));
     }
 
     [TestMethod]
@@ -1062,6 +1062,6 @@ public class RecordTests
         var id = re.Columns.Add<Int32>("Id");
         var row = re.AddRow();
         // Act & Assert - DateTime cannot be converted to int via SetValue
-        Assert.Throws<InvalidCastException>(() => id.SetValue(row.Row, DateTime.Now));
+        Assert.Throws<InvalidCastException>(() => id.Set(row.Row, DateTime.Now));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
@@ -95,8 +95,8 @@ public class RecordToStringTests
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
         var row = record.AddRow();
-        record.Columns[0].SetValue(row, 1);
-        record.Columns[1].SetValue(row, "Alice");
+        record.Columns[0].Set(row, 1);
+        record.Columns[1].Set(row, "Alice");
 
         // Act
         var result = record.ToString();
@@ -116,8 +116,8 @@ public class RecordToStringTests
         for (int i = 0; i < 2; i++)
         {
             var row = record.AddRow();
-            record.Columns[0].SetValue(row, i);
-            record.Columns[1].SetValue(row, "R" + i);
+            record.Columns[0].Set(row, i);
+            record.Columns[1].Set(row, "R" + i);
         }
 
         // Act
@@ -137,7 +137,7 @@ public class RecordToStringTests
         record.Columns.Add<string>("Val");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue(r1, "A");
+        record.Columns[0].Set(r1, "A");
         // r2 不设置值，保持 null
 
         // Act
@@ -156,8 +156,8 @@ public class RecordToStringTests
         record.Columns.Add<int>("X");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue(r1, 1);
-        record.Columns[0].SetValue(r2, 2);
+        record.Columns[0].Set(r1, 1);
+        record.Columns[0].Set(r2, 2);
 
         // Act
         var result = record.ToString();
@@ -178,8 +178,8 @@ public class RecordToStringTests
         record.Columns.Add<string>("Data");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
-        record.Columns[0].SetValue(r1, new string('A', 100));
-        record.Columns[0].SetValue(r2, "short");
+        record.Columns[0].Set(r1, new string('A', 100));
+        record.Columns[0].Set(r2, "short");
 
         // Act
         var result = record.ToString();


### PR DESCRIPTION
This pull request refactors and standardizes the column value access API in the `Record`, `RecordColumn`, and related classes, improving consistency, clarity, and dynamic access support. It replaces the previous `GetValue`/`SetValue` methods with unified `Get`/`Set` methods, updates dynamic access logic, and simplifies mapping between objects and records.

**API Standardization and Refactoring**

* Replaced `GetValue`/`SetValue` methods in `RecordColumn` and its derivatives with `Get`/`Set` for consistency and clarity, and updated all usages throughout the codebase. The generic accessor method is now `To<T>` instead of `Get<T>`. [[1]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL62-R70) [[2]](diffhunk://#diff-d8e13f9ed4cdd49ed253a6ba73ae388a88decae7fe1e86f42644533871d1b5aeL48-R55) [[3]](diffhunk://#diff-d8e13f9ed4cdd49ed253a6ba73ae388a88decae7fe1e86f42644533871d1b5aeL97-R107) [[4]](diffhunk://#diff-1f8dcc1f0712c3134cde21badc41f85723a2a60c2842444f47452838c459b9a6L25-R25) [[5]](diffhunk://#diff-1f8dcc1f0712c3134cde21badc41f85723a2a60c2842444f47452838c459b9a6L45-R45) [[6]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L271-R271) [[7]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L288-R288) [[8]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L444-R444) [[9]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L469-R469) [[10]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L521-R524) [[11]](diffhunk://#diff-e0202465fd136a87c02407c77e96f159ecd19f33178faada879f8857f9a500a0L564-R567) [[12]](diffhunk://#diff-57da0c9845ffe45b6b5e4b71b87b2b93875f72aa23642311849680475d426f06L174-R174) [[13]](diffhunk://#diff-57da0c9845ffe45b6b5e4b71b87b2b93875f72aa23642311849680475d426f06L200-R200) [[14]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL115-R115) [[15]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL124-R127) [[16]](diffhunk://#diff-9b6b816f8a06b4635fc4dcd9e326daa8450e3a7c09ca9c48882660aef7d66ccbL140-R152)

* Updated the `IXProp` interface implementation in `RecordColumn` to use the new `Get`/`Set` methods and improved error handling for dynamic access.

**Dynamic Access Improvements**

* Refactored the dynamic access implementation in `RecordRow.DynamicMetaObject.cs` to use the indexer (`this[string]`) for both get and set operations, simplifying the logic and ensuring consistency with direct property access. [[1]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833L15-R16) [[2]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833L43-R44) [[3]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833L69-R54) [[4]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833L80-R67)

**Object-Record Mapping Enhancements**

* Simplified object-to-record and record-to-object mapping: replaced `Fill` with `CopyTo` for clarity, and streamlined methods like `From`, `FromList`, and `AddRows` to use new overloads for direct object mapping. [[1]](diffhunk://#diff-ccc75ea73e38409475c04e4140541fbdc47c0e1b0facd5bef4dc3c3322d8c458L19-R19) [[2]](diffhunk://#diff-ccc75ea73e38409475c04e4140541fbdc47c0e1b0facd5bef4dc3c3322d8c458L35-R33) [[3]](diffhunk://#diff-ccc75ea73e38409475c04e4140541fbdc47c0e1b0facd5bef4dc3c3322d8c458L67-R60) [[4]](diffhunk://#diff-05de5650c3d98dc850873ebbe714e64d90d8ea882104d4c800749f3060d9015cL12-R12) [[5]](diffhunk://#diff-05de5650c3d98dc850873ebbe714e64d90d8ea882104d4c800749f3060d9015cL25-R25)

* Improved property copying logic in `XCopy<T>` to avoid unnecessary lookups and ensure only existing columns are written to or read from. [[1]](diffhunk://#diff-a464fdd7f6a1b22e67e7db30727213b93be3f1ddce8e79d5abb7a2949bd530eaR46-R49) [[2]](diffhunk://#diff-a464fdd7f6a1b22e67e7db30727213b93be3f1ddce8e79d5abb7a2949bd530eaL59-R64)

**Minor Cleanups**

* Removed unused `using` directives and streamlined references for clarity. [[1]](diffhunk://#diff-fa1a645064e97b6215f236cab5d196be366819a91100f58f3942c6e097162833L4) [[2]](diffhunk://#diff-c34e5a33f58876c73b51348e1cdc8fef8f990501b9ef0bc8cea3a4df5768b673L5)