### PR TITLE
重命名 Frame 为 Record 并新增核心类型及测试

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -1,15 +1,15 @@
-﻿# Frame
+﻿# Record
 
 ## 1. 定位
 
-`Frame` 是一个面向内存场景的列存储数据容器，适合：
+`Record` 是一个面向内存场景的列存储数据容器，适合：
 
 - 轻量表结构数据处理
 - 对象列表与表结构之间转换
 - 与 ADO.NET 的 `IDataReader` / `DataTable` / `DataSet` 互操作
 - 需要按列存储、按行访问的业务代码
 
-`FrameSet` 是多个 `Frame` 的命名集合，用于统一管理多张内存表，并提供与 `DataSet` 的双向互操作。
+`RecordSet` 是多个 `Record` 的命名集合，用于统一管理多张内存表，并提供与 `DataSet` 的双向互操作。
 
 设计重点：
 
@@ -18,31 +18,31 @@
 - 与对象映射、ADO.NET 互通
 - 支持二进制序列化
 
-`Frame`、`FrameRow`、`FrameSet` 都不是线程安全容器。多线程场景需要调用方自行同步。
+`Record`、`RecordRow`、`RecordSet` 都不是线程安全容器。多线程场景需要调用方自行同步。
 
 ---
 
 ## 2. 当前实现范围
 
-### 2.1 `Frame`
+### 2.1 `Record`
 
-`Frame` 提供：
+`Record` 提供：
 
 - 列结构管理：添加列、重命名列、类型转换、导出 schema
 - 行管理：新增、删除、批量删除、清空、按索引访问
-- 行枚举：实现 `IEnumerable<FrameRow>`
+- 行枚举：实现 `IEnumerable<RecordRow>`
 - 查询：按列值、Lambda、`dynamic` 条件查找
 - 分组：单字段、多字段字符串分组，以及 2/3 字段元组分组
-- 对象映射：对象/对象集合与 `Frame` 之间转换
+- 对象映射：对象/对象集合与 `Record` 之间转换
 - ADO.NET 互操作：`IDataReader`、`DataTable`、`DataSet`
-- 二进制序列化：`Frame` / `FrameSet` 都支持字节流读写
+- 二进制序列化：`Record` / `RecordSet` 都支持字节流读写
 - 服务端翻页元数据：`Page`、`PageSize`、`MaxCount`、`MaxPage`
 
-### 2.2 `FrameSet`
+### 2.2 `RecordSet`
 
-`FrameSet` 提供：
+`RecordSet` 提供：
 
-- 按名称管理多个 `Frame`
+- 按名称管理多个 `Record`
 - 名称比较器可配置
 - 与 `DataSet` 双向互操作
 - 二进制序列化
@@ -60,18 +60,18 @@
 
 ## 3. 核心类型
 
-### 3.1 `Frame`
+### 3.1 `Record`
 
 常用构造：
 
-- `new Frame()`
-- `new Frame(string name)`
-- `new Frame(string? name, int rows)`
+- `new Record()`
+- `new Record(string name)`
+- `new Record(string? name, int rows)`
 
 常用属性：
 
 - `Name`：表名
-- `Columns`：`FrameColumnCollection`
+- `Columns`：`RecordColumnCollection`
 - `Capacity`：当前容量
 - `Count`：实际行数
 - `IsEmpty`：是否空表
@@ -88,13 +88,13 @@
 - `CloneSchema()` 只复制结构，不复制分页元数据。
 - `Clone()` 会复制结构、全部数据以及分页元数据。
 
-### 3.2 `FrameRow`
+### 3.2 `RecordRow`
 
-`FrameRow` 是一个轻量 `struct`，表示某个 `Frame` 中的单行视图。
+`RecordRow` 是一个轻量 `struct`，表示某个 `Record` 中的单行视图。
 
-`FrameRow` 提供：
+`RecordRow` 提供：
 
-- `Frame`：所属 `Frame`
+- `Record`：所属 `Record`
 - `Row`：当前行号
 - `implicit operator int`
 - `this[string name]`：按列名读写当前行值
@@ -117,14 +117,14 @@
 
 补充说明：
 
-- `ToString(string? name)`：若 `name` 为 `null`/空白或列不存在，返回空字符串；否则等同于调用对应列的 `FrameColumn.ToString(int row)`。
+- `ToString(string? name)`：若 `name` 为 `null`/空白或列不存在，返回空字符串；否则等同于调用对应列的 `RecordColumn.ToString(int row)`。
 - 索引器读取时，如果列名为 `null`、空字符串或空白字符串，也直接返回 `null`。
 - 索引器写入时，如果列不存在且值非 `null`，会调用 `Columns.Add(name, value.GetType())` 自动建列；如果运行时类型不在支持白名单内，会抛出异常。
-- `FrameRow` 的公开获取方式通常是 `record[row]` 或通过枚举 `foreach (var row in record)`。
+- `RecordRow` 的公开获取方式通常是 `record[row]` 或通过枚举 `foreach (var row in record)`。
 
-### 3.3 `FrameColumn` / `FrameColumn<T>`
+### 3.3 `RecordColumn` / `RecordColumn<T>`
 
-`FrameColumn` 是列的抽象基类，`FrameColumn<T>` 是泛型实现。
+`RecordColumn` 是列的抽象基类，`RecordColumn<T>` 是泛型实现。
 
 常用成员：
 
@@ -141,17 +141,17 @@
 
 说明：
 
-- 列绑定到所属 `Frame`。
-- 列名可通过 `Frame.RenameColumn` 或 `Frame.Columns.Rename` 修改。
+- 列绑定到所属 `Record`。
+- 列名可通过 `Record.RenameColumn` 或 `Record.Columns.Rename` 修改。
 - `CastColumn()` 会创建新列替换旧列，旧列引用应视为失效。
 - 列删除行时会把后续数据左移。
 
-### 3.4 `FrameColumnCollection`
+### 3.4 `RecordColumnCollection`
 
-`Frame.Columns` 的类型是 `FrameColumnCollection`，其特性如下：
+`Record.Columns` 的类型是 `RecordColumnCollection`，其特性如下：
 
-- 实现 `IReadOnlyList<FrameColumn>`
-- 内部使用 `KeyedList<string, FrameColumn>` 存储
+- 实现 `IReadOnlyList<RecordColumn>`
+- 内部使用 `KeyedList<string, RecordColumn>` 存储
 - 名称比较使用 `StringComparer.Ordinal`
 
 常用 API：
@@ -165,7 +165,7 @@
 | 查索引 | `IndexOf(name)` | 不存在返回 `-1` |
 | 添加 | `Add(name, type)` / `Add<T>(name)` | 同名同类型返回已有列；同名不同类型抛 `InvalidOperationException` |
 | 删除 | `Remove(name)` | 不存在返回 `false` |
-| 清空 | `Clear()` | 清空列并把 `Frame.Count` 重置为 `0` |
+| 清空 | `Clear()` | 清空列并把 `Record.Count` 重置为 `0` |
 | 重命名 | `Rename(oldName, newName)` | 新名重复时抛 `DuplicateNameException` |
 | 按对象建列 | `AddFrom<T>()` 及相关重载 | 仅添加受支持属性 |
 
@@ -182,9 +182,9 @@
 - 指定属性名时，不存在或不支持的属性会被忽略
 - `filter` 方式本质上最终也是转成属性名列表后再加列
 
-### 3.5 `FrameSchema`
+### 3.5 `RecordSchema`
 
-`Frame.GetSchema()` 返回 `FrameSchema`，用于导出列定义。
+`Record.GetSchema()` 返回 `RecordSchema`，用于导出列定义。
 
 每个 `ColumnDef` 包含：
 
@@ -199,9 +199,9 @@
 - 调试与诊断
 - 序列化相关元信息输出
 
-### 3.6 `FrameSet`
+### 3.6 `RecordSet`
 
-`FrameSet` 是 `Frame` 的命名集合，实现 `IEnumerable<Frame>`。
+`RecordSet` 是 `Record` 的命名集合，实现 `IEnumerable<Record>`。
 
 它提供：
 
@@ -219,7 +219,7 @@
 
 说明：
 
-- 内部使用 `SortedDictionary<string, Frame>`。
+- 内部使用 `SortedDictionary<string, Record>`。
 - 枚举顺序与 `Names` 顺序都是**按比较器排序后的名称顺序**，不是按添加顺序。
 - `Add` / `Set` / `Rename` 都会同步更新 `record.Name`。
 
@@ -250,14 +250,14 @@
 
 ---
 
-## 5. `Frame` API 概览
+## 5. `Record` API 概览
 
 ### 5.1 建列与加行
 
 最常见的用法是先建列，再加行：
 
 ```csharp
-var record = new Frame("Orders", 1000);
+var record = new Record("Orders", 1000);
 
 var idCol = record.Columns.Add<int>("Id");
 var nameCol = record.Columns.Add<string>("Name");
@@ -271,11 +271,11 @@ amountCol.SetValue(row.Row, 99.5m);
 
 提供：
 
-- `AddRow()`：新增一行并返回 `FrameRow`
+- `AddRow()`：新增一行并返回 `RecordRow`
 - `AddRowFromValues(params object[] values)`：按列顺序填值，超出列数的值会被忽略
 
 ```csharp
-var record = new Frame();
+var record = new Record();
 record.Columns.Add<int>("Id");
 record.Columns.Add<string>("Name");
 
@@ -288,7 +288,7 @@ record.AddRowFromValues(2, "B", "Ignored");
 提供：
 
 - `Delete(int row)`：删除指定行，越界返回 `false`
-- `DeleteWhere(Func<FrameRow, bool>)`：按条件批量删除
+- `DeleteWhere(Func<RecordRow, bool>)`：按条件批量删除
 - `DeleteRows(IEnumerable<int>)`：按索引集合批量删除
 - `ClearRows()`：清空全部行，保留列结构
 
@@ -309,7 +309,7 @@ record.AddRowFromValues(2, "B", "Ignored");
 行为说明：
 
 - `record[row]` 越界时抛 `ArgumentOutOfRangeException`
-- 枚举时按 `0..Count-1` 顺序返回 `FrameRow`
+- 枚举时按 `0..Count-1` 顺序返回 `RecordRow`
 
 ### 5.4 查询
 
@@ -317,8 +317,8 @@ record.AddRowFromValues(2, "B", "Ignored");
 
 - `Find<T>(string name, T value)`
 - `FindAll<T>(string name, T value)`
-- `Find(Func<FrameRow, bool> filter)`
-- `FindAll(Func<FrameRow, bool> filter)`
+- `Find(Func<RecordRow, bool> filter)`
+- `FindAll(Func<RecordRow, bool> filter)`
 - `FindByDynamic(Func<dynamic, bool> filter)`
 - `FindAllByDynamic(Func<dynamic, bool> filter)`
 
@@ -363,8 +363,8 @@ foreach (var pair in groups)
 
 说明：
 
-- `Group<T>(string fld)` 的返回类型是 `IDictionary<T, List<FrameRow>>`
-- `Group(string fld)` 的返回类型是 `IDictionary<string, IList<FrameRow>>`
+- `Group<T>(string fld)` 的返回类型是 `IDictionary<T, List<RecordRow>>`
+- `Group(string fld)` 的返回类型是 `IDictionary<string, IList<RecordRow>>`
 - `Group<T>(string fld)` 仅支持值类型键；字符串键请使用 `Group(string fld)`
 
 #### 5.5.2 多字段字符串分组
@@ -382,8 +382,8 @@ var groups = record.Group("Category", "Status");
 
 在 `NETSTANDARD2.0+` / `NET6.0+` 目标下，还提供 2～3 字段元组分组：
 
-- `Group<T1, T2>(fld1, fld2)` -> `IDictionary<(T1?, T2?), IList<FrameRow>>`
-- `Group<T1, T2, T3>(fld1, fld2, fld3)` -> `IDictionary<(T1?, T2?, T3?), IList<FrameRow>>`
+- `Group<T1, T2>(fld1, fld2)` -> `IDictionary<(T1?, T2?), IList<RecordRow>>`
+- `Group<T1, T2, T3>(fld1, fld2, fld3)` -> `IDictionary<(T1?, T2?, T3?), IList<RecordRow>>`
 
 ```csharp
 var groups = record.Group<int, int>("Year", "Month");
@@ -425,7 +425,7 @@ var groups = record.Group<int, int>("Year", "Month");
 - 多行时以表格形式输出
 - 对宽字符做显示宽度处理
 - 单元格内容过长时按显示宽度截断
-- 单元格字符串值统一通过 `FrameColumn.ToString(int row)` 获取（`null` 渲染为空字符串）
+- 单元格字符串值统一通过 `RecordColumn.ToString(int row)` 获取（`null` 渲染为空字符串）
 
 这个输出更适合调试、日志和快速查看数据，而不是稳定的序列化格式。
 
@@ -433,12 +433,12 @@ var groups = record.Group<int, int>("Year", "Month");
 
 ## 6. 对象映射
 
-### 6.1 `Frame` 级别映射
+### 6.1 `Record` 级别映射
 
 提供：
 
-- `Frame.From<T>(T data)`
-- `Frame.FromList<T>(IEnumerable<T> items)`
+- `Record.From<T>(T data)`
+- `Record.FromList<T>(IEnumerable<T> items)`
 - `record.AddRowFrom<T>(T item)`
 - `record.AddRowsFromList<T>(IEnumerable<T> items)`
 - `record.ToList<T>()`
@@ -447,7 +447,7 @@ var groups = record.Group<int, int>("Year", "Month");
 示例：
 
 ```csharp
-var record = Frame.From(new OrderDto
+var record = Record.From(new OrderDto
 {
     Id = 1,
     Name = "Order-1"
@@ -457,7 +457,7 @@ List<OrderDto> list = record.ToList<OrderDto>();
 OrderDto first = record.To<OrderDto>();
 ```
 
-### 6.2 `FrameRow` 级别映射
+### 6.2 `RecordRow` 级别映射
 
 提供：
 
@@ -479,15 +479,15 @@ row.CopyTo(existing);
 
 实现上的关键点：
 
-- `Frame.From<T>` / `FromList<T>` 会先 `Columns.AddFrom<T>()`，再写入数据
+- `Record.From<T>` / `FromList<T>` 会先 `Columns.AddFrom<T>()`，再写入数据
 - `AddRowFrom<T>` 本身**不会自动建列**，它只是新增一行后执行 `CopyFrom`
 - `CopyFrom` / `AddRowFrom` / `AddRowsFromList` 写入时，仅对已存在列赋值；缺失列会被忽略
 - 对象映射只处理支持白名单中的属性类型
 
-因此，若不是使用 `Frame.From<T>` / `FromList<T>`，通常应先显式建列：
+因此，若不是使用 `Record.From<T>` / `FromList<T>`，通常应先显式建列：
 
 ```csharp
-var record = new Frame();
+var record = new Record();
 record.Columns.AddFrom<OrderDto>();
 record.AddRowFrom(dto);
 ```
@@ -496,12 +496,12 @@ record.AddRowFrom(dto);
 
 ## 7. ADO.NET 互操作
 
-### 7.1 `Frame` 与 `IDataReader` / `DataTable`
+### 7.1 `Record` 与 `IDataReader` / `DataTable`
 
 提供：
 
 - `void Read(IDataReader dr)`
-- `static Frame Read(DataTable dt)`
+- `static Record Read(DataTable dt)`
 - `void Write(DataTable dt)`
 - `DataTable ToDataTable()`
 
@@ -510,15 +510,15 @@ record.AddRowFrom(dto);
 - `Read(IDataReader)` 会先 `Columns.Clear()`，然后根据 reader 的字段结构重建整张表
 - `Read(IDataReader)` 读取到 `DBNull.Value` 时会跳过赋值，目标列保持默认值
 - `Write(DataTable dt)` 会把当前列结构和所有行写入到传入 `DataTable`
-- `ToDataTable()` 会创建新表，表名取 `Frame.Name`
+- `ToDataTable()` 会创建新表，表名取 `Record.Name`
 
 示例：
 
 ```csharp
-var record = new Frame();
+var record = new Record();
 record.Read(dataReader);
 
-var fromTable = Frame.Read(dataTable);
+var fromTable = Record.Read(dataTable);
 DataTable table = fromTable.ToDataTable();
 ```
 
@@ -526,32 +526,32 @@ DataTable table = fromTable.ToDataTable();
 
 - `Write(DataTable dt)` 是向目标表追加列和行，通常应传入空表。
 
-### 7.2 `FrameSet` 与 `DataSet`
+### 7.2 `RecordSet` 与 `DataSet`
 
 提供：
 
-- `FrameSet.FromDataSet(DataSet ds)`
+- `RecordSet.FromDataSet(DataSet ds)`
 - `ToDataSet()`
 - `WriteTo(DataSet ds)`
 
 示例：
 
 ```csharp
-var set = FrameSet.FromDataSet(dataSet);
+var set = RecordSet.FromDataSet(dataSet);
 DataSet ds = set.ToDataSet();
 ```
 
 行为说明：
 
-- `FromDataSet` 会把每个 `DataTable` 转成 `Frame`
-- `WriteTo(DataSet ds)` 会把每个 `Frame` 作为新表追加到目标 `DataSet`
+- `FromDataSet` 会把每个 `DataTable` 转成 `Record`
+- `WriteTo(DataSet ds)` 会把每个 `Record` 作为新表追加到目标 `DataSet`
 - 目标 `DataSet` 中表名冲突时，`DataSet.Tables.Add` 会抛异常，因此通常应传入空 `DataSet` 或自行保证不重名
 
 ---
 
 ## 8. 二进制序列化
 
-### 8.1 `Frame`
+### 8.1 `Record`
 
 提供：
 
@@ -566,7 +566,7 @@ DataSet ds = set.ToDataSet();
 1. payload header
 2. 格式版本号
 3. `Name`、`Page`、`PageSize`、`MaxCount`
-4. 列定义：列名、`FrameColumnType`、`IsNullable`
+4. 列定义：列名、`RecordColumnType`、`IsNullable`
 5. 行数
 6. 每列的顺序数据
 
@@ -581,10 +581,10 @@ DataSet ds = set.ToDataSet();
 
 ```csharp
 byte[] bytes = record.ToBytes();
-Frame copy = Frame.FromBytes(bytes);
+Record copy = Record.FromBytes(bytes);
 ```
 
-### 8.2 `FrameSet`
+### 8.2 `RecordSet`
 
 当前实现提供：
 
@@ -596,13 +596,13 @@ Frame copy = Frame.FromBytes(bytes);
 
 说明：
 
-- `FrameSet` 序列化时会先写自己的 payload header 与版本号
-- 内部逐个写出每个 `Frame`
-- 以字典键作为权威名称，避免外部修改 `Frame.Name` 后与集合键不一致
+- `RecordSet` 序列化时会先写自己的 payload header 与版本号
+- 内部逐个写出每个 `Record`
+- 以字典键作为权威名称，避免外部修改 `Record.Name` 后与集合键不一致
 
 ```csharp
 byte[] bytes = set.ToBytes();
-FrameSet copy = FrameSet.FromBytes(bytes);
+RecordSet copy = RecordSet.FromBytes(bytes);
 ```
 
 ---
@@ -620,7 +620,7 @@ FrameSet copy = FrameSet.FromBytes(bytes);
 | `Columns.Add(name, type)` 同名同类型 | 返回已有列 |
 | `Columns.Add(name, type)` 同名不同类型 | 抛 `InvalidOperationException` |
 | `Columns.Rename(old, new)` 新名已存在 | 抛 `DuplicateNameException` |
-| `Frame.Delete(row)` 越界 | 返回 `false` |
+| `Record.Delete(row)` 越界 | 返回 `false` |
 | `DeleteWhere(null)` | 抛 `ArgumentNullException` |
 | `DeleteRows(null)` | 抛 `ArgumentNullException` |
 | `Find(null)` / `FindAll(null)` | 抛 `ArgumentNullException` |
@@ -628,9 +628,9 @@ FrameSet copy = FrameSet.FromBytes(bytes);
 | `row["Missing"]` | 返回 `null` |
 | `row.To<T>("Missing")` | 返回 `default` |
 | `row["New"] = null` | 不建列，直接忽略 |
-| `FrameSet.Get(name)` 不存在 | 抛 `KeyNotFoundException` |
-| `FrameSet.Add(null/空白, record)` | 抛 `ArgumentException` |
-| `FrameSet.Add(name, null)` | 抛 `ArgumentNullException` |
+| `RecordSet.Get(name)` 不存在 | 抛 `KeyNotFoundException` |
+| `RecordSet.Add(null/空白, record)` | 抛 `ArgumentException` |
+| `RecordSet.Add(name, null)` | 抛 `ArgumentNullException` |
 
 特别说明：
 
@@ -657,7 +657,7 @@ for (int i = 0; i < count; i++)
 
 要点：
 
-- 热路径优先使用 `FrameColumn<T>.SetValue` / `GetValue`
+- 热路径优先使用 `RecordColumn<T>.SetValue` / `GetValue`
 - 避免在循环中反复按名称查列
 
 ### 10.2 schema 已知时优先先建列

--- a/src/LuYao.Common/Data/BinaryPayloadHeader.cs
+++ b/src/LuYao.Common/Data/BinaryPayloadHeader.cs
@@ -5,8 +5,8 @@ namespace LuYao.Data;
 
 internal enum BinaryPayloadType : byte
 {
-    Frame = 1,
-    FrameSet = 2
+    Record = 1,
+    RecordSet = 2
 }
 
 internal static class BinaryPayloadHeader
@@ -57,7 +57,7 @@ internal static class BinaryPayloadHeader
         if (data[0] != Marker || data[1] != Signature1 || data[2] != Signature2) return false;
 
         byte rawType = data[3];
-        if (rawType != (byte)BinaryPayloadType.Frame && rawType != (byte)BinaryPayloadType.FrameSet)
+        if (rawType != (byte)BinaryPayloadType.Record && rawType != (byte)BinaryPayloadType.RecordSet)
             return false;
 
         payloadType = (BinaryPayloadType)rawType;

--- a/src/LuYao.Common/Data/Helpers.cs
+++ b/src/LuYao.Common/Data/Helpers.cs
@@ -8,36 +8,36 @@ namespace LuYao.Data;
 
 static class Helpers
 {
-    #region FrameColumnType <-> Type 双向映射
+    #region RecordColumnType <-> Type 双向映射
 
-    private static readonly Dictionary<Type, FrameColumnType> TypeToColumnType = new()
+    private static readonly Dictionary<Type, RecordColumnType> TypeToColumnType = new()
     {
-        [typeof(bool)] = FrameColumnType.Boolean,
-        [typeof(sbyte)] = FrameColumnType.SByte,
-        [typeof(short)] = FrameColumnType.Int16,
-        [typeof(int)] = FrameColumnType.Int32,
-        [typeof(long)] = FrameColumnType.Int64,
-        [typeof(byte)] = FrameColumnType.Byte,
-        [typeof(ushort)] = FrameColumnType.UInt16,
-        [typeof(uint)] = FrameColumnType.UInt32,
-        [typeof(ulong)] = FrameColumnType.UInt64,
-        [typeof(float)] = FrameColumnType.Single,
-        [typeof(double)] = FrameColumnType.Double,
-        [typeof(decimal)] = FrameColumnType.Decimal,
-        [typeof(char)] = FrameColumnType.Char,
-        [typeof(string)] = FrameColumnType.String,
-        [typeof(DateTime)] = FrameColumnType.DateTime,
-        [typeof(DateTimeOffset)] = FrameColumnType.DateTimeOffset,
-        [typeof(TimeSpan)] = FrameColumnType.TimeSpan,
-        [typeof(Guid)] = FrameColumnType.Guid,
-        [typeof(byte[])] = FrameColumnType.ByteArray,
+        [typeof(bool)] = RecordColumnType.Boolean,
+        [typeof(sbyte)] = RecordColumnType.SByte,
+        [typeof(short)] = RecordColumnType.Int16,
+        [typeof(int)] = RecordColumnType.Int32,
+        [typeof(long)] = RecordColumnType.Int64,
+        [typeof(byte)] = RecordColumnType.Byte,
+        [typeof(ushort)] = RecordColumnType.UInt16,
+        [typeof(uint)] = RecordColumnType.UInt32,
+        [typeof(ulong)] = RecordColumnType.UInt64,
+        [typeof(float)] = RecordColumnType.Single,
+        [typeof(double)] = RecordColumnType.Double,
+        [typeof(decimal)] = RecordColumnType.Decimal,
+        [typeof(char)] = RecordColumnType.Char,
+        [typeof(string)] = RecordColumnType.String,
+        [typeof(DateTime)] = RecordColumnType.DateTime,
+        [typeof(DateTimeOffset)] = RecordColumnType.DateTimeOffset,
+        [typeof(TimeSpan)] = RecordColumnType.TimeSpan,
+        [typeof(Guid)] = RecordColumnType.Guid,
+        [typeof(byte[])] = RecordColumnType.ByteArray,
     };
 
-    private static readonly Dictionary<FrameColumnType, Type> ColumnTypeToType;
+    private static readonly Dictionary<RecordColumnType, Type> ColumnTypeToType;
 
     static Helpers()
     {
-        ColumnTypeToType = new Dictionary<FrameColumnType, Type>(TypeToColumnType.Count);
+        ColumnTypeToType = new Dictionary<RecordColumnType, Type>(TypeToColumnType.Count);
         foreach (var kv in TypeToColumnType)
         {
             ColumnTypeToType[kv.Value] = kv.Key;
@@ -45,9 +45,9 @@ static class Helpers
     }
 
     /// <summary>
-    /// 从 CLR <see cref="Type"/> 获取基础 <see cref="FrameColumnType"/>（不含 Nullable 信息）。
+    /// 从 CLR <see cref="Type"/> 获取基础 <see cref="RecordColumnType"/>（不含 Nullable 信息）。
     /// </summary>
-    internal static FrameColumnType GetColumnType(Type type)
+    internal static RecordColumnType GetColumnType(Type type)
     {
         var lookup = NormalizeColumnLookupType(type);
         if (TypeToColumnType.TryGetValue(lookup, out var ct))
@@ -64,9 +64,9 @@ static class Helpers
     }
 
     /// <summary>
-    /// 从基础 <see cref="FrameColumnType"/> 和 <paramref name="isNullable"/> 还原 CLR <see cref="Type"/>。
+    /// 从基础 <see cref="RecordColumnType"/> 和 <paramref name="isNullable"/> 还原 CLR <see cref="Type"/>。
     /// </summary>
-    internal static Type GetClrType(FrameColumnType columnType, bool isNullable)
+    internal static Type GetClrType(RecordColumnType columnType, bool isNullable)
     {
         if (!ColumnTypeToType.TryGetValue(columnType, out var baseType))
             throw new NotSupportedException($"未知列类型枚举值: {columnType}");
@@ -113,24 +113,24 @@ static class Helpers
         var effective = Nullable.GetUnderlyingType(type) ?? type;
         return effective.IsEnum ? Enum.GetUnderlyingType(effective) : effective;
     }
-    private static readonly ConcurrentDictionary<Type, Func<Frame, string, Type, FrameColumn>> _cache = new();
+    private static readonly ConcurrentDictionary<Type, Func<Record, string, Type, RecordColumn>> _cache = new();
 
-    private static Func<Frame, string, Type, FrameColumn> GetConstructor(Type type)
+    private static Func<Record, string, Type, RecordColumn> GetConstructor(Type type)
     {
         return _cache.GetOrAdd(type, static t =>
         {
             // 创建泛型类型
-            var genericType = typeof(FrameColumn<>).MakeGenericType(t);
+            var genericType = typeof(RecordColumn<>).MakeGenericType(t);
 
             // 获取构造函数
             var ctor = genericType.GetConstructor(new[] {
-                typeof(Frame),
+                typeof(Record),
                 typeof(string),
                 typeof(Type)
             }) ?? throw new InvalidOperationException($"Constructor not found for {genericType}");
 
             // 定义参数表达式
-            var pRecord = Expression.Parameter(typeof(Frame), "record");
+            var pRecord = Expression.Parameter(typeof(Record), "record");
             var pName = Expression.Parameter(typeof(string), "name");
             var pType = Expression.Parameter(typeof(Type), "type");
 
@@ -138,19 +138,19 @@ static class Helpers
             var newExpr = Expression.New(ctor, pRecord, pName, pType);
 
             // 编译表达式树为委托
-            return Expression.Lambda<Func<Frame, string, Type, FrameColumn>>(
+            return Expression.Lambda<Func<Record, string, Type, RecordColumn>>(
                 newExpr, pRecord, pName, pType).Compile();
         });
     }
 
-    public static FrameColumn MakeFrameColumn<T>(Frame record, string name)
+    public static RecordColumn MakeRecordColumn<T>(Record record, string name)
     {
         // 使用泛型方法优化，避免运行时查找类型
         var ctor = GetConstructor(typeof(T));
         return ctor.Invoke(record, name, typeof(T));
     }
 
-    public static FrameColumn MakeFrameColumn(Frame record, string name, Type type)
+    public static RecordColumn MakeRecordColumn(Record record, string name, Type type)
     {
         if (record == null) throw new ArgumentNullException(nameof(record));
         if (name == null) throw new ArgumentNullException(nameof(name));

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 namespace LuYao.Data.Meta;
 
 /// <summary>
-/// 提供在强类型对象与 <see cref="FrameRow"/> 之间进行属性双向复制的静态工具类。
+/// 提供在强类型对象与 <see cref="RecordRow"/> 之间进行属性双向复制的静态工具类。
 /// </summary>
 /// <typeparam name="T">要映射的对象类型，必须为引用类型。</typeparam>
 public static class XCopy<T> where T : class
@@ -35,15 +35,15 @@ public static class XCopy<T> where T : class
         return list.AsReadOnly();
     }
 
-    #region FrameRow
+    #region RecordRow
     /// <summary>
     /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="row"/> 对应的列。
     /// </summary>
     /// <param name="data">数据来源对象。</param>
     /// <param name="row">目标行；仅写入类型受支持的可读属性。Mapping 路径下若列不存在则静默跳过，<b>不会自动建列</b>。</param>
-    public static void CopyTo(T data, FrameRow row)
+    public static void CopyTo(T data, RecordRow row)
     {
-        var cols = row.Frame.Columns;
+        var cols = row.Record.Columns;
         foreach (var prop in _readableProps)
         {
             var col = cols.Find(prop.Name);
@@ -57,9 +57,9 @@ public static class XCopy<T> where T : class
     /// </summary>
     /// <param name="data">目标对象；仅更新类型受支持且行中存在对应列的可写属性。</param>
     /// <param name="row">数据来源行。</param>
-    public static void CopyFrom(T data, FrameRow row)
+    public static void CopyFrom(T data, RecordRow row)
     {
-        var cols = row.Frame.Columns;
+        var cols = row.Record.Columns;
         foreach (var prop in _writableProps)
         {
             var col = cols.Find(prop.Name);

--- a/src/LuYao.Common/Data/Record.Binary.cs
+++ b/src/LuYao.Common/Data/Record.Binary.cs
@@ -4,13 +4,13 @@ using System.Text;
 
 namespace LuYao.Data;
 
-public partial class Frame
+public partial class Record
 {
     // 二进制格式版本号，用于未来兼容性检查
     private const byte BinaryFormatVersion = 1;
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 写入二进制流。
+    /// 将当前 <see cref="Record"/> 写入二进制流。
     /// </summary>
     /// <param name="stream">目标流。</param>
     /// <exception cref="ArgumentNullException">当 <paramref name="stream"/> 为 null 时抛出。</exception>
@@ -22,7 +22,7 @@ public partial class Frame
     }
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 写入 <see cref="BinaryWriter"/>。
+    /// 将当前 <see cref="Record"/> 写入 <see cref="BinaryWriter"/>。
     /// </summary>
     /// <param name="writer">目标写入器。</param>
     public void WriteTo(BinaryWriter writer)
@@ -30,7 +30,7 @@ public partial class Frame
         if (writer == null) throw new ArgumentNullException(nameof(writer));
 
         // Header
-        BinaryPayloadHeader.Write(writer, BinaryPayloadType.Frame);
+        BinaryPayloadHeader.Write(writer, BinaryPayloadType.Record);
         writer.Write(BinaryFormatVersion);
         writer.Write(this.Name ?? string.Empty);
         writer.Write(this.Page);
@@ -59,7 +59,7 @@ public partial class Frame
     }
 
     /// <summary>
-    /// 从二进制流读取并填充当前 <see cref="Frame"/> 实例。
+    /// 从二进制流读取并填充当前 <see cref="Record"/> 实例。
     /// </summary>
     /// <param name="stream">源流。</param>
     /// <exception cref="ArgumentNullException">当 <paramref name="stream"/> 为 null 时抛出。</exception>
@@ -71,7 +71,7 @@ public partial class Frame
     }
 
     /// <summary>
-    /// 从 <see cref="BinaryReader"/> 读取并填充当前 <see cref="Frame"/> 实例。
+    /// 从 <see cref="BinaryReader"/> 读取并填充当前 <see cref="Record"/> 实例。
     /// </summary>
     /// <param name="reader">源读取器。</param>
     public void ReadFrom(BinaryReader reader)
@@ -79,7 +79,7 @@ public partial class Frame
         if (reader == null) throw new ArgumentNullException(nameof(reader));
 
         // Header
-        byte version = BinaryPayloadHeader.ReadHeaderAndVersion(reader, BinaryPayloadType.Frame);
+        byte version = BinaryPayloadHeader.ReadHeaderAndVersion(reader, BinaryPayloadType.Record);
         if (version != BinaryFormatVersion)
             throw new InvalidOperationException($"不支持的二进制格式版本: {version}");
 
@@ -94,7 +94,7 @@ public partial class Frame
         for (int c = 0; c < colCount; c++)
         {
             string name = reader.ReadString();
-            var columnType = (FrameColumnType)reader.ReadByte();
+            var columnType = (RecordColumnType)reader.ReadByte();
             bool isNullable = reader.ReadBoolean();
             Type clrType = Helpers.GetClrType(columnType, isNullable);
             this.Columns.Add(name, clrType);
@@ -117,13 +117,13 @@ public partial class Frame
     }
 
     /// <summary>
-    /// 从二进制流创建新的 <see cref="Frame"/> 实例。
+    /// 从二进制流创建新的 <see cref="Record"/> 实例。
     /// </summary>
     /// <param name="stream">源流。</param>
-    /// <returns>反序列化的 <see cref="Frame"/> 实例。</returns>
-    public static Frame FromStream(Stream stream)
+    /// <returns>反序列化的 <see cref="Record"/> 实例。</returns>
+    public static Record FromStream(Stream stream)
     {
-        var record = new Frame();
+        var record = new Record();
         record.ReadFrom(stream);
         return record;
     }
@@ -143,8 +143,8 @@ public partial class Frame
     /// 从字节数组反序列化。
     /// </summary>
     /// <param name="data">二进制数据。</param>
-    /// <returns>反序列化的 <see cref="Frame"/> 实例。</returns>
-    public static Frame FromBytes(byte[] data)
+    /// <returns>反序列化的 <see cref="Record"/> 实例。</returns>
+    public static Record FromBytes(byte[] data)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
         using var ms = new MemoryStream(data, writable: false);
@@ -152,22 +152,22 @@ public partial class Frame
     }
 
     /// <summary>
-    /// 检测二进制数据是否为带类型头的 <see cref="Frame"/>。
+    /// 检测二进制数据是否为带类型头的 <see cref="Record"/>。
     /// </summary>
     /// <param name="data">二进制数据。</param>
-    /// <returns>当数据包含 <see cref="Frame"/> 类型头时返回 true；否则返回 false。</returns>
+    /// <returns>当数据包含 <see cref="Record"/> 类型头时返回 true；否则返回 false。</returns>
     public static bool IsBinaryPayload(byte[] data)
     {
         if (data == null) return false;
         return BinaryPayloadHeader.TryGetPayloadType(data, out var payloadType)
-            && payloadType == BinaryPayloadType.Frame;
+            && payloadType == BinaryPayloadType.Record;
     }
 
     #region 列数据序列化
 
-    private static void WriteColumnData(BinaryWriter writer, FrameColumn col, int rowCount)
+    private static void WriteColumnData(BinaryWriter writer, RecordColumn col, int rowCount)
     {
-        bool needsNullCheck = col.IsNullable || col.ColumnType == FrameColumnType.String || col.ColumnType == FrameColumnType.ByteArray;
+        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || col.ColumnType == RecordColumnType.ByteArray;
 
         for (int r = 0; r < rowCount; r++)
         {
@@ -185,9 +185,9 @@ public partial class Frame
         }
     }
 
-    private static void ReadColumnData(BinaryReader reader, FrameColumn col, int rowCount)
+    private static void ReadColumnData(BinaryReader reader, RecordColumn col, int rowCount)
     {
-        bool needsNullCheck = col.IsNullable || col.ColumnType == FrameColumnType.String || col.ColumnType == FrameColumnType.ByteArray;
+        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || col.ColumnType == RecordColumnType.ByteArray;
 
         for (int r = 0; r < rowCount; r++)
         {
@@ -201,7 +201,7 @@ public partial class Frame
         }
     }
 
-    private static void WritePrimitiveValue(BinaryWriter writer, object value, FrameColumnType columnType)
+    private static void WritePrimitiveValue(BinaryWriter writer, object value, RecordColumnType columnType)
     {
         if (value.GetType().IsEnum)
         {
@@ -210,29 +210,29 @@ public partial class Frame
 
         switch (columnType)
         {
-            case FrameColumnType.Boolean: writer.Write((bool)value); break;
-            case FrameColumnType.SByte: writer.Write((sbyte)value); break;
-            case FrameColumnType.Int16: writer.Write((short)value); break;
-            case FrameColumnType.Int32: writer.Write((int)value); break;
-            case FrameColumnType.Int64: writer.Write((long)value); break;
-            case FrameColumnType.Byte: writer.Write((byte)value); break;
-            case FrameColumnType.UInt16: writer.Write((ushort)value); break;
-            case FrameColumnType.UInt32: writer.Write((uint)value); break;
-            case FrameColumnType.UInt64: writer.Write((ulong)value); break;
-            case FrameColumnType.Single: writer.Write((float)value); break;
-            case FrameColumnType.Double: writer.Write((double)value); break;
-            case FrameColumnType.Decimal: writer.Write((decimal)value); break;
-            case FrameColumnType.Char: writer.Write((char)value); break;
-            case FrameColumnType.String: writer.Write((string)value); break;
-            case FrameColumnType.DateTime: writer.Write(((DateTime)value).ToBinary()); break;
-            case FrameColumnType.DateTimeOffset:
+            case RecordColumnType.Boolean: writer.Write((bool)value); break;
+            case RecordColumnType.SByte: writer.Write((sbyte)value); break;
+            case RecordColumnType.Int16: writer.Write((short)value); break;
+            case RecordColumnType.Int32: writer.Write((int)value); break;
+            case RecordColumnType.Int64: writer.Write((long)value); break;
+            case RecordColumnType.Byte: writer.Write((byte)value); break;
+            case RecordColumnType.UInt16: writer.Write((ushort)value); break;
+            case RecordColumnType.UInt32: writer.Write((uint)value); break;
+            case RecordColumnType.UInt64: writer.Write((ulong)value); break;
+            case RecordColumnType.Single: writer.Write((float)value); break;
+            case RecordColumnType.Double: writer.Write((double)value); break;
+            case RecordColumnType.Decimal: writer.Write((decimal)value); break;
+            case RecordColumnType.Char: writer.Write((char)value); break;
+            case RecordColumnType.String: writer.Write((string)value); break;
+            case RecordColumnType.DateTime: writer.Write(((DateTime)value).ToBinary()); break;
+            case RecordColumnType.DateTimeOffset:
                 var dto = (DateTimeOffset)value;
                 writer.Write(dto.Ticks);
                 writer.Write((short)dto.Offset.TotalMinutes);
                 break;
-            case FrameColumnType.TimeSpan: writer.Write(((TimeSpan)value).Ticks); break;
-            case FrameColumnType.Guid: writer.Write(((Guid)value).ToByteArray()); break;
-            case FrameColumnType.ByteArray:
+            case RecordColumnType.TimeSpan: writer.Write(((TimeSpan)value).Ticks); break;
+            case RecordColumnType.Guid: writer.Write(((Guid)value).ToByteArray()); break;
+            case RecordColumnType.ByteArray:
                 var bytes = (byte[])value;
                 writer.Write(bytes.Length);
                 writer.Write(bytes);
@@ -242,32 +242,32 @@ public partial class Frame
         }
     }
 
-    private static object ReadPrimitiveValue(BinaryReader reader, FrameColumnType columnType)
+    private static object ReadPrimitiveValue(BinaryReader reader, RecordColumnType columnType)
     {
         switch (columnType)
         {
-            case FrameColumnType.Boolean: return reader.ReadBoolean();
-            case FrameColumnType.SByte: return reader.ReadSByte();
-            case FrameColumnType.Int16: return reader.ReadInt16();
-            case FrameColumnType.Int32: return reader.ReadInt32();
-            case FrameColumnType.Int64: return reader.ReadInt64();
-            case FrameColumnType.Byte: return reader.ReadByte();
-            case FrameColumnType.UInt16: return reader.ReadUInt16();
-            case FrameColumnType.UInt32: return reader.ReadUInt32();
-            case FrameColumnType.UInt64: return reader.ReadUInt64();
-            case FrameColumnType.Single: return reader.ReadSingle();
-            case FrameColumnType.Double: return reader.ReadDouble();
-            case FrameColumnType.Decimal: return reader.ReadDecimal();
-            case FrameColumnType.Char: return reader.ReadChar();
-            case FrameColumnType.String: return reader.ReadString();
-            case FrameColumnType.DateTime: return DateTime.FromBinary(reader.ReadInt64());
-            case FrameColumnType.DateTimeOffset:
+            case RecordColumnType.Boolean: return reader.ReadBoolean();
+            case RecordColumnType.SByte: return reader.ReadSByte();
+            case RecordColumnType.Int16: return reader.ReadInt16();
+            case RecordColumnType.Int32: return reader.ReadInt32();
+            case RecordColumnType.Int64: return reader.ReadInt64();
+            case RecordColumnType.Byte: return reader.ReadByte();
+            case RecordColumnType.UInt16: return reader.ReadUInt16();
+            case RecordColumnType.UInt32: return reader.ReadUInt32();
+            case RecordColumnType.UInt64: return reader.ReadUInt64();
+            case RecordColumnType.Single: return reader.ReadSingle();
+            case RecordColumnType.Double: return reader.ReadDouble();
+            case RecordColumnType.Decimal: return reader.ReadDecimal();
+            case RecordColumnType.Char: return reader.ReadChar();
+            case RecordColumnType.String: return reader.ReadString();
+            case RecordColumnType.DateTime: return DateTime.FromBinary(reader.ReadInt64());
+            case RecordColumnType.DateTimeOffset:
                 long ticks = reader.ReadInt64();
                 short offsetMinutes = reader.ReadInt16();
                 return new DateTimeOffset(ticks, TimeSpan.FromMinutes(offsetMinutes));
-            case FrameColumnType.TimeSpan: return new TimeSpan(reader.ReadInt64());
-            case FrameColumnType.Guid: return new Guid(reader.ReadBytes(16));
-            case FrameColumnType.ByteArray:
+            case RecordColumnType.TimeSpan: return new TimeSpan(reader.ReadInt64());
+            case RecordColumnType.Guid: return new Guid(reader.ReadBytes(16));
+            case RecordColumnType.ByteArray:
                 int len = reader.ReadInt32();
                 return reader.ReadBytes(len);
             default:

--- a/src/LuYao.Common/Data/Record.Group.cs
+++ b/src/LuYao.Common/Data/Record.Group.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace LuYao.Data;
 
-partial class Frame
+partial class Record
 {
     /// <summary>
     /// 按指定列的值对记录进行分组。
@@ -12,16 +12,16 @@ partial class Frame
     /// <typeparam name="T">分组键的类型。</typeparam>
     /// <param name="fld">要分组的列名。</param>
     /// <returns>针对所指定列名分组的记录行的字典。</returns>
-    public IDictionary<T, List<FrameRow>> Group<T>(string fld) where T : struct
+    public IDictionary<T, List<RecordRow>> Group<T>(string fld) where T : struct
     {
-        var ret = new Dictionary<T, List<FrameRow>>();
+        var ret = new Dictionary<T, List<RecordRow>>();
         var col = this.Columns.Find(fld);
         foreach (var row in this)
         {
             T key = col?.To<T>(row) ?? default;
             if (!ret.TryGetValue(key, out var tmp))
             {
-                tmp = new List<FrameRow>();
+                tmp = new List<RecordRow>();
                 ret.Add(key, tmp);
             }
             tmp.Add(row);
@@ -34,16 +34,16 @@ partial class Frame
     /// </summary>
     /// <param name="fld">要分组的列名。</param>
     /// <returns>针对所指定列名分组的记录行的字典。</returns>
-    public IDictionary<String, IList<FrameRow>> Group(string fld)
+    public IDictionary<String, IList<RecordRow>> Group(string fld)
     {
-        var ret = new Dictionary<String, IList<FrameRow>>();
+        var ret = new Dictionary<String, IList<RecordRow>>();
         var col = this.Columns.Find(fld);
         foreach (var row in this)
         {
             String key = col?.To<string>(row) ?? string.Empty;
             if (!ret.TryGetValue(key, out var tmp))
             {
-                tmp = new List<FrameRow>();
+                tmp = new List<RecordRow>();
                 ret.Add(key, tmp);
             }
             tmp.Add(row);
@@ -56,16 +56,16 @@ partial class Frame
     /// </summary>
     /// <param name="flds">要分组的列名数组。</param>
     /// <returns>针对所指定列名拼接后分组的记录行的字典。</returns>
-    public IDictionary<String, IList<FrameRow>> Group(params string[] flds)
+    public IDictionary<String, IList<RecordRow>> Group(params string[] flds)
     {
-        var ret = new Dictionary<String, IList<FrameRow>>();
+        var ret = new Dictionary<String, IList<RecordRow>>();
         var cols = flds.Select(Columns.Find).ToArray();
         foreach (var row in this)
         {
             String key = string.Join("-", cols.Select(c => c?.To<string>(row) ?? string.Empty));
             if (!ret.TryGetValue(key, out var tmp))
             {
-                tmp = new List<FrameRow>();
+                tmp = new List<RecordRow>();
                 ret.Add(key, tmp);
             }
             tmp.Add(row);
@@ -82,9 +82,9 @@ partial class Frame
     /// <param name="fld1">第一列的名称。</param>
     /// <param name="fld2">第二列的名称。</param>
     /// <returns>按指定两个列的值分组的记录行的字典。</returns>
-    public IDictionary<(T1?, T2?), IList<FrameRow>> Group<T1, T2>(string fld1, string fld2)
+    public IDictionary<(T1?, T2?), IList<RecordRow>> Group<T1, T2>(string fld1, string fld2)
     {
-        var ret = new Dictionary<(T1?, T2?), IList<FrameRow>>();
+        var ret = new Dictionary<(T1?, T2?), IList<RecordRow>>();
         var col1 = this.Columns.Find(fld1);
         var col2 = this.Columns.Find(fld2);
         foreach (var row in this)
@@ -96,7 +96,7 @@ partial class Frame
             (T1?, T2?) key = (val1, val2);
             if (!ret.TryGetValue(key, out var tmp))
             {
-                tmp = new List<FrameRow>();
+                tmp = new List<RecordRow>();
                 ret.Add(key, tmp);
             }
             tmp.Add(row);
@@ -114,9 +114,9 @@ partial class Frame
     /// <param name="fld2">第二列的名称。</param>
     /// <param name="fld3">第三列的名称。</param>
     /// <returns>按指定三个列的值分组的记录行的字典。</returns>
-    public IDictionary<(T1?, T2?, T3?), IList<FrameRow>> Group<T1, T2, T3>(string fld1, string fld2, string fld3)
+    public IDictionary<(T1?, T2?, T3?), IList<RecordRow>> Group<T1, T2, T3>(string fld1, string fld2, string fld3)
     {
-        var ret = new Dictionary<(T1?, T2?, T3?), IList<FrameRow>>();
+        var ret = new Dictionary<(T1?, T2?, T3?), IList<RecordRow>>();
         var col1 = this.Columns.Find(fld1);
         var col2 = this.Columns.Find(fld2);
         var col3 = this.Columns.Find(fld3);
@@ -131,7 +131,7 @@ partial class Frame
             var key = (val1, val2, val3);
             if (!ret.TryGetValue(key, out var tmp))
             {
-                tmp = new List<FrameRow>();
+                tmp = new List<RecordRow>();
                 ret.Add(key, tmp);
             }
             tmp.Add(row);

--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -4,43 +4,43 @@ using System.Collections.Generic;
 
 namespace LuYao.Data;
 
-partial class Frame
+partial class Record
 {
     /// <summary>
-    /// 根据单个对象创建一个 <see cref="Frame"/>，自动推断列结构并写入一行数据。
+    /// 根据单个对象创建一个 <see cref="Record"/>，自动推断列结构并写入一行数据。
     /// </summary>
     /// <typeparam name="T">数据来源的对象类型。</typeparam>
     /// <param name="data">用于初始化列结构和行数据的对象实例。</param>
-    /// <returns>包含一行数据的新 <see cref="Frame"/>。</returns>
-    public static Frame From<T>(T data) where T : class
+    /// <returns>包含一行数据的新 <see cref="Record"/>。</returns>
+    public static Record From<T>(T data) where T : class
     {
-        var re = new Frame();
+        var re = new Record();
         re.Columns.AddFrom<T>();
         re.AddRowFrom(data);
         return re;
     }
 
     /// <summary>
-    /// 根据对象集合创建一个 <see cref="Frame"/>，自动推断列结构并将每个对象写入一行。
+    /// 根据对象集合创建一个 <see cref="Record"/>，自动推断列结构并将每个对象写入一行。
     /// </summary>
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
     /// <param name="items">用于填充行数据的对象集合。</param>
-    /// <returns>包含与集合等量行数据的新 <see cref="Frame"/>。</returns>
-    public static Frame FromList<T>(IEnumerable<T> items) where T : class
+    /// <returns>包含与集合等量行数据的新 <see cref="Record"/>。</returns>
+    public static Record FromList<T>(IEnumerable<T> items) where T : class
     {
-        var re = new Frame();
+        var re = new Record();
         re.Columns.AddFrom<T>();
         re.AddRowsFromList(items);
         return re;
     }
 
     /// <summary>
-    /// 向当前 <see cref="Frame"/> 追加一行，并将 <paramref name="item"/> 的属性值写入该行。
+    /// 向当前 <see cref="Record"/> 追加一行，并将 <paramref name="item"/> 的属性值写入该行。
     /// </summary>
     /// <typeparam name="T">数据来源的对象类型。</typeparam>
     /// <param name="item">要追加的对象实例，不能为 <see langword="null"/>。</param>
     /// <exception cref="ArgumentNullException"><paramref name="item"/> 为 <see langword="null"/>。</exception>
-    public FrameRow AddRowFrom<T>(T item) where T : class
+    public RecordRow AddRowFrom<T>(T item) where T : class
     {
         if (item == null) throw new ArgumentNullException(nameof(item));
         var ret = this.AddRow();
@@ -49,7 +49,7 @@ partial class Frame
     }
 
     /// <summary>
-    /// 向当前 <see cref="Frame"/> 批量追加行，每个 <paramref name="items"/> 元素对应一行。
+    /// 向当前 <see cref="Record"/> 批量追加行，每个 <paramref name="items"/> 元素对应一行。
     /// </summary>
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
     /// <param name="items">要批量追加的对象集合。</param>
@@ -59,7 +59,7 @@ partial class Frame
     }
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 的所有行转换为 <typeparamref name="T"/> 对象列表。
+    /// 将当前 <see cref="Record"/> 的所有行转换为 <typeparamref name="T"/> 对象列表。
     /// </summary>
     /// <typeparam name="T">目标对象类型，必须有无参构造函数。</typeparam>
     /// <returns>与行数等量的对象列表。</returns>
@@ -75,8 +75,8 @@ partial class Frame
     }
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 的第一行转换为 <typeparamref name="T"/> 对象。
-    /// 如果 <see cref="Frame"/> 没有任何行，则返回一个使用无参构造函数创建的默认实例。
+    /// 将当前 <see cref="Record"/> 的第一行转换为 <typeparamref name="T"/> 对象。
+    /// 如果 <see cref="Record"/> 没有任何行，则返回一个使用无参构造函数创建的默认实例。
     /// </summary>
     /// <typeparam name="T">目标对象类型，必须有无参构造函数。</typeparam>
     /// <returns>转换后的对象实例。</returns>

--- a/src/LuYao.Common/Data/Record.Query.cs
+++ b/src/LuYao.Common/Data/Record.Query.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace LuYao.Data;
 
-public partial class Frame
+public partial class Record
 {
     /// <summary>
     /// 在当前记录的所有数据行中，查找指定列与目标值匹配的第一行数据。
@@ -12,8 +12,8 @@ public partial class Frame
     /// <typeparam name="T">要查找的列对应的数据类型。</typeparam>
     /// <param name="name">要查找的列名称。</param>
     /// <param name="value">要匹配的目标值。</param>
-    /// <returns>符合条件的第一条 <see cref="FrameRow"/>，未找到则返回 null。</returns>
-    public FrameRow? Find<T>(string name, T value)
+    /// <returns>符合条件的第一条 <see cref="RecordRow"/>，未找到则返回 null。</returns>
+    public RecordRow? Find<T>(string name, T value)
     {
         var col = this.Columns.Find(name);
         if (col == null) return null;
@@ -21,7 +21,7 @@ public partial class Frame
         for (int i = 0; i < this.Count; i++)
         {
             var val = col.To<T>(i);
-            if (comparer.Equals(val, value)) return new FrameRow(this, i);
+            if (comparer.Equals(val, value)) return new RecordRow(this, i);
         }
         return null;
     }
@@ -32,8 +32,8 @@ public partial class Frame
     /// <typeparam name="T">要查找的列对应的数据类型。</typeparam>
     /// <param name="name">要查找的列名称。</param>
     /// <param name="value">要匹配的目标值。</param>
-    /// <returns>一个包含所有符合条件 <see cref="FrameRow"/> 的枚举器序列。</returns>
-    public IEnumerable<FrameRow> FindAll<T>(string name, T value)
+    /// <returns>一个包含所有符合条件 <see cref="RecordRow"/> 的枚举器序列。</returns>
+    public IEnumerable<RecordRow> FindAll<T>(string name, T value)
     {
         var col = this.Columns.Find(name);
         if (col == null) yield break;
@@ -41,22 +41,22 @@ public partial class Frame
         for (int i = 0; i < this.Count; i++)
         {
             var val = col.To<T>(i);
-            if (comparer.Equals(val, value)) yield return new FrameRow(this, i);
+            if (comparer.Equals(val, value)) yield return new RecordRow(this, i);
         }
     }
 
     /// <summary>
     /// 使用指定的条件筛选器，查找符合要求的第一条行数据。
     /// </summary>
-    /// <param name="filter">用于筛选 <see cref="FrameRow"/> 数据行的条件委托。</param>
-    /// <returns>符合条件的第一条 <see cref="FrameRow"/>，未找到则返回 null。</returns>
+    /// <param name="filter">用于筛选 <see cref="RecordRow"/> 数据行的条件委托。</param>
+    /// <returns>符合条件的第一条 <see cref="RecordRow"/>，未找到则返回 null。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="filter"/> 为 null 时抛出。</exception>
-    public FrameRow? Find(Func<FrameRow, bool> filter)
+    public RecordRow? Find(Func<RecordRow, bool> filter)
     {
         if (filter == null) throw new ArgumentNullException(nameof(filter));
         for (int i = 0; i < this.Count; i++)
         {
-            var row = new FrameRow(this, i);
+            var row = new RecordRow(this, i);
             if (filter(row)) return row;
         }
         return null;
@@ -65,32 +65,32 @@ public partial class Frame
     /// <summary>
     /// 使用指定的条件筛选器，查找所有符合要求的行数据。
     /// </summary>
-    /// <param name="filter">用于筛选 <see cref="FrameRow"/> 数据行的条件委托。</param>
-    /// <returns>所有符合条件的 <see cref="FrameRow"/> 数据流序列。</returns>
+    /// <param name="filter">用于筛选 <see cref="RecordRow"/> 数据行的条件委托。</param>
+    /// <returns>所有符合条件的 <see cref="RecordRow"/> 数据流序列。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="filter"/> 为 null 时抛出。</exception>
-    public IEnumerable<FrameRow> FindAll(Func<FrameRow, bool> filter)
+    public IEnumerable<RecordRow> FindAll(Func<RecordRow, bool> filter)
     {
         if (filter == null) throw new ArgumentNullException(nameof(filter));
         for (int i = 0; i < this.Count; i++)
         {
-            var row = new FrameRow(this, i);
+            var row = new RecordRow(this, i);
             if (filter(row)) yield return row;
         }
     }
 
     /// <summary>
     /// 使用基于 dynamic 的动态类型筛选器，查找符合要求的第一条行数据。
-    /// （依赖 <see cref="FrameRow"/> 对 <see cref="System.Dynamic.IDynamicMetaObjectProvider"/> 的实现）
+    /// （依赖 <see cref="RecordRow"/> 对 <see cref="System.Dynamic.IDynamicMetaObjectProvider"/> 的实现）
     /// </summary>
     /// <param name="filter">用于动态筛选数据行的条件委托。</param>
-    /// <returns>符合条件的第一条 <see cref="FrameRow"/>，未找到则返回 null。</returns>
+    /// <returns>符合条件的第一条 <see cref="RecordRow"/>，未找到则返回 null。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="filter"/> 为 null 时抛出。</exception>
-    public FrameRow? FindByDynamic(Func<dynamic, bool> filter)
+    public RecordRow? FindByDynamic(Func<dynamic, bool> filter)
     {
         if (filter == null) throw new ArgumentNullException(nameof(filter));
         for (int i = 0; i < this.Count; i++)
         {
-            var row = new FrameRow(this, i);
+            var row = new RecordRow(this, i);
             if (filter(row)) return row;
         }
         return null;
@@ -100,14 +100,14 @@ public partial class Frame
     /// 使用基于 dynamic 的动态类型筛选器，查找所有符合要求的行数据。
     /// </summary>
     /// <param name="filter">用于动态筛选数据行的条件委托。</param>
-    /// <returns>所有符合条件的 <see cref="FrameRow"/> 数据流序列。</returns>
+    /// <returns>所有符合条件的 <see cref="RecordRow"/> 数据流序列。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="filter"/> 为 null 时抛出。</exception>
-    public IEnumerable<FrameRow> FindAllByDynamic(Func<dynamic, bool> filter)
+    public IEnumerable<RecordRow> FindAllByDynamic(Func<dynamic, bool> filter)
     {
         if (filter == null) throw new ArgumentNullException(nameof(filter));
         for (int i = 0; i < this.Count; i++)
         {
-            var row = new FrameRow(this, i);
+            var row = new RecordRow(this, i);
             if (filter(row)) yield return row;
         }
     }

--- a/src/LuYao.Common/Data/Record.cs
+++ b/src/LuYao.Common/Data/Record.cs
@@ -11,38 +11,38 @@ namespace LuYao.Data;
 /// <summary>
 /// 列存储数据集合
 /// </summary>
-[DebuggerTypeProxy(typeof(FrameDebuggerTypeProxy))]
-public partial class Frame : IEnumerable<FrameRow>
+[DebuggerTypeProxy(typeof(RecordDebuggerTypeProxy))]
+public partial class Record : IEnumerable<RecordRow>
 {
     /// <summary>
-    /// 初始化 <see cref="Frame"/> 类的新实例。
+    /// 初始化 <see cref="Record"/> 类的新实例。
     /// </summary>
-    public Frame() : this(null, 0)
+    public Record() : this(null, 0)
     {
 
     }
 
     /// <summary>
-    /// 初始化 <see cref="Frame"/> 类的新实例。
+    /// 初始化 <see cref="Record"/> 类的新实例。
     /// </summary>
     /// <param name="name">表名称。</param>
-    public Frame(string name) : this(name, 0)
+    public Record(string name) : this(name, 0)
     {
 
     }
 
     /// <summary>
-    /// 使用指定的表名和行数初始化 <see cref="Frame"/> 类的新实例。
+    /// 使用指定的表名和行数初始化 <see cref="Record"/> 类的新实例。
     /// </summary>
     /// <param name="name">表名称。</param>
     /// <param name="rows">初始行数。</param>
-    public Frame(string? name, int rows)
+    public Record(string? name, int rows)
     {
         if (!string.IsNullOrWhiteSpace(name)) this.Name = name!;
         int c = rows;
         if (c < 20) c = 20;
         this.Capacity = c;
-        _cols = new FrameColumnCollection(this);
+        _cols = new RecordColumnCollection(this);
     }
 
     /// <summary>
@@ -53,12 +53,12 @@ public partial class Frame : IEnumerable<FrameRow>
     /// <summary>
     /// 列集合的私有字段
     /// </summary>
-    private readonly FrameColumnCollection _cols;
+    private readonly RecordColumnCollection _cols;
 
     /// <summary>
     /// 表列集合
     /// </summary>
-    public FrameColumnCollection Columns => _cols;
+    public RecordColumnCollection Columns => _cols;
     /// <summary>
     /// 容量
     /// </summary>
@@ -117,12 +117,12 @@ public partial class Frame : IEnumerable<FrameRow>
     /// 添加一行数据。
     /// </summary>
     /// <returns>新添加的行数据。</returns>
-    public FrameRow AddRow()
+    public RecordRow AddRow()
     {
         int row = this.Count;
         this.Count++;
         this.Columns.OnAddRow();
-        return new FrameRow(this, row);
+        return new RecordRow(this, row);
     }
 
     /// <summary>
@@ -133,7 +133,7 @@ public partial class Frame : IEnumerable<FrameRow>
     /// <remarks>
     /// 如果提供的值数量少于列数，则只填充对应的列；如果值数量多于列数，则忽略多余的值。
     /// </remarks>
-    public FrameRow AddRowFromValues(params object[] values)
+    public RecordRow AddRowFromValues(params object[] values)
     {
         var row = AddRow();
         for (int i = 0; i < values.Length && i < this.Columns.Count; i++)
@@ -149,7 +149,7 @@ public partial class Frame : IEnumerable<FrameRow>
     public bool Delete(int row)
     {
         if (row < 0 || row >= this.Count) return false;
-        foreach (FrameColumn col in this._cols) col.Delete(row);
+        foreach (RecordColumn col in this._cols) col.Delete(row);
         this.Count--;
         return true;
     }
@@ -160,13 +160,13 @@ public partial class Frame : IEnumerable<FrameRow>
     /// <param name="predicate">行筛选谓词，返回 true 的行将被删除。</param>
     /// <returns>实际删除的行数。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="predicate"/> 为 null 时抛出。</exception>
-    public int DeleteWhere(Func<FrameRow, bool> predicate)
+    public int DeleteWhere(Func<RecordRow, bool> predicate)
     {
         if (predicate == null) throw new ArgumentNullException(nameof(predicate));
         int deleted = 0;
         for (int i = this.Count - 1; i >= 0; i--)
         {
-            if (predicate(new FrameRow(this, i)))
+            if (predicate(new RecordRow(this, i)))
             {
                 Delete(i);
                 deleted++;
@@ -200,7 +200,7 @@ public partial class Frame : IEnumerable<FrameRow>
     public void ClearRows()
     {
         this.OnClear();
-        foreach (FrameColumn col in this.Columns)
+        foreach (RecordColumn col in this.Columns)
         {
             col.Clear();
         }
@@ -217,11 +217,11 @@ public partial class Frame : IEnumerable<FrameRow>
     #region IEnumerable
 
     /// <inheritdoc/> 
-    public IEnumerator<FrameRow> GetEnumerator()
+    public IEnumerator<RecordRow> GetEnumerator()
     {
         for (int i = 0; i < Count; i++)
         {
-            yield return new FrameRow(this, i);
+            yield return new RecordRow(this, i);
         }
     }
 
@@ -238,7 +238,7 @@ public partial class Frame : IEnumerable<FrameRow>
 
     #region IDataReader
     /// <summary>
-    /// 从指定的 <see cref="IDataReader"/> 读取数据并填充到当前 <see cref="Frame"/> 实例。
+    /// 从指定的 <see cref="IDataReader"/> 读取数据并填充到当前 <see cref="Record"/> 实例。
     /// </summary>
     /// <param name="dr">用于读取数据的 <see cref="IDataReader"/> 实例。</param>
     public void Read(IDataReader dr)
@@ -282,7 +282,7 @@ public partial class Frame : IEnumerable<FrameRow>
         {
             //只有一行数据时，输出每列的值
             int max = this._cols.Max(f => DisplayWidth(f.Name));
-            foreach (FrameColumn col in this._cols)
+            foreach (RecordColumn col in this._cols)
             {
                 sb.Append(PadRightByWidth(col.Name, max));
                 sb.Append(" | ");
@@ -298,7 +298,7 @@ public partial class Frame : IEnumerable<FrameRow>
             string[,] arr = new string[Count, this._cols.Count];
             for (int k = 0; k < this._cols.Count; k++)
             {
-                FrameColumn col = this._cols[k];
+                RecordColumn col = this._cols[k];
                 int max = DisplayWidth(col.Name);
 
                 for (int i = 0; i < Count; i++)
@@ -423,24 +423,24 @@ public partial class Frame : IEnumerable<FrameRow>
     public bool IsEmpty => this.Count == 0;
 
     /// <summary>
-    /// 获取指定索引处的 <see cref="FrameRow"/> 实例。
+    /// 获取指定索引处的 <see cref="RecordRow"/> 实例。
     /// </summary>
     /// <param name="row">要获取的行的索引。</param>
-    /// <returns>指定索引处的 <see cref="FrameRow"/>。</returns>
+    /// <returns>指定索引处的 <see cref="RecordRow"/>。</returns>
     /// <exception cref="ArgumentOutOfRangeException">当索引超出范围时抛出。</exception>
-    public FrameRow this[int row]
+    public RecordRow this[int row]
     {
         get
         {
             if (row < 0 || row >= this.Count) throw new ArgumentOutOfRangeException(nameof(row), "索引超出范围");
-            return new FrameRow(this, row);
+            return new RecordRow(this, row);
         }
     }
 
     #region DataTable
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 实例的数据写入指定的 <see cref="DataTable"/>。
+    /// 将当前 <see cref="Record"/> 实例的数据写入指定的 <see cref="DataTable"/>。
     /// </summary>
     /// <param name="dt">用于接收数据的 <see cref="DataTable"/> 实例。</param>
     /// <remarks>
@@ -450,7 +450,7 @@ public partial class Frame : IEnumerable<FrameRow>
     public void Write(DataTable dt)
     {
         if (dt == null) throw new ArgumentNullException(nameof(dt));
-        foreach (FrameColumn col in this.Columns)
+        foreach (RecordColumn col in this.Columns)
         {
             dt.Columns.Add(col.Name, col.Type);
         }
@@ -466,20 +466,20 @@ public partial class Frame : IEnumerable<FrameRow>
     }
 
     /// <summary>
-    /// 从指定的 <see cref="DataTable"/> 读取数据并返回一个新的 <see cref="Frame"/> 实例。
+    /// 从指定的 <see cref="DataTable"/> 读取数据并返回一个新的 <see cref="Record"/> 实例。
     /// </summary>
     /// <param name="dt">用于读取数据的 <see cref="DataTable"/> 实例。</param>
-    /// <returns>读取到的 <see cref="Frame"/> 实例。</returns>
-    public static Frame Read(DataTable dt)
+    /// <returns>读取到的 <see cref="Record"/> 实例。</returns>
+    public static Record Read(DataTable dt)
     {
-        var ret = new Frame(dt.TableName, dt.Rows.Count);
+        var ret = new Record(dt.TableName, dt.Rows.Count);
         foreach (DataColumn col in dt.Columns)
         {
             ret.Columns.Add(col.ColumnName, col.DataType);
         }
         foreach (DataRow row in dt.Rows)
         {
-            FrameRow recordRow = ret.AddRow();
+            RecordRow recordRow = ret.AddRow();
             for (int i = 0; i < dt.Columns.Count; i++)
             {
                 var col = ret.Columns[i];
@@ -491,7 +491,7 @@ public partial class Frame : IEnumerable<FrameRow>
     }
 
     /// <summary>
-    /// 将当前 <see cref="Frame"/> 实例转换为 <see cref="DataTable"/>。
+    /// 将当前 <see cref="Record"/> 实例转换为 <see cref="DataTable"/>。
     /// </summary>
     /// <returns>包含当前记录所有数据的 <see cref="DataTable"/> 实例。</returns>
     /// <remarks>
@@ -532,7 +532,7 @@ public partial class Frame : IEnumerable<FrameRow>
         if (oldCol.Type == newType) return;
 
         int idx = this.Columns.IndexOf(name);
-        var newCol = Helpers.MakeFrameColumn(this, name, newType);
+        var newCol = Helpers.MakeRecordColumn(this, name, newType);
 
         for (int r = 0; r < this.Count; r++)
         {
@@ -547,13 +547,13 @@ public partial class Frame : IEnumerable<FrameRow>
     }
 
     /// <summary>
-    /// 仅复制列结构（零行），返回新 <see cref="Frame"/>。
+    /// 仅复制列结构（零行），返回新 <see cref="Record"/>。
     /// </summary>
-    /// <returns>具有相同列结构但零行的新 <see cref="Frame"/> 实例。</returns>
-    public Frame CloneSchema()
+    /// <returns>具有相同列结构但零行的新 <see cref="Record"/> 实例。</returns>
+    public Record CloneSchema()
     {
-        var clone = new Frame(this.Name, 0);
-        foreach (FrameColumn col in this.Columns)
+        var clone = new Record(this.Name, 0);
+        foreach (RecordColumn col in this.Columns)
         {
             clone.Columns.Add(col.Name, col.Type);
         }
@@ -561,16 +561,16 @@ public partial class Frame : IEnumerable<FrameRow>
     }
 
     /// <summary>
-    /// 复制列结构与全部行数据，返回新 <see cref="Frame"/>。
+    /// 复制列结构与全部行数据，返回新 <see cref="Record"/>。
     /// </summary>
-    /// <returns>包含相同列结构和全部数据的新 <see cref="Frame"/> 实例。</returns>
-    public Frame Clone()
+    /// <returns>包含相同列结构和全部数据的新 <see cref="Record"/> 实例。</returns>
+    public Record Clone()
     {
-        var clone = new Frame(this.Name, this.Count);
+        var clone = new Record(this.Name, this.Count);
         clone.Page = this.Page;
         clone._maxCount = this._maxCount;
         clone._pageSize = this._pageSize;
-        foreach (FrameColumn col in this.Columns)
+        foreach (RecordColumn col in this.Columns)
         {
             clone.Columns.Add(col.Name, col.Type);
         }
@@ -592,15 +592,15 @@ public partial class Frame : IEnumerable<FrameRow>
     /// <summary>
     /// 导出列定义信息（列名 + 类型）。
     /// </summary>
-    /// <returns>表示当前列结构的 <see cref="FrameSchema"/> 实例。</returns>
-    public FrameSchema GetSchema()
+    /// <returns>表示当前列结构的 <see cref="RecordSchema"/> 实例。</returns>
+    public RecordSchema GetSchema()
     {
-        var columns = new List<FrameSchema.ColumnDef>(this.Columns.Count);
-        foreach (FrameColumn col in this.Columns)
+        var columns = new List<RecordSchema.ColumnDef>(this.Columns.Count);
+        foreach (RecordColumn col in this.Columns)
         {
-            columns.Add(new FrameSchema.ColumnDef(col.Name, col.ColumnType, col.IsNullable));
+            columns.Add(new RecordSchema.ColumnDef(col.Name, col.ColumnType, col.IsNullable));
         }
-        return new FrameSchema(columns);
+        return new RecordSchema(columns);
     }
 
     #endregion

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -6,7 +6,7 @@ namespace LuYao.Data;
 /// 泛型列
 /// </summary>
 /// <typeparam name="T"></typeparam>
-public class FrameColumn<T> : FrameColumn
+public class RecordColumn<T> : RecordColumn
 {
     /// <summary>
     /// 数据存储数组
@@ -16,7 +16,7 @@ public class FrameColumn<T> : FrameColumn
     /// <summary>
     /// 创建一个泛型列
     /// </summary>
-    public FrameColumn(Frame record, string name, Type type)
+    public RecordColumn(Record record, string name, Type type)
         : base(record, name, type)
     {
         var capacity = record.Capacity;
@@ -37,7 +37,7 @@ public class FrameColumn<T> : FrameColumn
     public override void Delete(int row)
     {
         OnGet(row);
-        var count = this.Frame.Count;
+        var count = this.Record.Count;
         for (int i = row; i < count - 1; i++)
         {
             this._data[i] = this._data[i + 1];

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -6,13 +6,13 @@ namespace LuYao.Data;
 /// <summary>
 /// 表示一个数据列。
 /// </summary>
-public abstract class FrameColumn : IXProp
+public abstract class RecordColumn : IXProp
 {
     /// <summary>
     /// 获取关联的记录实例。
     /// </summary>
-    /// <value>包含此列的 <see cref="Frame"/> 对象。</value>
-    public Frame Frame { get; }
+    /// <value>包含此列的 <see cref="Record"/> 对象。</value>
+    public Record Record { get; }
 
     /// <summary>
     /// 创建一个数据列实例。
@@ -22,9 +22,9 @@ public abstract class FrameColumn : IXProp
     /// <param name="type">列的实际数据类型。</param>
     /// 
     /// <exception cref="ArgumentNullException">当 <paramref name="record"/>、<paramref name="name"/> 或 <paramref name="type"/> 为 null 时抛出。</exception>
-    internal FrameColumn(Frame record, string name, Type type)
+    internal RecordColumn(Record record, string name, Type type)
     {
-        this.Frame = record ?? throw new ArgumentNullException(nameof(record));
+        this.Record = record ?? throw new ArgumentNullException(nameof(record));
         this.Name = name ?? throw new ArgumentNullException(nameof(name));
         this._type = type ?? throw new ArgumentNullException(nameof(type));
         this.ColumnType = Helpers.GetColumnType(type);
@@ -46,7 +46,7 @@ public abstract class FrameColumn : IXProp
     /// <summary>
     /// 获取列的基础枚举类型标识（不含可空信息）。
     /// </summary>
-    public FrameColumnType ColumnType { get; }
+    public RecordColumnType ColumnType { get; }
 
     /// <summary>
     /// 获取列是否为可空类型。
@@ -105,11 +105,11 @@ public abstract class FrameColumn : IXProp
 
     internal void OnSet(int row)
     {
-        if (row < 0 || row >= this.Frame.Count) throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {Frame.Count - 1}]");
+        if (row < 0 || row >= this.Record.Count) throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {Record.Count - 1}]");
     }
     internal void OnGet(int row)
     {
-        if (row < 0 || row >= this.Frame.Count) throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {Frame.Count - 1}]");
+        if (row < 0 || row >= this.Record.Count) throw new ArgumentOutOfRangeException(nameof(row), $"行索引 {row} 超出有效范围 [0, {Record.Count - 1}]");
     }
 
     #region To 
@@ -146,13 +146,13 @@ public abstract class FrameColumn : IXProp
 
     object? IXProp.GetValue(object instance)
     {
-        if (instance is FrameRow row) return Get(row.Row);
+        if (instance is RecordRow row) return Get(row.Row);
         throw new InvalidCastException();
     }
 
     void IXProp.SetValue(object instance, object? value)
     {
-        if (instance is FrameRow row)
+        if (instance is RecordRow row)
             Set(row.Row, value);
         else
             throw new InvalidCastException();

--- a/src/LuYao.Common/Data/RecordColumnCollection.cs
+++ b/src/LuYao.Common/Data/RecordColumnCollection.cs
@@ -23,24 +23,24 @@ namespace LuYao.Data;
 ///     同名不同类型抛 <see cref="InvalidOperationException"/>。</description></item>
 /// </list>
 /// </remarks>
-public class FrameColumnCollection : IReadOnlyList<FrameColumn>
+public class RecordColumnCollection : IReadOnlyList<RecordColumn>
 {
-    private readonly KeyedList<string, FrameColumn> _items
-        = new KeyedList<string, FrameColumn>(c => c.Name, StringComparer.Ordinal);
+    private readonly KeyedList<string, RecordColumn> _items
+        = new KeyedList<string, RecordColumn>(c => c.Name, StringComparer.Ordinal);
 
     /// <summary>
     /// 关联的记录。
     /// </summary>
-    public Frame Frame { get; }
+    public Record Record { get; }
 
     /// <summary>
-    /// 初始化 <see cref="FrameColumnCollection"/> 类的新实例。
+    /// 初始化 <see cref="RecordColumnCollection"/> 类的新实例。
     /// </summary>
     /// <param name="record">关联的记录实例。</param>
     /// <exception cref="ArgumentNullException">当 <paramref name="record"/> 为 null 时抛出。</exception>
-    internal FrameColumnCollection(Frame record)
+    internal RecordColumnCollection(Record record)
     {
-        this.Frame = record ?? throw new ArgumentNullException(nameof(record));
+        this.Record = record ?? throw new ArgumentNullException(nameof(record));
     }
 
     /// <summary>
@@ -52,13 +52,13 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// 按索引访问列。
     /// </summary>
     /// <param name="index">从零开始的列索引。</param>
-    public FrameColumn this[int index] => _items[index];
+    public RecordColumn this[int index] => _items[index];
 
     /// <summary>
     /// 按列名访问列。列不存在时返回 <see langword="null"/>。
     /// </summary>
     /// <param name="name">要查找的列名。</param>
-    public FrameColumn? this[string name]
+    public RecordColumn? this[string name]
     {
         get
         {
@@ -73,13 +73,13 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     internal void OnAddRow()
     {
         if (_items.Count == 0) return;
-        int num = this.Frame.Count;
-        foreach (FrameColumn col in _items)
+        int num = this.Record.Count;
+        foreach (RecordColumn col in _items)
         {
             if (col.Capacity >= num) continue;
             col.Extend(num);
         }
-        this.Frame.Capacity = _items.Min(f => f.Capacity);
+        this.Record.Capacity = _items.Min(f => f.Capacity);
     }
 
     /// <summary>
@@ -108,8 +108,8 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// 根据列名查找列。
     /// </summary>
     /// <param name="name">要查找的列名。</param>
-    /// <returns>如果找到列则返回 <see cref="FrameColumn"/> 实例，否则返回 <see langword="null"/>。</returns>
-    public FrameColumn? Find(string name)
+    /// <returns>如果找到列则返回 <see cref="RecordColumn"/> 实例，否则返回 <see langword="null"/>。</returns>
+    public RecordColumn? Find(string name)
     {
         if (name == null) return null;
         int idx = _items.IndexOfKey(name);
@@ -117,12 +117,12 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     }
 
     /// <summary>
-    /// 根据列名获取 <see cref="FrameColumn"/> 实例。
+    /// 根据列名获取 <see cref="RecordColumn"/> 实例。
     /// </summary>
     /// <param name="name">要查找的列名。</param>
-    /// <returns>对应的 <see cref="FrameColumn"/> 实例。</returns>
+    /// <returns>对应的 <see cref="RecordColumn"/> 实例。</returns>
     /// <exception cref="KeyNotFoundException">当列名不存在时抛出。</exception>
-    public FrameColumn Get(string name)
+    public RecordColumn Get(string name)
     {
         var col = Find(name);
         if (col == null) throw new KeyNotFoundException($"列 '{name}' 不存在");
@@ -134,13 +134,13 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// </summary>
     /// <typeparam name="T">要查找的列的数据类型。</typeparam>
     /// <param name="name">要查找的列名。</param>
-    /// <returns>如果找到且类型匹配则返回 <see cref="FrameColumn{T}"/> 实例；列不存在时返回 <see langword="null"/>。</returns>
+    /// <returns>如果找到且类型匹配则返回 <see cref="RecordColumn{T}"/> 实例；列不存在时返回 <see langword="null"/>。</returns>
     /// <exception cref="InvalidCastException">当找到的列类型与 <typeparamref name="T"/> 不匹配时抛出。</exception>
-    public FrameColumn<T>? Find<T>(string name)
+    public RecordColumn<T>? Find<T>(string name)
     {
         var col = this.Find(name);
         if (col == null) return null;
-        if (col.Type == typeof(T)) return (FrameColumn<T>)col;
+        if (col.Type == typeof(T)) return (RecordColumn<T>)col;
         throw new InvalidCastException($"列 '{name}' 的类型为 {col.Type.Name}，无法转换为 {typeof(T).Name}");
     }
 
@@ -166,7 +166,7 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     public void Clear()
     {
         _items.Clear();
-        this.Frame.OnClear();
+        this.Record.OnClear();
     }
 
     #region Add
@@ -176,10 +176,10 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// </summary>
     /// <param name="name">列名。</param>
     /// <param name="type">列的数据类型。</param>
-    /// <returns>新建或已有的 <see cref="FrameColumn"/> 实例。</returns>
+    /// <returns>新建或已有的 <see cref="RecordColumn"/> 实例。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="name"/> 为空或空白时抛出。</exception>
     /// <exception cref="InvalidOperationException">当列名已存在但类型与 <paramref name="type"/> 不一致时抛出。</exception>
-    public FrameColumn Add(string name, Type type)
+    public RecordColumn Add(string name, Type type)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name), "列名不能为空");
         if (type == null) throw new ArgumentNullException(nameof(type));
@@ -191,7 +191,7 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
                     $"列 '{name}' 已存在且类型为 {existing.Type.Name}，无法以类型 {type.Name} 重新添加。");
             return existing;
         }
-        FrameColumn col = Helpers.MakeFrameColumn(this.Frame, name, type);
+        RecordColumn col = Helpers.MakeRecordColumn(this.Record, name, type);
         _items.Add(col);
         return col;
     }
@@ -201,10 +201,10 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// </summary>
     /// <typeparam name="T">列的数据类型。</typeparam>
     /// <param name="name">列名。</param>
-    /// <returns>新建或已有的 <see cref="FrameColumn{T}"/> 实例。</returns>
+    /// <returns>新建或已有的 <see cref="RecordColumn{T}"/> 实例。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="name"/> 为空或空白时抛出。</exception>
     /// <exception cref="InvalidOperationException">当列名已存在但类型与 <typeparamref name="T"/> 不一致时抛出。</exception>
-    public FrameColumn<T> Add<T>(string name)
+    public RecordColumn<T> Add<T>(string name)
     {
         if (string.IsNullOrWhiteSpace(name)) throw new ArgumentNullException(nameof(name), "列名不能为空");
         var existing = Find(name);
@@ -213,10 +213,10 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
             if (existing.Type != typeof(T))
                 throw new InvalidOperationException(
                     $"列 '{name}' 已存在且类型为 {existing.Type.Name}，无法以类型 {typeof(T).Name} 重新添加。");
-            return (FrameColumn<T>)existing;
+            return (RecordColumn<T>)existing;
         }
         Helpers.ValidateColumnType(typeof(T));
-        var col = new FrameColumn<T>(this.Frame, name, typeof(T));
+        var col = new RecordColumn<T>(this.Record, name, typeof(T));
         _items.Add(col);
         return col;
     }
@@ -313,13 +313,13 @@ public class FrameColumnCollection : IReadOnlyList<FrameColumn>
     /// </summary>
     /// <param name="index">要替换的列索引。</param>
     /// <param name="column">新的列实例。</param>
-    internal void ReplaceAt(int index, FrameColumn column)
+    internal void ReplaceAt(int index, RecordColumn column)
     {
         _items[index] = column;
     }
 
     /// <inheritdoc/>
-    public IEnumerator<FrameColumn> GetEnumerator() => _items.GetEnumerator();
+    public IEnumerator<RecordColumn> GetEnumerator() => _items.GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
 }

--- a/src/LuYao.Common/Data/RecordColumnType.cs
+++ b/src/LuYao.Common/Data/RecordColumnType.cs
@@ -1,10 +1,10 @@
 ﻿namespace LuYao.Data;
 
 /// <summary>
-/// 定义 <see cref="FrameColumn"/> 支持的所有基础列数据类型。
-/// 白名单封闭，不可外部扩展。可空性通过 <see cref="FrameColumn.IsNullable"/> 独立表达。
+/// 定义 <see cref="RecordColumn"/> 支持的所有基础列数据类型。
+/// 白名单封闭，不可外部扩展。可空性通过 <see cref="RecordColumn.IsNullable"/> 独立表达。
 /// </summary>
-public enum FrameColumnType : byte
+public enum RecordColumnType : byte
 {
     /// <summary>布尔类型 (<see cref="bool"/>)。</summary>
     Boolean = 1,

--- a/src/LuYao.Common/Data/RecordDebuggerTypeProxy.cs
+++ b/src/LuYao.Common/Data/RecordDebuggerTypeProxy.cs
@@ -3,12 +3,12 @@ using System.Diagnostics;
 
 namespace LuYao.Data;
 
-internal class FrameDebuggerTypeProxy
+internal class RecordDebuggerTypeProxy
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly Frame _record;
+    private readonly Record _record;
 
-    public FrameDebuggerTypeProxy(Frame record)
+    public RecordDebuggerTypeProxy(Record record)
     {
         _record = record ?? throw new ArgumentNullException(nameof(record));
     }

--- a/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
+++ b/src/LuYao.Common/Data/RecordRow.DynamicMetaObject.cs
@@ -4,33 +4,33 @@ using System.Linq.Expressions;
 
 namespace LuYao.Data;
 
-partial struct FrameRow
+partial struct RecordRow
 {
     /// <summary>
-    /// 为 <see cref="FrameRow"/> 提供动态成员绑定支持。
+    /// 为 <see cref="RecordRow"/> 提供动态成员绑定支持。
     /// </summary>
-    private sealed class FrameRowMetaObject : DynamicMetaObject
+    private sealed class RecordRowMetaObject : DynamicMetaObject
     {
         // dynamic 读取/写入走 this[string] 索引器
         private static readonly System.Reflection.PropertyInfo IndexerProperty =
-            typeof(FrameRow).GetProperty("Item", new[] { typeof(string) })!;
+            typeof(RecordRow).GetProperty("Item", new[] { typeof(string) })!;
 
-        public FrameRowMetaObject(Expression expression, FrameRow value)
+        public RecordRowMetaObject(Expression expression, RecordRow value)
             : base(expression, BindingRestrictions.Empty, value)
         {
         }
 
         private Expression GetLimitedSelf()
-            => Expression.Convert(Expression, typeof(FrameRow));
+            => Expression.Convert(Expression, typeof(RecordRow));
 
         /// <inheritdoc/>
         public override System.Collections.Generic.IEnumerable<string> GetDynamicMemberNames()
-            => ((FrameRow)Value!).Frame.Columns.Select(c => c.Name);
+            => ((RecordRow)Value!).Record.Columns.Select(c => c.Name);
 
         /// <inheritdoc/>
         public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
         {
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(FrameRow));
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
             var call = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { Expression.Constant(binder.Name) });
             return new DynamicMetaObject(call, restrictions);
         }
@@ -38,7 +38,7 @@ partial struct FrameRow
         /// <inheritdoc/>
         public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
         {
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(FrameRow));
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
             var indexAccess = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { Expression.Constant(binder.Name) });
             var assign = Expression.Assign(indexAccess, Expression.Convert(value.Expression, typeof(object)));
             return new DynamicMetaObject(assign, restrictions);
@@ -49,7 +49,7 @@ partial struct FrameRow
         {
             if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
                 return base.BindGetIndex(binder, indexes);
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(FrameRow));
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
             var key = Expression.Convert(indexes[0].Expression, typeof(string));
             var call = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { key });
             return new DynamicMetaObject(call, restrictions);
@@ -60,7 +60,7 @@ partial struct FrameRow
         {
             if (indexes.Length != 1 || indexes[0].LimitType != typeof(string))
                 return base.BindSetIndex(binder, indexes, value);
-            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(FrameRow));
+            var restrictions = BindingRestrictions.GetTypeRestriction(Expression, typeof(RecordRow));
             var key = Expression.Convert(indexes[0].Expression, typeof(string));
             var indexAccess = Expression.MakeIndex(GetLimitedSelf(), IndexerProperty, new[] { key });
             var assign = Expression.Assign(indexAccess, Expression.Convert(value.Expression, typeof(object)));

--- a/src/LuYao.Common/Data/RecordRow.Mapping.cs
+++ b/src/LuYao.Common/Data/RecordRow.Mapping.cs
@@ -2,7 +2,7 @@
 
 namespace LuYao.Data;
 
-partial struct FrameRow
+partial struct RecordRow
 {
     /// <summary>
     /// 将当前行的列值填充到已有对象 <paramref name="data"/> 的对应属性中。

--- a/src/LuYao.Common/Data/RecordRow.cs
+++ b/src/LuYao.Common/Data/RecordRow.cs
@@ -8,18 +8,18 @@ namespace LuYao.Data;
 /// <summary>
 /// 代表一行数据，提供对列存储数据集合中特定行数据的访问。
 /// </summary>
-public partial struct FrameRow : IDynamicMetaObjectProvider
+public partial struct RecordRow : IDynamicMetaObjectProvider
 {
     /// <summary>
-    /// 初始化 <see cref="FrameRow"/> 结构体的新实例。
+    /// 初始化 <see cref="RecordRow"/> 结构体的新实例。
     /// </summary>
     /// <param name="record">包含此行的数据集合。</param>
     /// <param name="row">行索引，必须在有效范围内。</param>
     /// <exception cref="ArgumentOutOfRangeException">当行索引超出记录范围时抛出。</exception>
     /// <exception cref="ArgumentNullException">当记录参数为 null 时抛出。</exception>
-    internal FrameRow(Frame record, int row)
+    internal RecordRow(Record record, int row)
     {
-        this.Frame = record ?? throw new ArgumentNullException(nameof(record));
+        this.Record = record ?? throw new ArgumentNullException(nameof(record));
         if (row < 0 || row >= record.Count) throw new ArgumentOutOfRangeException(nameof(row));
         this.Row = row;
     }
@@ -27,8 +27,8 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     /// <summary>
     /// 获取包含此行的数据集合。
     /// </summary>
-    /// <value>关联的 <see cref="Frame"/> 实例。</value>
-    public Frame Frame { get; }
+    /// <value>关联的 <see cref="Record"/> 实例。</value>
+    public Record Record { get; }
 
     /// <summary>
     /// 获取当前行在数据集合中的索引位置。
@@ -40,15 +40,15 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     /// 返回 <see cref="DynamicMetaObject"/>，支持动态成员访问。
     /// </summary>
     public readonly DynamicMetaObject GetMetaObject(System.Linq.Expressions.Expression parameter)
-        => new FrameRowMetaObject(parameter, this);
+        => new RecordRowMetaObject(parameter, this);
 
     /// <summary>
-    /// 定义从 <see cref="FrameRow"/> 到 <see cref="int"/> 的隐式转换。
+    /// 定义从 <see cref="RecordRow"/> 到 <see cref="int"/> 的隐式转换。
     /// 返回行的索引位置。
     /// </summary>
-    /// <param name="rowRef">要转换的 <see cref="FrameRow"/> 实例。</param>
+    /// <param name="rowRef">要转换的 <see cref="RecordRow"/> 实例。</param>
     /// <returns>该行在数据集合中的索引位置。</returns>
-    public static implicit operator int(FrameRow rowRef) => rowRef.Row;
+    public static implicit operator int(RecordRow rowRef) => rowRef.Row;
 
     /// <summary>
     /// 返回包含行号与当前行列值的字符串表示。
@@ -58,7 +58,7 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
         var sb = new StringBuilder();
         sb.Append("{ Row = ").Append(this.Row).Append(", Data = { ");
         bool first = true;
-        foreach (var col in this.Frame.Columns)
+        foreach (var col in this.Record.Columns)
         {
             if (!first) sb.Append(", ");
             var value = col.Get(this);
@@ -75,8 +75,8 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     /// <returns>键为列名、值为当前行对应列值的字典。</returns>
     public readonly Dictionary<string, object?> ToDictionary()
     {
-        var ret = new Dictionary<string, object?>(this.Frame.Columns.Count, StringComparer.Ordinal);
-        foreach (var col in this.Frame.Columns)
+        var ret = new Dictionary<string, object?>(this.Record.Columns.Count, StringComparer.Ordinal);
+        foreach (var col in this.Record.Columns)
         {
             ret[col.Name] = col.Get(this);
         }
@@ -86,7 +86,7 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     /// <summary>
     /// 使用列名访问或设置当前行的列值。
     /// </summary>
-    /// <param name="name">要访问或设置的列名。若为 null、空或仅空白，将返回默认值；查找列时使用 Frame.Columns.Find(name)。</param>
+    /// <param name="name">要访问或设置的列名。若为 null、空或仅空白，将返回默认值；查找列时使用 Record.Columns.Find(name)。</param>
     /// <returns>若指定列存在，返回该列在当前行的值；否则返回 null（或默认）。在设置器中：若列不存在且 value 非 null，将根据 value 的运行时类型创建新列并赋值。</returns>
     public readonly object? this[String name]
     {
@@ -94,7 +94,7 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
         {
             if (!string.IsNullOrWhiteSpace(name))
             {
-                var col = this.Frame.Columns.Find(name);
+                var col = this.Record.Columns.Find(name);
                 if (col != null) return col.Get(this);
             }
             return default;
@@ -102,11 +102,11 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
         set
         {
             if (string.IsNullOrWhiteSpace(name)) return;
-            var col = this.Frame.Columns.Find(name);
+            var col = this.Record.Columns.Find(name);
             if (col == null)
             {
                 if (value == null) return;
-                col = this.Frame.Columns.Add(name, value.GetType());
+                col = this.Record.Columns.Add(name, value.GetType());
             }
             col.Set(this, value);
         }
@@ -121,7 +121,7 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     public readonly T? To<T>(String name)
     {
         if (string.IsNullOrWhiteSpace(name)) return default;
-        var col = this.Frame.Columns.Find(name);
+        var col = this.Record.Columns.Find(name);
         if (col == null) return default;
         return col.To<T>(this);
     }
@@ -134,7 +134,7 @@ public partial struct FrameRow : IDynamicMetaObjectProvider
     public readonly String ToString(string? name)
     {
         if (string.IsNullOrWhiteSpace(name)) return string.Empty;
-        var col = this.Frame.Columns.Find(name);
+        var col = this.Record.Columns.Find(name);
         if (col == null) return string.Empty;
         return col.ToString(this.Row);
     }

--- a/src/LuYao.Common/Data/RecordSchema.cs
+++ b/src/LuYao.Common/Data/RecordSchema.cs
@@ -4,13 +4,13 @@ using System.Collections.Generic;
 namespace LuYao.Data;
 
 /// <summary>
-/// 表示 Frame 的列定义信息（列名 + 类型），用于序列化、传输或 Schema 比较。
+/// 表示 Record 的列定义信息（列名 + 类型），用于序列化、传输或 Schema 比较。
 /// </summary>
-public sealed class FrameSchema
+public sealed class RecordSchema
 {
     private readonly List<ColumnDef> _columns;
 
-    internal FrameSchema(List<ColumnDef> columns)
+    internal RecordSchema(List<ColumnDef> columns)
     {
         _columns = columns ?? throw new ArgumentNullException(nameof(columns));
     }
@@ -33,7 +33,7 @@ public sealed class FrameSchema
         /// <summary>
         /// 列的基础枚举类型标识。
         /// </summary>
-        public FrameColumnType ColumnType { get; }
+        public RecordColumnType ColumnType { get; }
 
         /// <summary>
         /// 列是否为可空类型。
@@ -45,7 +45,7 @@ public sealed class FrameSchema
         /// </summary>
         public Type Type => Helpers.GetClrType(ColumnType, IsNullable);
 
-        internal ColumnDef(string name, FrameColumnType columnType, bool isNullable)
+        internal ColumnDef(string name, RecordColumnType columnType, bool isNullable)
         {
             Name = name;
             ColumnType = columnType;

--- a/src/LuYao.Common/Data/RecordSet.Binary.cs
+++ b/src/LuYao.Common/Data/RecordSet.Binary.cs
@@ -4,12 +4,12 @@ using System.Text;
 
 namespace LuYao.Data;
 
-public partial class FrameSet
+public partial class RecordSet
 {
     private const byte BinaryFormatVersion = 1;
 
     /// <summary>
-    /// 将当前 <see cref="FrameSet"/> 写入二进制流。
+    /// 将当前 <see cref="RecordSet"/> 写入二进制流。
     /// </summary>
     /// <param name="stream">目标流。</param>
     public void WriteTo(Stream stream)
@@ -20,25 +20,25 @@ public partial class FrameSet
     }
 
     /// <summary>
-    /// 将当前 <see cref="FrameSet"/> 写入 <see cref="BinaryWriter"/>。
+    /// 将当前 <see cref="RecordSet"/> 写入 <see cref="BinaryWriter"/>。
     /// </summary>
     /// <param name="writer">目标写入器。</param>
     public void WriteTo(BinaryWriter writer)
     {
         if (writer == null) throw new ArgumentNullException(nameof(writer));
-        BinaryPayloadHeader.Write(writer, BinaryPayloadType.FrameSet);
+        BinaryPayloadHeader.Write(writer, BinaryPayloadType.RecordSet);
         writer.Write(BinaryFormatVersion);
         writer.Write(_records.Count);
         foreach (var kvp in _records)
         {
-            // 以字典键作为权威名称，防止 Frame.Name 被外部修改后产生漂移
+            // 以字典键作为权威名称，防止 Record.Name 被外部修改后产生漂移
             kvp.Value.Name = kvp.Key;
             kvp.Value.WriteTo(writer);
         }
     }
 
     /// <summary>
-    /// 从二进制流读取并填充当前 <see cref="FrameSet"/> 实例。
+    /// 从二进制流读取并填充当前 <see cref="RecordSet"/> 实例。
     /// </summary>
     /// <param name="stream">源流。</param>
     public void ReadFrom(Stream stream)
@@ -49,13 +49,13 @@ public partial class FrameSet
     }
 
     /// <summary>
-    /// 从 <see cref="BinaryReader"/> 读取并填充当前 <see cref="FrameSet"/> 实例。
+    /// 从 <see cref="BinaryReader"/> 读取并填充当前 <see cref="RecordSet"/> 实例。
     /// </summary>
     /// <param name="reader">源读取器。</param>
     public void ReadFrom(BinaryReader reader)
     {
         if (reader == null) throw new ArgumentNullException(nameof(reader));
-        byte version = BinaryPayloadHeader.ReadHeaderAndVersion(reader, BinaryPayloadType.FrameSet);
+        byte version = BinaryPayloadHeader.ReadHeaderAndVersion(reader, BinaryPayloadType.RecordSet);
         if (version != BinaryFormatVersion)
             throw new InvalidOperationException($"不支持的二进制格式版本: {version}");
 
@@ -63,20 +63,20 @@ public partial class FrameSet
         int count = reader.ReadInt32();
         for (int i = 0; i < count; i++)
         {
-            var record = new Frame();
+            var record = new Record();
             record.ReadFrom(reader);
             this.Add(record.Name, record);
         }
     }
 
     /// <summary>
-    /// 从二进制流创建新的 <see cref="FrameSet"/> 实例。
+    /// 从二进制流创建新的 <see cref="RecordSet"/> 实例。
     /// </summary>
     /// <param name="stream">源流。</param>
-    /// <returns>反序列化的 <see cref="FrameSet"/> 实例。</returns>
-    public static FrameSet FromStream(Stream stream)
+    /// <returns>反序列化的 <see cref="RecordSet"/> 实例。</returns>
+    public static RecordSet FromStream(Stream stream)
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
         set.ReadFrom(stream);
         return set;
     }
@@ -95,8 +95,8 @@ public partial class FrameSet
     /// 从字节数组反序列化。
     /// </summary>
     /// <param name="data">二进制数据。</param>
-    /// <returns>反序列化的 <see cref="FrameSet"/> 实例。</returns>
-    public static FrameSet FromBytes(byte[] data)
+    /// <returns>反序列化的 <see cref="RecordSet"/> 实例。</returns>
+    public static RecordSet FromBytes(byte[] data)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
         using var ms = new MemoryStream(data, writable: false);
@@ -104,14 +104,14 @@ public partial class FrameSet
     }
 
     /// <summary>
-    /// 检测二进制数据是否为带类型头的 <see cref="FrameSet"/>。
+    /// 检测二进制数据是否为带类型头的 <see cref="RecordSet"/>。
     /// </summary>
     /// <param name="data">二进制数据。</param>
-    /// <returns>当数据包含 <see cref="FrameSet"/> 类型头时返回 true；否则返回 false。</returns>
+    /// <returns>当数据包含 <see cref="RecordSet"/> 类型头时返回 true；否则返回 false。</returns>
     public static bool IsBinaryPayload(byte[] data)
     {
         if (data == null) return false;
         return BinaryPayloadHeader.TryGetPayloadType(data, out var payloadType)
-            && payloadType == BinaryPayloadType.FrameSet;
+            && payloadType == BinaryPayloadType.RecordSet;
     }
 }

--- a/src/LuYao.Common/Data/RecordSet.cs
+++ b/src/LuYao.Common/Data/RecordSet.cs
@@ -8,59 +8,59 @@ using System.Linq;
 namespace LuYao.Data;
 
 /// <summary>
-/// 命名 Frame 集合，用于组织和管理多个 <see cref="Frame"/>。
-/// 以 <see cref="Frame.Name"/> 作为管理键，支持按名称增删改查。
+/// 命名 Record 集合，用于组织和管理多个 <see cref="Record"/>。
+/// 以 <see cref="Record.Name"/> 作为管理键，支持按名称增删改查。
 /// </summary>
-public partial class FrameSet : IEnumerable<Frame>
+public partial class RecordSet : IEnumerable<Record>
 {
-    private readonly SortedDictionary<string, Frame> _records;
+    private readonly SortedDictionary<string, Record> _records;
     private readonly StringComparer _comparer;
 
     /// <summary>
-    /// 使用默认名称比较策略（区分大小写）初始化 <see cref="FrameSet"/> 的新实例。
+    /// 使用默认名称比较策略（区分大小写）初始化 <see cref="RecordSet"/> 的新实例。
     /// </summary>
-    public FrameSet() : this(StringComparer.Ordinal)
+    public RecordSet() : this(StringComparer.Ordinal)
     {
     }
 
     /// <summary>
-    /// 使用指定的名称比较策略初始化 <see cref="FrameSet"/> 的新实例。
+    /// 使用指定的名称比较策略初始化 <see cref="RecordSet"/> 的新实例。
     /// </summary>
-    /// <param name="comparer">用于比较 Frame 名称的比较器。</param>
+    /// <param name="comparer">用于比较 Record 名称的比较器。</param>
     /// <exception cref="ArgumentNullException">当 <paramref name="comparer"/> 为 null 时抛出。</exception>
-    public FrameSet(StringComparer comparer)
+    public RecordSet(StringComparer comparer)
     {
         _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
-        _records = new SortedDictionary<string, Frame>(_comparer);
+        _records = new SortedDictionary<string, Record>(_comparer);
     }
 
     /// <summary>
-    /// 获取集合中 Frame 的数量。
+    /// 获取集合中 Record 的数量。
     /// </summary>
     public int Count => _records.Count;
 
     /// <summary>
-    /// 获取集合中所有 Frame 的名称。
+    /// 获取集合中所有 Record 的名称。
     /// </summary>
     public IEnumerable<string> Names => _records.Keys;
 
     /// <summary>
-    /// 按名称获取 Frame。
+    /// 按名称获取 Record。
     /// </summary>
-    /// <param name="name">Frame 的名称。</param>
-    /// <returns>对应的 <see cref="Frame"/> 实例。</returns>
+    /// <param name="name">Record 的名称。</param>
+    /// <returns>对应的 <see cref="Record"/> 实例。</returns>
     /// <exception cref="KeyNotFoundException">当名称不存在时抛出。</exception>
-    public Frame this[string name] => Get(name);
+    public Record this[string name] => Get(name);
 
     /// <summary>
-    /// 按名称添加一个 Frame。如果名称已存在则抛出异常。
+    /// 按名称添加一个 Record。如果名称已存在则抛出异常。
     /// </summary>
-    /// <param name="name">Frame 的名称。</param>
-    /// <param name="record">要添加的 <see cref="Frame"/> 实例。</param>
+    /// <param name="name">Record 的名称。</param>
+    /// <param name="record">要添加的 <see cref="Record"/> 实例。</param>
     /// <exception cref="ArgumentException">当 <paramref name="name"/> 为空或空白时抛出。</exception>
     /// <exception cref="ArgumentNullException">当 <paramref name="record"/> 为 null 时抛出。</exception>
     /// <exception cref="ArgumentException">当名称已存在时抛出。</exception>
-    public void Add(string name, Frame record)
+    public void Add(string name, Record record)
     {
         ValidateName(name);
         if (record == null) throw new ArgumentNullException(nameof(record));
@@ -70,13 +70,13 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 按名称设置一个 Frame。如果名称已存在则覆盖，不存在则添加。
+    /// 按名称设置一个 Record。如果名称已存在则覆盖，不存在则添加。
     /// </summary>
-    /// <param name="name">Frame 的名称。</param>
-    /// <param name="record">要设置的 <see cref="Frame"/> 实例。</param>
+    /// <param name="name">Record 的名称。</param>
+    /// <param name="record">要设置的 <see cref="Record"/> 实例。</param>
     /// <exception cref="ArgumentException">当 <paramref name="name"/> 为空或空白时抛出。</exception>
     /// <exception cref="ArgumentNullException">当 <paramref name="record"/> 为 null 时抛出。</exception>
-    public void Set(string name, Frame record)
+    public void Set(string name, Record record)
     {
         ValidateName(name);
         if (record == null) throw new ArgumentNullException(nameof(record));
@@ -85,12 +85,12 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 按名称获取 Frame。
+    /// 按名称获取 Record。
     /// </summary>
-    /// <param name="name">Frame 的名称。</param>
-    /// <returns>对应的 <see cref="Frame"/> 实例。</returns>
+    /// <param name="name">Record 的名称。</param>
+    /// <returns>对应的 <see cref="Record"/> 实例。</returns>
     /// <exception cref="KeyNotFoundException">当名称不存在时抛出。</exception>
-    public Frame Get(string name)
+    public Record Get(string name)
     {
         if (!_records.TryGetValue(name, out var record))
             throw new KeyNotFoundException($"名称 '{name}' 不存在");
@@ -98,28 +98,28 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 尝试按名称获取 Frame。
+    /// 尝试按名称获取 Record。
     /// </summary>
-    /// <param name="name">Frame 的名称。</param>
-    /// <param name="record">如果找到则返回对应的 <see cref="Frame"/> 实例，否则为 null。</param>
+    /// <param name="name">Record 的名称。</param>
+    /// <param name="record">如果找到则返回对应的 <see cref="Record"/> 实例，否则为 null。</param>
     /// <returns>如果找到则返回 true，否则返回 false。</returns>
 
 #if NETCOREAPP2_0_OR_GREATER
-    public bool TryGet(string name, [MaybeNullWhen(false)] out Frame record)
+    public bool TryGet(string name, [MaybeNullWhen(false)] out Record record)
     {
         return _records.TryGetValue(name, out record);
     }
 #else
-    public bool TryGet(string name, out Frame record)
+    public bool TryGet(string name, out Record record)
     {
         return _records.TryGetValue(name, out record);
     }
 #endif
 
     /// <summary>
-    /// 按名称删除 Frame。
+    /// 按名称删除 Record。
     /// </summary>
-    /// <param name="name">要删除的 Frame 的名称。</param>
+    /// <param name="name">要删除的 Record 的名称。</param>
     /// <returns>如果成功删除则返回 true，否则返回 false。</returns>
     public bool Remove(string name)
     {
@@ -127,7 +127,7 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 判断指定名称的 Frame 是否存在。
+    /// 判断指定名称的 Record 是否存在。
     /// </summary>
     /// <param name="name">要检查的名称。</param>
     /// <returns>如果存在则返回 true，否则返回 false。</returns>
@@ -137,7 +137,7 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 重命名一个 Frame。
+    /// 重命名一个 Record。
     /// </summary>
     /// <param name="oldName">原名称。</param>
     /// <param name="newName">新名称。</param>
@@ -158,7 +158,7 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 清空所有 Frame。
+    /// 清空所有 Record。
     /// </summary>
     public void Clear()
     {
@@ -166,27 +166,27 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <summary>
-    /// 从 <see cref="DataSet"/> 创建 <see cref="FrameSet"/>。
+    /// 从 <see cref="DataSet"/> 创建 <see cref="RecordSet"/>。
     /// </summary>
     /// <param name="ds">源 <see cref="DataSet"/> 实例。</param>
-    /// <returns>包含所有表数据的 <see cref="FrameSet"/> 实例。</returns>
+    /// <returns>包含所有表数据的 <see cref="RecordSet"/> 实例。</returns>
     /// <exception cref="ArgumentNullException">当 <paramref name="ds"/> 为 null 时抛出。</exception>
-    public static FrameSet FromDataSet(DataSet ds)
+    public static RecordSet FromDataSet(DataSet ds)
     {
         if (ds == null) throw new ArgumentNullException(nameof(ds));
-        var set = new FrameSet();
+        var set = new RecordSet();
         foreach (DataTable dt in ds.Tables)
         {
-            var record = Frame.Read(dt);
+            var record = Record.Read(dt);
             set.Add(dt.TableName, record);
         }
         return set;
     }
 
     /// <summary>
-    /// 将当前 <see cref="FrameSet"/> 导出为 <see cref="DataSet"/>。
+    /// 将当前 <see cref="RecordSet"/> 导出为 <see cref="DataSet"/>。
     /// </summary>
-    /// <returns>包含所有 Frame 数据的 <see cref="DataSet"/> 实例。</returns>
+    /// <returns>包含所有 Record 数据的 <see cref="DataSet"/> 实例。</returns>
     public DataSet ToDataSet()
     {
         var ds = new DataSet();
@@ -211,7 +211,7 @@ public partial class FrameSet : IEnumerable<Frame>
     }
 
     /// <inheritdoc/>
-    public IEnumerator<Frame> GetEnumerator() => _records.Values.GetEnumerator();
+    public IEnumerator<Record> GetEnumerator() => _records.Values.GetEnumerator();
 
     /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/GenericMethodTests.cs
@@ -10,13 +10,13 @@ namespace LuYao.Data;
 public class GenericMethodTests
 {
     /// <summary>
-    /// Verifies generic Set on FrameColumn.
+    /// Verifies generic Set on RecordColumn.
     /// </summary>
     [TestMethod]
-    public void FrameColumn_GenericSet_ShouldWorkWithAllTypes()
+    public void RecordColumn_GenericSet_ShouldWorkWithAllTypes()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
@@ -45,13 +45,13 @@ public class GenericMethodTests
     }
 
     /// <summary>
-    /// Verifies generic Set through FrameRow.
+    /// Verifies generic Set through RecordRow.
     /// </summary>
     [TestMethod]
-    public void FrameRow_GenericSet_ShouldWorkWithAllTypes()
+    public void RecordRow_GenericSet_ShouldWorkWithAllTypes()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var boolColumn = record.Columns.Add<Boolean>("BoolColumn");
@@ -76,7 +76,7 @@ public class GenericMethodTests
     public void GenericTo_ShouldReturnCorrectTypes()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var row = record.AddRow();
@@ -96,7 +96,7 @@ public class GenericMethodTests
         string intAsString = intColumn.To<string>(0);
         Assert.AreEqual("42", intAsString);
 
-        // Verify access through FrameRow
+        // Verify access through RecordRow
         int intFromRow = row.To<int>("IntColumn");
         Assert.AreEqual(42, intFromRow);
 
@@ -111,7 +111,7 @@ public class GenericMethodTests
     public void GenericMethods_NullableTypes_ShouldWork()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var row = record.AddRow();
 
@@ -133,7 +133,7 @@ public class GenericMethodTests
     public void GenericMethods_EdgeCases_ShouldHandleCorrectly()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var stringColumn = record.Columns.Add<String>("StringColumn");
         var row = record.AddRow();
 
@@ -154,7 +154,7 @@ public class GenericMethodTests
     public void GenericSet_InvalidIndex_ShouldThrowException()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         record.AddRow(); // only one row, valid index is 0
 
@@ -173,7 +173,7 @@ public class GenericMethodTests
     public void GenericMethods_PerformanceComparison()
     {
         // Arrange
-        var record = new Frame("PerfTest", 1000);
+        var record = new Record("PerfTest", 1000);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
 
         // Add 1000 rows
@@ -229,7 +229,7 @@ public class GenericMethodTests
     public void GenericMethods_TypeConversionMatrix_ShouldWork()
     {
         // Arrange
-        var record = new Frame("ConversionTest", 1);
+        var record = new Record("ConversionTest", 1);
         var intColumn = record.Columns.Add<Int32>("IntColumn");
         var doubleColumn = record.Columns.Add<Double>("DoubleColumn");
         var stringColumn = record.Columns.Add<String>("StringColumn");

--- a/tests/LuYao.Common.UnitTests/Data/HelperTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/HelperTests.cs
@@ -15,25 +15,25 @@ public class HelperTests
     }
 
     [TestMethod]
-    public void MakeFrameColumn_ShouldCreateFrameColumnOfType()
+    public void MakeRecordColumn_ShouldCreateRecordColumnOfType()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
         string name = "TestColumn";
         Type type = typeof(int);
         // Act
-        var column = Helpers.MakeFrameColumn(record, name, type);
+        var column = Helpers.MakeRecordColumn(record, name, type);
         // Assert
         Assert.IsNotNull(column);
         Assert.AreEqual(name, column.Name);
         Assert.AreEqual(type, column.Type);
-        Assert.IsInstanceOfType(column, typeof(FrameColumn<int>));
+        Assert.IsInstanceOfType(column, typeof(RecordColumn<int>));
     }
 
     [TestMethod]
-    public void MakeFrameColumn_UnsupportedType_ShouldThrow()
+    public void MakeRecordColumn_UnsupportedType_ShouldThrow()
     {
-        var record = new Frame();
-        Assert.Throws<NotSupportedException>(() => Helpers.MakeFrameColumn(record, "Test", typeof(Foo)));
+        var record = new Record();
+        Assert.Throws<NotSupportedException>(() => Helpers.MakeRecordColumn(record, "Test", typeof(Foo)));
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/NameFilterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/NameFilterTests.cs
@@ -106,7 +106,7 @@ public class NameFilterTests
     public void AddFrom_WithNames_RespectsInputOrder()
     {
         // 传入顺序与声明顺序故意相反，验证列顺序与传入顺序一致
-        var record = new Frame();
+        var record = new Record();
         record.Columns.AddFrom<SampleData>(new[] { nameof(SampleData.Email), nameof(SampleData.Id) });
         Assert.AreEqual(nameof(SampleData.Email), record.Columns[0].Name);
         Assert.AreEqual(nameof(SampleData.Id), record.Columns[1].Name);
@@ -115,7 +115,7 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithAnonymousTemplate_AddsColumnsFromTemplateType()
     {
-        var record = new Frame();
+        var record = new Record();
 
         record.Columns.AddFrom(new { Id = 1, Name = "Test", IsOk = true });
 
@@ -131,7 +131,7 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithNullTemplate_ThrowsArgumentNullException()
     {
-        var record = new Frame();
+        var record = new Record();
         SampleData template = null;
 
         var ex = Assert.Throws<ArgumentNullException>(() => record.Columns.AddFrom(template));
@@ -141,8 +141,8 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithFilter_RespectsManualIncludeOrder()
     {
-        // 通过 NameFilter 手动 Include 的顺序应正确反映到 Frame 列顺序
-        var record = new Frame();
+        // 通过 NameFilter 手动 Include 的顺序应正确反映到 Record 列顺序
+        var record = new Record();
         record.Columns.AddFrom<SampleData>(f => f.Clear()
             .Include(x => x.CreatedAt)
             .Include(x => x.Name));
@@ -153,7 +153,7 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithNames_OnlyAddsSpecifiedColumns()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.AddFrom<SampleData>(new[] { nameof(SampleData.Id), nameof(SampleData.Name) });
         Assert.AreEqual(2, record.Columns.Count);
         Assert.IsNotNull(record.Columns[nameof(SampleData.Id)]);
@@ -163,11 +163,11 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithNullOrEmptyNames_AddsNoColumns()
     {
-        var record1 = new Frame();
+        var record1 = new Record();
         record1.Columns.AddFrom<SampleData>(new string[0]);
         Assert.AreEqual(0, record1.Columns.Count, "空数组不应追加任何列。");
 
-        var record2 = new Frame();
+        var record2 = new Record();
         record2.Columns.AddFrom<SampleData>((string[])null);
         Assert.AreEqual(0, record2.Columns.Count, "null 不应追加任何列。");
     }
@@ -175,7 +175,7 @@ public class NameFilterTests
     [TestMethod]
     public void AddFrom_WithFilter_ExcludesSpecifiedColumn()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.AddFrom<SampleData>(f => f.Exclude(x => x.Email));
         Assert.AreEqual(3, record.Columns.Count);
         Assert.IsNull(record.Columns[nameof(SampleData.Email)], "Email column should not exist.");

--- a/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordBoundaryTests.cs
@@ -4,14 +4,14 @@ using System.Linq;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameBoundaryTests
+public class RecordBoundaryTests
 {
     #region Large Row Count Expansion
 
     [TestMethod]
     public void WhenAddingManyRowsThenCapacityGrowsEfficiently()
     {
-        var record = new Frame("Big", 0);
+        var record = new Record("Big", 0);
         var col = record.Columns.Add<int>("Id");
 
         const int rowCount = 10000;
@@ -35,7 +35,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteThenEnumerationIsConsistent()
     {
-        var record = new Frame("Test", 5);
+        var record = new Record("Test", 5);
         var idCol = record.Columns.Add<int>("Id");
 
         for (int i = 0; i < 5; i++)
@@ -55,7 +55,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteThenAddRowThenDataIsCorrect()
     {
-        var record = new Frame("Test", 3);
+        var record = new Record("Test", 3);
         var idCol = record.Columns.Add<int>("Id");
         var nameCol = record.Columns.Add<string>("Name");
 
@@ -87,7 +87,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteWhereThenMatchingRowsRemoved()
     {
-        var record = new Frame("Test", 5);
+        var record = new Record("Test", 5);
         var idCol = record.Columns.Add<int>("Id");
 
         for (int i = 0; i < 5; i++)
@@ -107,7 +107,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteRowsWithIndicesThenCorrectRowsRemoved()
     {
-        var record = new Frame("Test", 5);
+        var record = new Record("Test", 5);
         var idCol = record.Columns.Add<int>("Id");
 
         for (int i = 0; i < 5; i++)
@@ -127,7 +127,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteRowsWithDuplicateIndicesThenDeduplicates()
     {
-        var record = new Frame("Test", 3);
+        var record = new Record("Test", 3);
         var idCol = record.Columns.Add<int>("Id");
 
         for (int i = 0; i < 3; i++)
@@ -145,7 +145,7 @@ public class FrameBoundaryTests
     [TestMethod]
     public void WhenDeleteWhereNoMatchThenNothingDeleted()
     {
-        var record = new Frame("Test", 3);
+        var record = new Record("Test", 3);
         var idCol = record.Columns.Add<int>("Id");
 
         for (int i = 0; i < 3; i++)
@@ -162,12 +162,12 @@ public class FrameBoundaryTests
 
     #endregion
 
-    #region FrameRow.Set<T>
+    #region RecordRow.Set<T>
 
     [TestMethod]
-    public void WhenFrameRowSetGenericThenValueSetCorrectly()
+    public void WhenRecordRowSetGenericThenValueSetCorrectly()
     {
-        var record = new Frame("Test", 1);
+        var record = new Record("Test", 1);
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
 

--- a/tests/LuYao.Common.UnitTests/Data/RecordColumnCollectionTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordColumnCollectionTests.cs
@@ -6,27 +6,27 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace LuYao.Data;
 
 /// <summary>
-/// FrameColumnCollection 新语义单元测试：
+/// RecordColumnCollection 新语义单元测试：
 /// - Find 不存在返回 null；
 /// - Get 不存在抛 KeyNotFoundException；
 /// - Add 同名同类型返回已存在列；
 /// - Add 同名不同类型抛 InvalidOperationException；
-/// - 实现 IReadOnlyList&lt;FrameColumn&gt; 而不再继承 List。
+/// - 实现 IReadOnlyList&lt;RecordColumn&gt; 而不再继承 List。
 /// </summary>
 [TestClass]
-public class FrameColumnCollectionTests
+public class RecordColumnCollectionTests
 {
     [TestMethod]
     public void Find_ColumnNotExist_ReturnsNull()
     {
-        var record = new Frame();
+        var record = new Record();
         Assert.IsNull(record.Columns.Find("NoSuchColumn"));
     }
 
     [TestMethod]
     public void Find_ColumnExists_ReturnsColumn()
     {
-        var record = new Frame();
+        var record = new Record();
         var added = record.Columns.Add<int>("Id");
         var found = record.Columns.Find("Id");
         Assert.AreSame(added, found);
@@ -35,14 +35,14 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Get_ColumnNotExist_ThrowsKeyNotFoundException()
     {
-        var record = new Frame();
+        var record = new Record();
         Assert.Throws<KeyNotFoundException>(() => record.Columns.Get("NoSuchColumn"));
     }
 
     [TestMethod]
     public void Get_ColumnExists_ReturnsColumn()
     {
-        var record = new Frame();
+        var record = new Record();
         var added = record.Columns.Add<string>("Name");
         var got = record.Columns.Get("Name");
         Assert.AreSame(added, got);
@@ -51,7 +51,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Add_SameNameSameType_ReturnsExistingInstance()
     {
-        var record = new Frame();
+        var record = new Record();
         var first = record.Columns.Add<int>("Id");
         var second = record.Columns.Add<int>("Id");
         Assert.AreSame(first, second);
@@ -61,7 +61,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Add_SameNameSameType_NonGeneric_ReturnsExistingInstance()
     {
-        var record = new Frame();
+        var record = new Record();
         var first = record.Columns.Add("Id", typeof(int));
         var second = record.Columns.Add("Id", typeof(int));
         Assert.AreSame(first, second);
@@ -71,7 +71,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Add_SameNameDifferentType_ThrowsInvalidOperationException()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id");
         Assert.Throws<InvalidOperationException>(() => record.Columns.Add<string>("Id"));
     }
@@ -79,7 +79,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Add_SameNameDifferentType_NonGeneric_ThrowsInvalidOperationException()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add("Id", typeof(int));
         Assert.Throws<InvalidOperationException>(() => record.Columns.Add("Id", typeof(string)));
     }
@@ -87,9 +87,9 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Collection_IsReadOnlyList()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id");
-        IReadOnlyList<FrameColumn> readOnly = record.Columns;
+        IReadOnlyList<RecordColumn> readOnly = record.Columns;
         Assert.AreEqual(1, readOnly.Count);
         Assert.AreEqual("Id", readOnly[0].Name);
     }
@@ -97,15 +97,15 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Collection_DoesNotInheritList()
     {
-        // 显式破坏期望：不应再继承 List<FrameColumn>，避免 Add(FrameColumn)、Insert 等绕过校验。
-        var record = new Frame();
-        Assert.IsFalse(typeof(System.Collections.Generic.List<FrameColumn>).IsAssignableFrom(typeof(FrameColumnCollection)));
+        // 显式破坏期望：不应再继承 List<RecordColumn>，避免 Add(RecordColumn)、Insert 等绕过校验。
+        var record = new Record();
+        Assert.IsFalse(typeof(System.Collections.Generic.List<RecordColumn>).IsAssignableFrom(typeof(RecordColumnCollection)));
     }
 
     [TestMethod]
     public void IndexOf_ByName_ReturnsCorrectIndex()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("A");
         record.Columns.Add<string>("B");
         record.Columns.Add<bool>("C");
@@ -119,7 +119,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Contains_Name_Works()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("A");
         Assert.IsTrue(record.Columns.Contains("A"));
         Assert.IsFalse(record.Columns.Contains("B"));
@@ -128,7 +128,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Remove_ByName_RemovesAndReturnsTrue()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("A");
         Assert.IsTrue(record.Columns.Remove("A"));
         Assert.AreEqual(0, record.Columns.Count);
@@ -138,7 +138,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Rename_Works()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("A");
         record.Columns.Rename("A", "B");
         Assert.IsFalse(record.Columns.Contains("A"));
@@ -148,7 +148,7 @@ public class FrameColumnCollectionTests
     [TestMethod]
     public void Enumerate_PreservesInsertionOrder()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("A");
         record.Columns.Add<string>("B");
         record.Columns.Add<bool>("C");

--- a/tests/LuYao.Common.UnitTests/Data/RecordGroupTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordGroupTests.cs
@@ -4,11 +4,11 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameGroupTests
+public class RecordGroupTests
 {
-    private Frame CreateTestFrame()
+    private Record CreateTestRecord()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Category");
         record.Columns.Add<string>("Status");
@@ -25,7 +25,7 @@ public class FrameGroupTests
     [TestMethod]
     public void Group_ByStructColumn_ReturnsGroupedDictionary()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var groups = record.Group<int>("Id");
 
         Assert.IsNotNull(groups);
@@ -36,7 +36,7 @@ public class FrameGroupTests
     [TestMethod]
     public void Group_ByStringColumn_ReturnsGroupedDictionary()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var groups = record.Group("Category");
 
         Assert.IsNotNull(groups);
@@ -52,7 +52,7 @@ public class FrameGroupTests
     [TestMethod]
     public void Group_ByParamsStringColumns_ReturnsGroupedDictionary()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var groups = record.Group("Category", "Status");
 
         Assert.IsNotNull(groups);
@@ -71,7 +71,7 @@ public class FrameGroupTests
     [TestMethod]
     public void Group_ByTwoColumns_ReturnsGroupedDictionary()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var groups = record.Group<string, string>("Category", "Status");
 
         Assert.IsNotNull(groups);
@@ -83,7 +83,7 @@ public class FrameGroupTests
     [TestMethod]
     public void Group_ByThreeColumns_ReturnsGroupedDictionary()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var groups = record.Group<string, string, int>("Category", "Status", "Id");
 
         Assert.IsNotNull(groups);

--- a/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace LuYao.Data;
 
 [TestClass]
-public class FrameMappingTests
+public class RecordMappingTests
 {
     private sealed class TestModel
     {
@@ -20,7 +20,7 @@ public class FrameMappingTests
             new TestModel { Id = 2, Name = "Name2" }
         };
 
-        var record = new Frame();
+        var record = new Record();
         record.Columns.AddFrom<TestModel>();
         record.AddRowsFromList(list);
 
@@ -34,11 +34,11 @@ public class FrameMappingTests
     // ── From<T> ──────────────────────────────────────────────────────────────
 
     [TestMethod]
-    public void From_ShouldCreateFrameWithSingleRow()
+    public void From_ShouldCreateRecordWithSingleRow()
     {
         var model = new TestModel { Id = 42, Name = "Alice" };
 
-        var record = Frame.From(model);
+        var record = Record.From(model);
 
         Assert.AreEqual(1,       record.Count);
         Assert.AreEqual(42,      record[0]["Id"]);
@@ -48,7 +48,7 @@ public class FrameMappingTests
     // ── FromList<T> ───────────────────────────────────────────────────────────
 
     [TestMethod]
-    public void FromList_ShouldCreateFrameWithAllRows()
+    public void FromList_ShouldCreateRecordWithAllRows()
     {
         var list = new List<TestModel>
         {
@@ -57,7 +57,7 @@ public class FrameMappingTests
             new TestModel { Id = 3, Name = "Carol" }
         };
 
-        var record = Frame.FromList(list);
+        var record = Record.FromList(list);
 
         Assert.AreEqual(3,       record.Count);
         Assert.AreEqual(1,       record[0]["Id"]);
@@ -67,9 +67,9 @@ public class FrameMappingTests
     }
 
     [TestMethod]
-    public void FromList_WithEmptyCollection_ShouldCreateFrameWithNoRows()
+    public void FromList_WithEmptyCollection_ShouldCreateRecordWithNoRows()
     {
-        var record = Frame.FromList(new List<TestModel>());
+        var record = Record.FromList(new List<TestModel>());
 
         Assert.AreEqual(0, record.Count);
     }
@@ -79,7 +79,7 @@ public class FrameMappingTests
     [TestMethod]
     public void To_WithRows_ShouldMapFirstRowToModel()
     {
-        var record = new Frame("Users", 2);
+        var record = new Record("Users", 2);
         var idCol   = record.Columns.Add<int>("Id");
         var nameCol = record.Columns.Add<string>("Name");
 
@@ -100,7 +100,7 @@ public class FrameMappingTests
     [TestMethod]
     public void To_WithNoRows_ShouldReturnDefaultInstance()
     {
-        var record = new Frame("Users", 0);
+        var record = new Record("Users", 0);
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
 
@@ -121,7 +121,7 @@ public class FrameMappingTests
             new TestModel { Id = 1, Name = "Alice" },
             new TestModel { Id = 2, Name = "Bob" }
         };
-        var record = Frame.FromList(source);
+        var record = Record.FromList(source);
 
         var result = record.ToList<TestModel>();
 
@@ -135,7 +135,7 @@ public class FrameMappingTests
     [TestMethod]
     public void ToList_WithNoRows_ShouldReturnEmptyList()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.AddFrom<TestModel>();
 
         var result = record.ToList<TestModel>();

--- a/tests/LuYao.Common.UnitTests/Data/RecordPagingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordPagingTests.cs
@@ -3,26 +3,26 @@
 namespace LuYao.Data;
 
 [TestClass]
-public class FramePagingTests
+public class RecordPagingTests
 {
     [TestMethod]
     public void WhenDefaultConstructorThenPageIsOne()
     {
-        var record = new Frame();
+        var record = new Record();
         Assert.AreEqual(1, record.Page);
     }
 
     [TestMethod]
     public void WhenDefaultConstructorThenPageSizeIsZero()
     {
-        var record = new Frame();
+        var record = new Record();
         Assert.AreEqual(0, record.PageSize);
     }
 
     [TestMethod]
     public void WhenMaxCountNotSetThenReturnsCount()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id");
         record.AddRow();
         record.AddRow();
@@ -33,7 +33,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenMaxCountSetThenReturnsSetValue()
     {
-        var record = new Frame();
+        var record = new Record();
         record.MaxCount = 100;
 
         Assert.AreEqual(100, record.MaxCount);
@@ -42,7 +42,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenMaxCountZeroThenMaxPageIsZero()
     {
-        var record = new Frame();
+        var record = new Record();
 
         Assert.AreEqual(0, record.MaxPage);
     }
@@ -50,7 +50,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenPageSizeZeroThenMaxPageUsesDefault20()
     {
-        var record = new Frame();
+        var record = new Record();
         record.MaxCount = 50;
 
         Assert.AreEqual(3, record.MaxPage); // (50-1)/20+1 = 3
@@ -59,7 +59,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenPageSizeSetThenMaxPageCalculatesCorrectly()
     {
-        var record = new Frame();
+        var record = new Record();
         record.MaxCount = 100;
         record.PageSize = 10;
 
@@ -69,7 +69,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenMaxCountNotExactMultipleThenMaxPageRoundsUp()
     {
-        var record = new Frame();
+        var record = new Record();
         record.MaxCount = 101;
         record.PageSize = 10;
 
@@ -79,7 +79,7 @@ public class FramePagingTests
     [TestMethod]
     public void WhenCloneThenPagingPropertiesAreCopied()
     {
-        var record = new Frame("Test", 0);
+        var record = new Record("Test", 0);
         record.Page = 3;
         record.PageSize = 25;
         record.MaxCount = 200;

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -5,11 +5,11 @@ using System.Linq;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameQueryTests
+public class RecordQueryTests
 {
-    private Frame CreateTestFrame()
+    private Record CreateTestRecord()
     {
-        var record = new Frame("TestFrame");
+        var record = new Record("TestRecord");
         record.Columns.Add("Id", typeof(int));
         record.Columns.Add("Name", typeof(string));
         record.Columns.Add("IsActive", typeof(bool));
@@ -36,7 +36,7 @@ public class FrameQueryTests
     public void FindT_WithExistingValue_ReturnsFirstMatch()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.Find<bool>("IsActive", true);
@@ -50,7 +50,7 @@ public class FrameQueryTests
     public void FindT_WithNonExistingValue_ReturnsNull()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.Find<int>("Id", 99);
@@ -63,7 +63,7 @@ public class FrameQueryTests
     public void FindT_WithNonExistingColumn_ReturnsNull()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.Find<string>("NonExisting", "Alice");
@@ -76,7 +76,7 @@ public class FrameQueryTests
     public void FindAllT_WithExistingValue_ReturnsAllMatches()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var results = record.FindAll<bool>("IsActive", true).ToList();
@@ -91,7 +91,7 @@ public class FrameQueryTests
     public void Find_WithValidPredicate_ReturnsFirstMatch()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.Find(r => r.To<string>("Name") == "Bob");
@@ -105,7 +105,7 @@ public class FrameQueryTests
     public void Find_WithInvalidPredicate_ReturnsNull()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.Find(r => r.To<int>("Id") > 10);
@@ -118,7 +118,7 @@ public class FrameQueryTests
     public void FindAll_WithValidPredicate_ReturnsAllMatches()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var results = record.FindAll(r => r.To<bool>("IsActive")).ToList();
@@ -133,7 +133,7 @@ public class FrameQueryTests
     public void FindByDynamic_WithValidPredicate_ReturnsFirstMatch()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.FindByDynamic(d => d.Name == "Charlie");
@@ -147,7 +147,7 @@ public class FrameQueryTests
     public void FindByDynamic_WithInvalidPredicate_ReturnsNull()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var result = record.FindByDynamic(d => d.Id == 99);
@@ -160,7 +160,7 @@ public class FrameQueryTests
     public void FindAllByDynamic_WithValidPredicate_ReturnsAllMatches()
     {
         // Arrange
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         // Act
         var results = record.FindAllByDynamic(d => d.IsActive == true).ToList();

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace LuYao.Data;
 
 /// <summary>
-/// 验证 FrameRow 新的访问语义：
+/// 验证 RecordRow 新的访问语义：
 /// - Field&lt;T&gt; 取值（替代旧 Get&lt;T&gt;）；
 /// - Set&lt;T&gt; 写入时若列不存在自动建列；
 /// - dynamic 写入时按运行时类型自动建列，null 值跳过；
@@ -14,12 +14,12 @@ namespace LuYao.Data;
 /// - Mapping（IPropertyAccessor）写入不会自动建列。
 /// </summary>
 [TestClass]
-public class FrameRowSemanticsTests
+public class RecordRowSemanticsTests
 {
     [TestMethod]
     public void Field_ColumnExists_ReturnsTypedValue()
     {
-        var record = new Frame();
+        var record = new Record();
         var col = record.Columns.Add<int>("Id");
         var row = record.AddRow();
         col.Set(row.Row, 123);
@@ -29,7 +29,7 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Field_ColumnNotExist_ReturnsDefault()
     {
-        var record = new Frame();
+        var record = new Record();
         record.AddRow();
         var row = record[0];
         Assert.AreEqual(0, row.To<int>("NoSuch"));
@@ -39,7 +39,7 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Set_ColumnNotExist_AutoCreatesColumn()
     {
-        var record = new Frame();
+        var record = new Record();
         var row = record.AddRow();
         row["Id"] = 100;
 
@@ -52,7 +52,7 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Set_ColumnExistsSameType_WritesValue()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<string>("Name");
         var row = record.AddRow();
         row["Name"] = "abc";
@@ -62,7 +62,7 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Dynamic_SetMember_AutoCreatesColumnByRuntimeType()
     {
-        var record = new Frame();
+        var record = new Record();
         dynamic dto = record.AddRow();
         dto.Id = 100;
         dto.Name = "abc";
@@ -79,7 +79,7 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Dynamic_SetMember_NullAndColumnMissing_IsSkipped()
     {
-        var record = new Frame();
+        var record = new Record();
         dynamic dto = record.AddRow();
         dto.Tag = null;
         Assert.AreEqual(0, record.Columns.Count);
@@ -88,18 +88,18 @@ public class FrameRowSemanticsTests
     [TestMethod]
     public void Dynamic_SetMember_NullOnExistingColumn_IsWritten()
     {
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<string>("Name");
         dynamic dto = record.AddRow();
         dto.Name = "x";
         dto.Name = null;
-        Assert.IsNull(((FrameRow)dto).To<string>("Name"));
+        Assert.IsNull(((RecordRow)dto).To<string>("Name"));
     }
 
     [TestMethod]
     public void Dynamic_SetIndex_AutoCreatesColumn()
     {
-        var record = new Frame();
+        var record = new Record();
         dynamic dto = record.AddRow();
         dto["Id"] = 7;
         Assert.AreEqual(1, record.Columns.Count);
@@ -110,7 +110,7 @@ public class FrameRowSemanticsTests
     public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
     {
         // 预期：缺列静默跳过，不建列。
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id"); // 只声明 Id 列；Name 故意不建
         var row = record.AddRow();
         row.CopyFrom(new MappingDto { Id = 9, Name = "ignored" });

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowTests.cs
@@ -6,17 +6,17 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace LuYao.Data;
 
 /// <summary>
-/// 测试 <see cref="FrameRow"/> 的构造、字段访问、赋值与 dynamic 行为。
+/// 测试 <see cref="RecordRow"/> 的构造、字段访问、赋值与 dynamic 行为。
 /// </summary>
 [TestClass]
-public class FrameRowTests
+public class RecordRowTests
 {
     /// <summary>
     /// 创建包含整型、字符串和布尔列的测试记录。
     /// </summary>
-    private (Frame record, FrameColumn<int> intColumn, FrameColumn<string> stringColumn, FrameColumn<bool> boolColumn) CreateTestFrame()
+    private (Record record, RecordColumn<int> intColumn, RecordColumn<string> stringColumn, RecordColumn<bool> boolColumn) CreateTestRecord()
     {
-        var record = new Frame("TestTable", 5);
+        var record = new Record("TestTable", 5);
         var intColumn = record.Columns.Add<int>("IntColumn");
         var stringColumn = record.Columns.Add<string>("StringColumn");
         var boolColumn = record.Columns.Add<bool>("BoolColumn");
@@ -42,13 +42,13 @@ public class FrameRowTests
     public void Constructor_ValidParameters_ShouldInitializeCorrectly()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
+        var (record, _, _, _) = CreateTestRecord();
 
         // Act
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Assert
-        Assert.AreEqual(record, recordRow.Frame);
+        Assert.AreEqual(record, recordRow.Record);
         Assert.AreEqual(0, recordRow.Row);
     }
 
@@ -56,10 +56,10 @@ public class FrameRowTests
     /// 当记录为 null 时，应抛出 <see cref="ArgumentNullException"/>。
     /// </summary>
     [TestMethod]
-    public void Constructor_NullFrame_ShouldThrowArgumentNullException()
+    public void Constructor_NullRecord_ShouldThrowArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new FrameRow(null!, 0));
+        Assert.Throws<ArgumentNullException>(() => new RecordRow(null!, 0));
     }
 
     /// <summary>
@@ -69,10 +69,10 @@ public class FrameRowTests
     public void Constructor_NegativeRowIndex_ShouldThrowArgumentOutOfRangeException()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
+        var (record, _, _, _) = CreateTestRecord();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => new FrameRow(record, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, -1));
     }
 
     /// <summary>
@@ -82,41 +82,41 @@ public class FrameRowTests
     public void Constructor_RowIndexOutOfRange_ShouldThrowArgumentOutOfRangeException()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
+        var (record, _, _, _) = CreateTestRecord();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => new FrameRow(record, record.Count));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new FrameRow(record, record.Count + 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new RecordRow(record, record.Count + 1));
     }
 
 
 
     /// <summary>
-    /// <see cref="FrameRow.Frame"/> 应返回所属的 <see cref="Frame"/>。
+    /// <see cref="RecordRow.Record"/> 应返回所属的 <see cref="Record"/>。
     /// </summary>
     [TestMethod]
-    public void Frame_Property_ShouldReturnCorrectFrame()
+    public void Record_Property_ShouldReturnCorrectRecord()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
-        var result = recordRow.Frame;
+        var result = recordRow.Record;
 
         // Assert
         Assert.AreEqual(record, result);
     }
 
     /// <summary>
-    /// <see cref="FrameRow.Row"/> 应返回当前行号。
+    /// <see cref="RecordRow.Row"/> 应返回当前行号。
     /// </summary>
     [TestMethod]
     public void Row_Property_ShouldReturnCorrectRowIndex()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.Row;
@@ -134,8 +134,8 @@ public class FrameRowTests
     public void ImplicitConversion_ToInt_ShouldReturnRowIndex()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         int rowIndex = recordRow;
@@ -153,8 +153,8 @@ public class FrameRowTests
     public void GetBoolean_ByName_ColumnExists_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, _, _, boolColumn) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, boolColumn) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<bool>("BoolColumn");
@@ -170,8 +170,8 @@ public class FrameRowTests
     public void GetBoolean_ByName_ColumnNotExists_ShouldReturnDefault()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<bool>("NonExistentColumn");
@@ -187,8 +187,8 @@ public class FrameRowTests
     public void GetString_ByName_ColumnExists_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, _, stringColumn, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.To<string>("StringColumn");
@@ -204,8 +204,8 @@ public class FrameRowTests
     public void GetString_ByName_ColumnNotExists_ShouldReturnDefault()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<string>("NonExistentColumn");
@@ -221,8 +221,8 @@ public class FrameRowTests
     public void GetInt32_ByName_ColumnExists_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.To<int>("IntColumn");
@@ -238,8 +238,8 @@ public class FrameRowTests
     public void GetInt32_ByName_ColumnNotExists_ShouldReturnDefault()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<int>("NonExistentColumn");
@@ -255,8 +255,8 @@ public class FrameRowTests
     public void GetGeneric_ByName_ColumnExists_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<int>("IntColumn");
@@ -272,8 +272,8 @@ public class FrameRowTests
     public void GetGeneric_ByName_ColumnNotExists_ShouldReturnDefault()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<int>("NonExistentColumn");
@@ -289,11 +289,11 @@ public class FrameRowTests
     public void GetByte_ByName_ShouldWork()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var byteColumn = record.Columns.Add<byte>("ByteColumn");
         var row = record.AddRow();
         byteColumn.Set(row.Row, 255);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<byte>("ByteColumn");
@@ -309,11 +309,11 @@ public class FrameRowTests
     public void GetDouble_ByName_ShouldWork()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var doubleColumn = record.Columns.Add<double>("DoubleColumn");
         var row = record.AddRow();
         doubleColumn.Set(row.Row, 3.14159);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<double>("DoubleColumn");
@@ -329,12 +329,12 @@ public class FrameRowTests
     public void GetDateTime_ByName_ShouldWork()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var dateTimeColumn = record.Columns.Add<DateTime>("DateTimeColumn");
         var testDate = new DateTime(2023, 8, 15, 14, 30, 0);
         var row = record.AddRow();
         dateTimeColumn.Set(row.Row, testDate);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.To<DateTime>("DateTimeColumn");
@@ -352,8 +352,8 @@ public class FrameRowTests
     public void GetMethods_EmptyColumnName_ShouldReturnDefault()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act & Assert
         Assert.AreEqual(default(int), recordRow.To<int>(""));
@@ -368,16 +368,16 @@ public class FrameRowTests
     public void GetMethods_MultipleRows_ShouldReturnCorrectValues()
     {
         // Arrange
-        var (record, intColumn, stringColumn, boolColumn) = CreateTestFrame();
+        var (record, intColumn, stringColumn, boolColumn) = CreateTestRecord();
 
         var row3 = record.AddRow();
         intColumn.Set(row3.Row, 300);
         stringColumn.Set(row3.Row, "Test3");
         boolColumn.Set(row3.Row, true);
 
-        var recordRow0 = new FrameRow(record, 0);
-        var recordRow1 = new FrameRow(record, 1);
-        var recordRow2 = new FrameRow(record, 2);
+        var recordRow0 = new RecordRow(record, 0);
+        var recordRow1 = new RecordRow(record, 1);
+        var recordRow2 = new RecordRow(record, 2);
 
         // Act & Assert
         Assert.AreEqual(100, recordRow0.To<int>("IntColumn"));
@@ -402,8 +402,8 @@ public class FrameRowTests
     public void GetMethods_RepeatedAccess_ShouldReturnConsistentResults()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result1 = recordRow.To<int>("IntColumn");
@@ -423,8 +423,8 @@ public class FrameRowTests
     public void Set_TypedColumn_ShouldUpdateValue()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         recordRow["IntColumn"] = 999;
@@ -440,8 +440,8 @@ public class FrameRowTests
     public void Set_StringColumn_ShouldUpdateValue()
     {
         // Arrange
-        var (record, _, stringColumn, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         recordRow["StringColumn"] = "NewValue";
@@ -451,14 +451,14 @@ public class FrameRowTests
     }
 
     /// <summary>
-    /// 当列不存在时，<see cref="FrameRow.Set{T}(string, T)"/> 应自动创建对应列。
+    /// 当列不存在时，<see cref="RecordRow.Set{T}(string, T)"/> 应自动创建对应列。
     /// </summary>
     [TestMethod]
     public void Set_ColumnNotExists_ShouldAutoCreateColumn()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
         int beforeCount = record.Columns.Count;
 
         // Act
@@ -479,8 +479,8 @@ public class FrameRowTests
     public void Set_ThenReadViaIndexer_ShouldBeConsistent()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         recordRow["IntColumn"] = 42;
@@ -498,8 +498,8 @@ public class FrameRowTests
     public void Dynamic_GetMember_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, _, stringColumn, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
         // Act
         var result = row.StringColumn;
@@ -515,14 +515,14 @@ public class FrameRowTests
     public void Dynamic_SetMember_ShouldUpdateValue()
     {
         // Arrange
-        var (record, _, stringColumn, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
         // Act
         row.StringColumn = "DynValue";
 
         // Assert
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
         Assert.AreEqual("DynValue", recordRow.To<string>("StringColumn"));
     }
 
@@ -533,8 +533,8 @@ public class FrameRowTests
     public void Dynamic_GetIndex_ShouldReturnCorrectValue()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 1);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 1);
 
         // Act - dynamic 索引读取
         var result = row["IntColumn"];
@@ -550,14 +550,14 @@ public class FrameRowTests
     public void Dynamic_SetIndex_ShouldUpdateValue()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
         // Act - dynamic 索引写入
         row["IntColumn"] = 777;
 
         // Assert
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
         Assert.AreEqual(777, recordRow.To<int>("IntColumn"));
     }
 
@@ -568,8 +568,8 @@ public class FrameRowTests
     public void Dynamic_GetMember_ColumnNotExists_ShouldReturnNull()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
         // Act
         var result = row.NoSuchColumn;
@@ -585,8 +585,8 @@ public class FrameRowTests
     public void Dynamic_SetMember_ColumnNotExists_ShouldNotThrow()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
 
         // Act & Assert
         row.NoSuchColumn = "ignored"; // should not throw
@@ -599,9 +599,9 @@ public class FrameRowTests
     public void Dynamic_GetMember_ShouldBeConsistentWithGetMethod()
     {
         // Arrange
-        var (record, intColumn, _, boolColumn) = CreateTestFrame();
-        dynamic row = new FrameRow(record, 0);
-        var recordRow = new FrameRow(record, 0);
+        var (record, intColumn, _, boolColumn) = CreateTestRecord();
+        dynamic row = new RecordRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act & Assert
         Assert.AreEqual(recordRow.To<int>("IntColumn"), (int)row.IntColumn!);
@@ -615,8 +615,8 @@ public class FrameRowTests
     public void FieldObject_ByName_ColumnExists_ShouldReturnValue()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow["IntColumn"];
@@ -633,8 +633,8 @@ public class FrameRowTests
     public void FieldObject_ByName_ColumnNotExists_ShouldReturnNull()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow["NonExistentColumn"];
@@ -644,14 +644,14 @@ public class FrameRowTests
     }
 
     /// <summary>
-    /// <see cref="FrameRow.ToDictionary"/> 应返回当前行的全部列与对应值。
+    /// <see cref="RecordRow.ToDictionary"/> 应返回当前行的全部列与对应值。
     /// </summary>
     [TestMethod]
     public void ToDictionary_ShouldReturnAllColumnsWithCurrentRowValues()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.ToDictionary();
@@ -664,17 +664,17 @@ public class FrameRowTests
     }
 
     /// <summary>
-    /// <see cref="FrameRow.ToDictionary"/> 对于 null 列值应保留 null。
+    /// <see cref="RecordRow.ToDictionary"/> 对于 null 列值应保留 null。
     /// </summary>
     [TestMethod]
     public void ToDictionary_WhenColumnValueIsNull_ShouldKeepNullValue()
     {
         // Arrange
-        var record = new Frame("TestTable", 2);
+        var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
         nullableColumn.SetValue(0, null!);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToDictionary();
@@ -686,14 +686,14 @@ public class FrameRowTests
     }
 
     /// <summary>
-    /// <see cref="FrameRow.ToString"/> 应输出行号以及字典风格的列值信息。
+    /// <see cref="RecordRow.ToString"/> 应输出行号以及字典风格的列值信息。
     /// </summary>
     [TestMethod]
     public void ToString_ShouldContainRowAndDictionaryLikeValues()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.ToString();
@@ -703,17 +703,17 @@ public class FrameRowTests
     }
 
     /// <summary>
-    /// <see cref="FrameRow.ToString"/> 对于 null 值应按匿名类型风格输出空值。
+    /// <see cref="RecordRow.ToString"/> 对于 null 值应按匿名类型风格输出空值。
     /// </summary>
     [TestMethod]
     public void ToString_WhenValueIsNull_ShouldRenderEmptyValue()
     {
         // Arrange
-        var record = new Frame("TestTable", 2);
+        var record = new Record("TestTable", 2);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
         nullableColumn.SetValue(0, null!);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString();
@@ -729,8 +729,8 @@ public class FrameRowTests
     public void ToString_ByName_ColumnExistsWithValue_ShouldReturnStringRepresentation()
     {
         // Arrange
-        var (record, _, stringColumn, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, stringColumn, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("StringColumn");
@@ -746,8 +746,8 @@ public class FrameRowTests
     public void ToString_ByName_NullColumnName_ShouldReturnEmptyString()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString(null!);
@@ -763,8 +763,8 @@ public class FrameRowTests
     public void ToString_ByName_EmptyColumnName_ShouldReturnEmptyString()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("");
@@ -780,8 +780,8 @@ public class FrameRowTests
     public void ToString_ByName_WhitespaceColumnName_ShouldReturnEmptyString()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("   ");
@@ -797,8 +797,8 @@ public class FrameRowTests
     public void ToString_ByName_ColumnNotExists_ShouldReturnEmptyString()
     {
         // Arrange
-        var (record, _, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("NonExistentColumn");
@@ -814,11 +814,11 @@ public class FrameRowTests
     public void ToString_ByName_ColumnExistsWithNullValue_ShouldReturnEmptyString()
     {
         // Arrange
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var nullableColumn = record.Columns.Add<string>("NullableColumn");
         record.AddRow();
         nullableColumn.SetValue(0, null!);
-        var recordRow = new FrameRow(record, 0);
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("NullableColumn");
@@ -834,8 +834,8 @@ public class FrameRowTests
     public void ToString_ByName_IntColumnExists_ShouldReturnStringRepresentation()
     {
         // Arrange
-        var (record, intColumn, _, _) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 1);
+        var (record, intColumn, _, _) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 1);
 
         // Act
         var result = recordRow.ToString("IntColumn");
@@ -851,8 +851,8 @@ public class FrameRowTests
     public void ToString_ByName_BoolColumnExists_ShouldReturnStringRepresentation()
     {
         // Arrange
-        var (record, _, _, boolColumn) = CreateTestFrame();
-        var recordRow = new FrameRow(record, 0);
+        var (record, _, _, boolColumn) = CreateTestRecord();
+        var recordRow = new RecordRow(record, 0);
 
         // Act
         var result = recordRow.ToString("BoolColumn");

--- a/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSchemaOperationsTests.cs
@@ -6,11 +6,11 @@ using System.Linq;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameSchemaOperationsTests
+public class RecordSchemaOperationsTests
 {
-    private static Frame CreateTestFrame()
+    private static Record CreateTestRecord()
     {
-        var record = new Frame("Test", 3);
+        var record = new Record("Test", 3);
         var idCol = record.Columns.Add<int>("Id");
         var nameCol = record.Columns.Add<string>("Name");
         var ageCol = record.Columns.Add<int>("Age");
@@ -29,7 +29,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnThenColumnNameChanges()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         record.RenameColumn("Name", "FullName");
 
@@ -41,7 +41,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnNonExistentThenThrowsKeyNotFoundException()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         Assert.Throws<KeyNotFoundException>(() => record.RenameColumn("NonExistent", "NewName"));
     }
@@ -49,7 +49,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnToExistingNameThenThrowsDuplicateNameException()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         Assert.Throws<DuplicateNameException>(() => record.RenameColumn("Name", "Id"));
     }
@@ -57,7 +57,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnToEmptyNameThenThrowsArgumentException()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         Assert.Throws<ArgumentException>(() => record.RenameColumn("Name", ""));
     }
@@ -65,7 +65,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnToSameNameThenSucceeds()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         record.RenameColumn("Name", "Name");
 
@@ -75,11 +75,11 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenRenameColumnThenDataPreserved()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
-        record.RenameColumn("Id", "FrameId");
+        record.RenameColumn("Id", "RecordId");
 
-        var col = record.Columns.Find("FrameId");
+        var col = record.Columns.Find("RecordId");
         Assert.IsNotNull(col);
         Assert.AreEqual(1, col!.Get(0));
         Assert.AreEqual(2, col.Get(1));
@@ -93,7 +93,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnThenTypeChanges()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         record.CastColumn("Id", typeof(string));
 
@@ -105,7 +105,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnThenDataConverted()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         record.CastColumn("Id", typeof(string));
 
@@ -118,7 +118,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnToSameTypeThenNoChange()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var originalCol = record.Columns.Find("Id");
 
         record.CastColumn("Id", typeof(int));
@@ -130,7 +130,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnNonExistentThenThrowsKeyNotFoundException()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         Assert.Throws<KeyNotFoundException>(() => record.CastColumn("NonExistent", typeof(string)));
     }
@@ -138,7 +138,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnNullTypeThenThrowsArgumentNullException()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         Assert.Throws<ArgumentNullException>(() => record.CastColumn("Id", null!));
     }
@@ -146,7 +146,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCastColumnThenColumnPositionPreserved()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         record.CastColumn("Age", typeof(long));
 
@@ -161,9 +161,9 @@ public class FrameSchemaOperationsTests
     #region CloneSchema
 
     [TestMethod]
-    public void WhenCloneSchemaThenNewFrameHasSameColumns()
+    public void WhenCloneSchemaThenNewRecordHasSameColumns()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.CloneSchema();
 
@@ -177,9 +177,9 @@ public class FrameSchemaOperationsTests
     }
 
     [TestMethod]
-    public void WhenCloneSchemaThenNewFrameHasZeroRows()
+    public void WhenCloneSchemaThenNewRecordHasZeroRows()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.CloneSchema();
 
@@ -189,7 +189,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCloneSchemaThenNamePreserved()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.CloneSchema();
 
@@ -199,7 +199,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCloneSchemaThenOriginalUnchanged()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.CloneSchema();
         clone.Columns.Add<double>("Score");
@@ -208,9 +208,9 @@ public class FrameSchemaOperationsTests
     }
 
     [TestMethod]
-    public void WhenCloneSchemaEmptyFrameThenReturnsEmptySchema()
+    public void WhenCloneSchemaEmptyRecordThenReturnsEmptySchema()
     {
-        var record = new Frame();
+        var record = new Record();
 
         var clone = record.CloneSchema();
 
@@ -223,9 +223,9 @@ public class FrameSchemaOperationsTests
     #region Clone
 
     [TestMethod]
-    public void WhenCloneThenNewFrameHasSameColumnsAndData()
+    public void WhenCloneThenNewRecordHasSameColumnsAndData()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.Clone();
 
@@ -239,7 +239,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCloneThenModifyingCloneDoesNotAffectOriginal()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.Clone();
         clone.Columns[0].Set(0, 999);
@@ -251,7 +251,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenCloneThenNamePreserved()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var clone = record.Clone();
 
@@ -259,9 +259,9 @@ public class FrameSchemaOperationsTests
     }
 
     [TestMethod]
-    public void WhenCloneEmptyFrameThenReturnsEmptyFrame()
+    public void WhenCloneEmptyRecordThenReturnsEmptyRecord()
     {
-        var record = new Frame("Empty", 0);
+        var record = new Record("Empty", 0);
         record.Columns.Add<int>("Id");
 
         var clone = record.Clone();
@@ -277,7 +277,7 @@ public class FrameSchemaOperationsTests
     [TestMethod]
     public void WhenGetSchemaThenReturnsColumnDefinitions()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
 
         var schema = record.GetSchema();
 
@@ -291,9 +291,9 @@ public class FrameSchemaOperationsTests
     }
 
     [TestMethod]
-    public void WhenGetSchemaEmptyFrameThenReturnsEmptySchema()
+    public void WhenGetSchemaEmptyRecordThenReturnsEmptySchema()
     {
-        var record = new Frame();
+        var record = new Record();
 
         var schema = record.GetSchema();
 
@@ -301,12 +301,12 @@ public class FrameSchemaOperationsTests
     }
 
     [TestMethod]
-    public void WhenGetSchemaThenChangingFrameDoesNotAffectSchema()
+    public void WhenGetSchemaThenChangingRecordDoesNotAffectSchema()
     {
-        var record = CreateTestFrame();
+        var record = CreateTestRecord();
         var schema = record.GetSchema();
 
-        record.RenameColumn("Id", "FrameId");
+        record.RenameColumn("Id", "RecordId");
 
         Assert.AreEqual("Id", schema.Columns[0].Name);
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -4,7 +4,7 @@ using System.IO;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameSerializationTests
+public class RecordSerializationTests
 {
     private enum FavoriteType
     {
@@ -12,9 +12,9 @@ public class FrameSerializationTests
         Chat = 200,
     }
 
-    private static Frame CreateTestFrame()
+    private static Record CreateTestRecord()
     {
-        var record = new Frame("Orders", 2);
+        var record = new Record("Orders", 2);
         var idCol = record.Columns.Add<int>("Id");
         var nameCol = record.Columns.Add<string>("Name");
         record.Page = 2;
@@ -37,10 +37,10 @@ public class FrameSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripThenDataPreserved()
     {
-        var original = CreateTestFrame();
+        var original = CreateTestRecord();
 
         var bytes = original.ToBytes();
-        var deserialized = Frame.FromBytes(bytes);
+        var deserialized = Record.FromBytes(bytes);
 
         Assert.AreEqual("Orders", deserialized.Name);
         Assert.AreEqual(2, deserialized.Count);
@@ -56,14 +56,14 @@ public class FrameSerializationTests
     }
 
     [TestMethod]
-    public void WhenBinaryRoundTripEmptyFrameThenSchemaPreserved()
+    public void WhenBinaryRoundTripEmptyRecordThenSchemaPreserved()
     {
-        var original = new Frame("Empty", 0);
+        var original = new Record("Empty", 0);
         original.Columns.Add<int>("Id");
         original.Columns.Add<string>("Name");
 
         var bytes = original.ToBytes();
-        var deserialized = Frame.FromBytes(bytes);
+        var deserialized = Record.FromBytes(bytes);
 
         Assert.AreEqual("Empty", deserialized.Name);
         Assert.AreEqual(0, deserialized.Count);
@@ -75,13 +75,13 @@ public class FrameSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripWithNullValuesThenPreserved()
     {
-        var record = new Frame("Test", 1);
+        var record = new Record("Test", 1);
         record.Columns.Add<string>("Name");
         record.Columns.Add<int?>("Value");
         record.AddRow();
 
         var bytes = record.ToBytes();
-        var deserialized = Frame.FromBytes(bytes);
+        var deserialized = Record.FromBytes(bytes);
 
         Assert.AreEqual(1, deserialized.Count);
         Assert.IsNull(deserialized.Columns[0].Get(0));
@@ -91,13 +91,13 @@ public class FrameSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripWithByteArrayThenPreserved()
     {
-        var record = new Frame("Binary", 1);
+        var record = new Record("Binary", 1);
         var col = record.Columns.Add<byte[]>("Data");
         var row = record.AddRow();
         col.SetValue(row.Row, new byte[] { 1, 2, 3, 4, 5 });
 
         var bytes = record.ToBytes();
-        var deserialized = Frame.FromBytes(bytes);
+        var deserialized = Record.FromBytes(bytes);
 
         var data = deserialized.Columns.Find<byte[]>("Data")!.GetValue(0);
         CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, data);
@@ -106,7 +106,7 @@ public class FrameSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripWithAllTypesThenPreserved()
     {
-        var record = new Frame("AllTypes", 1);
+        var record = new Record("AllTypes", 1);
         record.Columns.Add<bool>("Bool");
         record.Columns.Add<sbyte>("SByte");
         record.Columns.Add<short>("Short");
@@ -150,7 +150,7 @@ public class FrameSerializationTests
         record.Columns.Find<Guid>("Guid")!.SetValue(r.Row, guid);
 
         var bytes = record.ToBytes();
-        var d = Frame.FromBytes(bytes);
+        var d = Record.FromBytes(bytes);
 
         Assert.AreEqual(true, d.Columns.Find<bool>("Bool")!.Get(0));
         Assert.AreEqual((sbyte)-1, d.Columns.Find<sbyte>("SByte")!.Get(0));
@@ -175,7 +175,7 @@ public class FrameSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripWithEnumColumnThenPreserved()
     {
-        var record = new Frame("EnumFrame", 1);
+        var record = new Record("EnumRecord", 1);
         var favoriteCol = record.Columns.Add<FavoriteType>("Favorite");
         var nullableFavoriteCol = record.Columns.Add<FavoriteType?>("NullableFavorite");
         var row = record.AddRow();
@@ -183,16 +183,16 @@ public class FrameSerializationTests
         nullableFavoriteCol.SetValue(row.Row, FavoriteType.Common);
 
         var bytes = record.ToBytes();
-        var deserialized = Frame.FromBytes(bytes);
+        var deserialized = Record.FromBytes(bytes);
 
         Assert.AreEqual(200, deserialized.Columns.Find<int>("Favorite")!.Get(0));
         Assert.AreEqual(100, deserialized.Columns.Find<int?>("NullableFavorite")!.Get(0));
     }
 
     [TestMethod]
-    public void WhenSerializeToBytesThenFrameHeaderContainsFrameType()
+    public void WhenSerializeToBytesThenRecordHeaderContainsRecordType()
     {
-        var record = new Frame("Orders", 1);
+        var record = new Record("Orders", 1);
         record.Columns.Add<int>("Id");
         record.AddRow();
 
@@ -206,59 +206,59 @@ public class FrameSerializationTests
     }
 
     [TestMethod]
-    public void WhenReadFrameFromFrameSetPayloadThenThrowTypeMismatch()
+    public void WhenReadRecordFromRecordSetPayloadThenThrowTypeMismatch()
     {
-        var set = new FrameSet();
-        set.Add("Orders", new Frame("Orders", 0));
+        var set = new RecordSet();
+        set.Add("Orders", new Record("Orders", 0));
 
         var bytes = set.ToBytes();
 
-        Assert.Throws<InvalidOperationException>(() => Frame.FromBytes(bytes));
+        Assert.Throws<InvalidOperationException>(() => Record.FromBytes(bytes));
     }
 
     [TestMethod]
-    public void IsBinaryPayload_DetectsFrameAndFrameSetCorrectly()
+    public void IsBinaryPayload_DetectsRecordAndRecordSetCorrectly()
     {
-        var record = new Frame("Orders", 0);
-        var set = new FrameSet();
-        set.Add("Orders", new Frame("Orders", 0));
+        var record = new Record("Orders", 0);
+        var set = new RecordSet();
+        set.Add("Orders", new Record("Orders", 0));
 
         var recordBytes = record.ToBytes();
         var setBytes = set.ToBytes();
 
-        Assert.IsTrue(Frame.IsBinaryPayload(recordBytes));
-        Assert.IsFalse(Frame.IsBinaryPayload(setBytes));
-        Assert.IsFalse(Frame.IsBinaryPayload(new byte[] { 1, 2, 3, 4 }));
-        Assert.IsFalse(Frame.IsBinaryPayload((byte[])null));
+        Assert.IsTrue(Record.IsBinaryPayload(recordBytes));
+        Assert.IsFalse(Record.IsBinaryPayload(setBytes));
+        Assert.IsFalse(Record.IsBinaryPayload(new byte[] { 1, 2, 3, 4 }));
+        Assert.IsFalse(Record.IsBinaryPayload((byte[])null));
     }
 
     #endregion
 }
 
 [TestClass]
-public class FrameSetSerializationTests
+public class RecordSetSerializationTests
 {
     #region Binary Serialization
 
     [TestMethod]
-    public void WhenBinaryRoundTripThenAllFramesPreserved()
+    public void WhenBinaryRoundTripThenAllRecordsPreserved()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
-        var orders = new Frame("Orders", 1);
+        var orders = new Record("Orders", 1);
         orders.Columns.Add<int>("Id");
         var row = orders.AddRow();
         orders.Columns[0].Set(row.Row, 1);
         set.Add("Orders", orders);
 
-        var customers = new Frame("Customers", 1);
+        var customers = new Record("Customers", 1);
         customers.Columns.Add<string>("Name");
         var row2 = customers.AddRow();
         customers.Columns[0].Set(row2.Row, "Alice");
         set.Add("Customers", customers);
 
         var bytes = set.ToBytes();
-        var deserialized = FrameSet.FromBytes(bytes);
+        var deserialized = RecordSet.FromBytes(bytes);
 
         Assert.AreEqual(2, deserialized.Count);
         Assert.IsTrue(deserialized.Contains("Orders"));
@@ -270,19 +270,19 @@ public class FrameSetSerializationTests
     [TestMethod]
     public void WhenBinaryRoundTripEmptySetThenEmpty()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         var bytes = set.ToBytes();
-        var deserialized = FrameSet.FromBytes(bytes);
+        var deserialized = RecordSet.FromBytes(bytes);
 
         Assert.AreEqual(0, deserialized.Count);
     }
 
     [TestMethod]
-    public void WhenSerializeToBytesThenFrameSetHeaderContainsFrameSetType()
+    public void WhenSerializeToBytesThenRecordSetHeaderContainsRecordSetType()
     {
-        var set = new FrameSet();
-        set.Add("Orders", new Frame("Orders", 0));
+        var set = new RecordSet();
+        set.Add("Orders", new Record("Orders", 0));
 
         var bytes = set.ToBytes();
 
@@ -294,28 +294,28 @@ public class FrameSetSerializationTests
     }
 
     [TestMethod]
-    public void WhenReadFrameSetFromFramePayloadThenThrowTypeMismatch()
+    public void WhenReadRecordSetFromRecordPayloadThenThrowTypeMismatch()
     {
-        var record = new Frame("Orders", 0);
+        var record = new Record("Orders", 0);
         var bytes = record.ToBytes();
 
-        Assert.Throws<InvalidOperationException>(() => FrameSet.FromBytes(bytes));
+        Assert.Throws<InvalidOperationException>(() => RecordSet.FromBytes(bytes));
     }
 
     [TestMethod]
-    public void IsBinaryPayload_DetectsFrameSetAndFrameCorrectly()
+    public void IsBinaryPayload_DetectsRecordSetAndRecordCorrectly()
     {
-        var record = new Frame("Orders", 0);
-        var set = new FrameSet();
-        set.Add("Orders", new Frame("Orders", 0));
+        var record = new Record("Orders", 0);
+        var set = new RecordSet();
+        set.Add("Orders", new Record("Orders", 0));
 
         var recordBytes = record.ToBytes();
         var setBytes = set.ToBytes();
 
-        Assert.IsTrue(FrameSet.IsBinaryPayload(setBytes));
-        Assert.IsFalse(FrameSet.IsBinaryPayload(recordBytes));
-        Assert.IsFalse(FrameSet.IsBinaryPayload(new byte[] { 0xFF, (byte)'L', (byte)'Y', 9 }));
-        Assert.IsFalse(FrameSet.IsBinaryPayload((byte[])null));
+        Assert.IsTrue(RecordSet.IsBinaryPayload(setBytes));
+        Assert.IsFalse(RecordSet.IsBinaryPayload(recordBytes));
+        Assert.IsFalse(RecordSet.IsBinaryPayload(new byte[] { 0xFF, (byte)'L', (byte)'Y', 9 }));
+        Assert.IsFalse(RecordSet.IsBinaryPayload((byte[])null));
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSetTests.cs
@@ -5,11 +5,11 @@ using System.Linq;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameSetTests
+public class RecordSetTests
 {
-    private static Frame CreateTestFrame(string name, int rowCount)
+    private static Record CreateTestRecord(string name, int rowCount)
     {
-        var record = new Frame(name, rowCount);
+        var record = new Record(name, rowCount);
         var idCol = record.Columns.Add<int>("Id");
         var nameCol = record.Columns.Add<string>("Name");
         for (int i = 0; i < rowCount; i++)
@@ -26,7 +26,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenDefaultConstructorThenEmptySet()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.AreEqual(0, set.Count);
         Assert.AreEqual(0, set.Names.Count());
@@ -35,7 +35,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenNullComparerThenThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new FrameSet(null!));
+        Assert.Throws<ArgumentNullException>(() => new RecordSet(null!));
     }
 
     #endregion
@@ -43,10 +43,10 @@ public class FrameSetTests
     #region Add
 
     [TestMethod]
-    public void WhenAddValidFrameThenCountIncreases()
+    public void WhenAddValidRecordThenCountIncreases()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 2);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 2);
 
         set.Add("Orders", record);
 
@@ -57,8 +57,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenAddNullNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("test", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("test", 1);
 
         Assert.Throws<ArgumentException>(() => set.Add(null!, record));
     }
@@ -66,8 +66,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenAddEmptyNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("test", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("test", 1);
 
         Assert.Throws<ArgumentException>(() => set.Add("", record));
     }
@@ -75,16 +75,16 @@ public class FrameSetTests
     [TestMethod]
     public void WhenAddWhitespaceNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("test", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("test", 1);
 
         Assert.Throws<ArgumentException>(() => set.Add("   ", record));
     }
 
     [TestMethod]
-    public void WhenAddNullFrameThenThrowsArgumentNullException()
+    public void WhenAddNullRecordThenThrowsArgumentNullException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<ArgumentNullException>(() => set.Add("Orders", null!));
     }
@@ -92,18 +92,18 @@ public class FrameSetTests
     [TestMethod]
     public void WhenAddDuplicateNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        set.Add("Orders", CreateTestFrame("Orders", 1));
+        var set = new RecordSet();
+        set.Add("Orders", CreateTestRecord("Orders", 1));
 
-        Assert.Throws<ArgumentException>(() => set.Add("Orders", CreateTestFrame("Orders", 2)));
+        Assert.Throws<ArgumentException>(() => set.Add("Orders", CreateTestRecord("Orders", 2)));
     }
 
     [TestMethod]
     public void WhenAddWithCaseSensitiveComparerThenDifferentCaseIsAllowed()
     {
-        var set = new FrameSet(StringComparer.Ordinal);
-        set.Add("Orders", CreateTestFrame("Orders", 1));
-        set.Add("orders", CreateTestFrame("orders", 2));
+        var set = new RecordSet(StringComparer.Ordinal);
+        set.Add("Orders", CreateTestRecord("Orders", 1));
+        set.Add("orders", CreateTestRecord("orders", 2));
 
         Assert.AreEqual(2, set.Count);
     }
@@ -111,10 +111,10 @@ public class FrameSetTests
     [TestMethod]
     public void WhenAddWithCaseInsensitiveComparerThenDifferentCaseThrows()
     {
-        var set = new FrameSet(StringComparer.OrdinalIgnoreCase);
-        set.Add("Orders", CreateTestFrame("Orders", 1));
+        var set = new RecordSet(StringComparer.OrdinalIgnoreCase);
+        set.Add("Orders", CreateTestRecord("Orders", 1));
 
-        Assert.Throws<ArgumentException>(() => set.Add("orders", CreateTestFrame("orders", 2)));
+        Assert.Throws<ArgumentException>(() => set.Add("orders", CreateTestRecord("orders", 2)));
     }
 
     #endregion
@@ -122,10 +122,10 @@ public class FrameSetTests
     #region Set
 
     [TestMethod]
-    public void WhenSetNewNameThenAddsFrame()
+    public void WhenSetNewNameThenAddsRecord()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 2);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 2);
 
         set.Set("Orders", record);
 
@@ -134,11 +134,11 @@ public class FrameSetTests
     }
 
     [TestMethod]
-    public void WhenSetExistingNameThenReplacesFrame()
+    public void WhenSetExistingNameThenReplacesRecord()
     {
-        var set = new FrameSet();
-        var record1 = CreateTestFrame("Orders", 1);
-        var record2 = CreateTestFrame("Orders", 3);
+        var set = new RecordSet();
+        var record1 = CreateTestRecord("Orders", 1);
+        var record2 = CreateTestRecord("Orders", 3);
 
         set.Add("Orders", record1);
         set.Set("Orders", record2);
@@ -148,9 +148,9 @@ public class FrameSetTests
     }
 
     [TestMethod]
-    public void WhenSetNullFrameThenThrowsArgumentNullException()
+    public void WhenSetNullRecordThenThrowsArgumentNullException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<ArgumentNullException>(() => set.Set("Orders", null!));
     }
@@ -158,9 +158,9 @@ public class FrameSetTests
     [TestMethod]
     public void WhenSetEmptyNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
-        Assert.Throws<ArgumentException>(() => set.Set("", CreateTestFrame("test", 1)));
+        Assert.Throws<ArgumentException>(() => set.Set("", CreateTestRecord("test", 1)));
     }
 
     #endregion
@@ -168,10 +168,10 @@ public class FrameSetTests
     #region Get / TryGet
 
     [TestMethod]
-    public void WhenGetExistingNameThenReturnsFrame()
+    public void WhenGetExistingNameThenReturnsRecord()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 2);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 2);
         set.Add("Orders", record);
 
         var result = set.Get("Orders");
@@ -182,16 +182,16 @@ public class FrameSetTests
     [TestMethod]
     public void WhenGetNonExistingNameThenThrowsKeyNotFoundException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<KeyNotFoundException>(() => set.Get("NonExistent"));
     }
 
     [TestMethod]
-    public void WhenTryGetExistingNameThenReturnsTrueAndFrame()
+    public void WhenTryGetExistingNameThenReturnsTrueAndRecord()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 2);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 2);
         set.Add("Orders", record);
 
         var found = set.TryGet("Orders", out var result);
@@ -203,7 +203,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenTryGetNonExistingNameThenReturnsFalse()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         var found = set.TryGet("NonExistent", out var result);
 
@@ -216,10 +216,10 @@ public class FrameSetTests
     #region Indexer
 
     [TestMethod]
-    public void WhenIndexerExistingNameThenReturnsFrame()
+    public void WhenIndexerExistingNameThenReturnsRecord()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 1);
         set.Add("Orders", record);
 
         var result = set["Orders"];
@@ -230,7 +230,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenIndexerNonExistingNameThenThrowsKeyNotFoundException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<KeyNotFoundException>(() => _ = set["NonExistent"]);
     }
@@ -242,8 +242,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRemoveExistingThenReturnsTrueAndRemoves()
     {
-        var set = new FrameSet();
-        set.Add("Orders", CreateTestFrame("Orders", 1));
+        var set = new RecordSet();
+        set.Add("Orders", CreateTestRecord("Orders", 1));
 
         var removed = set.Remove("Orders");
 
@@ -255,7 +255,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRemoveNonExistingThenReturnsFalse()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         var removed = set.Remove("NonExistent");
 
@@ -265,10 +265,10 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRemoveThenNamesListUpdated()
     {
-        var set = new FrameSet();
-        set.Add("A", CreateTestFrame("A", 1));
-        set.Add("B", CreateTestFrame("B", 1));
-        set.Add("C", CreateTestFrame("C", 1));
+        var set = new RecordSet();
+        set.Add("A", CreateTestRecord("A", 1));
+        set.Add("B", CreateTestRecord("B", 1));
+        set.Add("C", CreateTestRecord("C", 1));
 
         set.Remove("B");
 
@@ -283,8 +283,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenContainsExistingNameThenReturnsTrue()
     {
-        var set = new FrameSet();
-        set.Add("Orders", CreateTestFrame("Orders", 1));
+        var set = new RecordSet();
+        set.Add("Orders", CreateTestRecord("Orders", 1));
 
         Assert.IsTrue(set.Contains("Orders"));
     }
@@ -292,7 +292,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenContainsNonExistingNameThenReturnsFalse()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.IsFalse(set.Contains("NonExistent"));
     }
@@ -304,8 +304,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameExistingThenNameChanges()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 1);
         set.Add("Orders", record);
 
         set.Rename("Orders", "AllOrders");
@@ -319,7 +319,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameNonExistingThenThrowsKeyNotFoundException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<KeyNotFoundException>(() => set.Rename("NonExistent", "NewName"));
     }
@@ -327,9 +327,9 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameToExistingNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        set.Add("A", CreateTestFrame("A", 1));
-        set.Add("B", CreateTestFrame("B", 1));
+        var set = new RecordSet();
+        set.Add("A", CreateTestRecord("A", 1));
+        set.Add("B", CreateTestRecord("B", 1));
 
         Assert.Throws<ArgumentException>(() => set.Rename("A", "B"));
     }
@@ -337,8 +337,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameToEmptyNameThenThrowsArgumentException()
     {
-        var set = new FrameSet();
-        set.Add("A", CreateTestFrame("A", 1));
+        var set = new RecordSet();
+        set.Add("A", CreateTestRecord("A", 1));
 
         Assert.Throws<ArgumentException>(() => set.Rename("A", ""));
     }
@@ -346,8 +346,8 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameToSameNameThenSucceeds()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Orders", 1);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Orders", 1);
         set.Add("Orders", record);
 
         set.Rename("Orders", "Orders");
@@ -359,10 +359,10 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRenameThenNamesListHasDeterministicOrder()
     {
-        var set = new FrameSet();
-        set.Add("A", CreateTestFrame("A", 1));
-        set.Add("B", CreateTestFrame("B", 1));
-        set.Add("C", CreateTestFrame("C", 1));
+        var set = new RecordSet();
+        set.Add("A", CreateTestRecord("A", 1));
+        set.Add("B", CreateTestRecord("B", 1));
+        set.Add("C", CreateTestRecord("C", 1));
 
         set.Rename("B", "D");
 
@@ -376,9 +376,9 @@ public class FrameSetTests
     [TestMethod]
     public void WhenClearThenSetIsEmpty()
     {
-        var set = new FrameSet();
-        set.Add("A", CreateTestFrame("A", 1));
-        set.Add("B", CreateTestFrame("B", 1));
+        var set = new RecordSet();
+        set.Add("A", CreateTestRecord("A", 1));
+        set.Add("B", CreateTestRecord("B", 1));
 
         set.Clear();
 
@@ -391,12 +391,12 @@ public class FrameSetTests
     #region Enumeration
 
     [TestMethod]
-    public void WhenEnumerateThenReturnsAllFramesInOrder()
+    public void WhenEnumerateThenReturnsAllRecordsInOrder()
     {
-        var set = new FrameSet();
-        var r1 = CreateTestFrame("A", 1);
-        var r2 = CreateTestFrame("B", 2);
-        var r3 = CreateTestFrame("C", 3);
+        var set = new RecordSet();
+        var r1 = CreateTestRecord("A", 1);
+        var r2 = CreateTestRecord("B", 2);
+        var r3 = CreateTestRecord("C", 3);
         set.Add("A", r1);
         set.Add("B", r2);
         set.Add("C", r3);
@@ -412,7 +412,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenEnumerateEmptySetThenReturnsEmpty()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         var records = set.ToArray();
 
@@ -424,7 +424,7 @@ public class FrameSetTests
     #region DataSet Interop
 
     [TestMethod]
-    public void WhenFromDataSetThenCreatesFrameSet()
+    public void WhenFromDataSetThenCreatesRecordSet()
     {
         var ds = new DataSet();
         var dt1 = ds.Tables.Add("Orders");
@@ -438,7 +438,7 @@ public class FrameSetTests
         dt2.Columns.Add("Name", typeof(string));
         dt2.Rows.Add(1, "Alice");
 
-        var set = FrameSet.FromDataSet(ds);
+        var set = RecordSet.FromDataSet(ds);
 
         Assert.AreEqual(2, set.Count);
         Assert.IsTrue(set.Contains("Orders"));
@@ -450,15 +450,15 @@ public class FrameSetTests
     [TestMethod]
     public void WhenFromDataSetNullThenThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => FrameSet.FromDataSet(null!));
+        Assert.Throws<ArgumentNullException>(() => RecordSet.FromDataSet(null!));
     }
 
     [TestMethod]
     public void WhenToDataSetThenCreatesDataSet()
     {
-        var set = new FrameSet();
-        var r1 = CreateTestFrame("Orders", 2);
-        var r2 = CreateTestFrame("Customers", 1);
+        var set = new RecordSet();
+        var r1 = CreateTestRecord("Orders", 2);
+        var r2 = CreateTestRecord("Customers", 1);
         set.Add("Orders", r1);
         set.Add("Customers", r2);
 
@@ -474,7 +474,7 @@ public class FrameSetTests
     [TestMethod]
     public void WhenWriteToNullDataSetThenThrowsArgumentNullException()
     {
-        var set = new FrameSet();
+        var set = new RecordSet();
 
         Assert.Throws<ArgumentNullException>(() => set.WriteTo((System.Data.DataSet)null!));
     }
@@ -482,12 +482,12 @@ public class FrameSetTests
     [TestMethod]
     public void WhenRoundTripThroughDataSetThenDataPreserved()
     {
-        var set = new FrameSet();
-        var record = CreateTestFrame("Products", 3);
+        var set = new RecordSet();
+        var record = CreateTestRecord("Products", 3);
         set.Add("Products", record);
 
         var ds = set.ToDataSet();
-        var set2 = FrameSet.FromDataSet(ds);
+        var set2 = RecordSet.FromDataSet(ds);
 
         Assert.AreEqual(1, set2.Count);
         Assert.IsTrue(set2.Contains("Products"));
@@ -497,11 +497,11 @@ public class FrameSetTests
     }
 
     [TestMethod]
-    public void WhenFromEmptyDataSetThenCreatesEmptyFrameSet()
+    public void WhenFromEmptyDataSetThenCreatesEmptyRecordSet()
     {
         var ds = new DataSet();
 
-        var set = FrameSet.FromDataSet(ds);
+        var set = RecordSet.FromDataSet(ds);
 
         Assert.AreEqual(0, set.Count);
     }

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -8,13 +8,13 @@ using System.Threading.Tasks;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameTests
+public class RecordTests
 {
     [TestMethod]
     public void Constructor_ValidParameters_InitializesCorrectly()
     {
         // Arrange
-        var dt = new Frame();
+        var dt = new Record();
 
         // Assert
         Assert.AreEqual(0, dt.Count);
@@ -26,7 +26,7 @@ public class FrameTests
     public void AddRowAndSetColumnValue_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<int>("Id"); // 替换 Add<Int32> 为 Add<int>
         var colName = table.Columns.Add<string>("Name"); // 替换 Add<String> 为 Add<string>
 
@@ -46,7 +46,7 @@ public class FrameTests
     public void Constructor_WithNameAndRows_InitializesCorrectly()
     {
         // Arrange & Act
-        var table = new Frame("TestTable", 10);
+        var table = new Record("TestTable", 10);
 
         // Assert
         Assert.AreEqual("TestTable", table.Name);
@@ -59,7 +59,7 @@ public class FrameTests
     public void AddMultipleRowsAndColumns_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<int>("Id"); // 替换 Add<Int32> 为 Add<int>
         var colName = table.Columns.Add<string>("Name"); // 替换 Add<String> 为 Add<string>
         var colAge = table.Columns.Add<int>("Age"); // 替换 Add<Int32> 为 Add<int>
@@ -92,7 +92,7 @@ public class FrameTests
     public void SetValue_ByColumnName_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var idCol = table.Columns.Add<int>("Id");
         var nameCol = table.Columns.Add<string>("Name");
         table.AddRow();
@@ -110,7 +110,7 @@ public class FrameTests
     public void GetValue_ByColumnName_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<int>("Id");
         var colName = table.Columns.Add<string>("Name");
         var row = table.AddRow();
@@ -126,7 +126,7 @@ public class FrameTests
     public void Contains_ExistingColumn_ReturnsTrue()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.Columns.Add<int>("Id");
         table.Columns.Add<string>("Name");
 
@@ -140,7 +140,7 @@ public class FrameTests
     public void GetValue_NonExistentColumn_ThrowsKeyNotFoundException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.AddRow();
 
         // Act & Assert
@@ -152,7 +152,7 @@ public class FrameTests
     public void SetValue_NonExistentColumn_ThrowsKeyNotFoundException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.AddRow();
 
         // Act & Assert
@@ -164,7 +164,7 @@ public class FrameTests
     public void GetRow_ValidIndex_ReturnsCorrectRow()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<int>("Id");
         table.AddRow();
         table.AddRow();
@@ -187,7 +187,7 @@ public class FrameTests
     public void GetRow_InvalidIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.AddRow();
 
         // Act & Assert
@@ -199,7 +199,7 @@ public class FrameTests
     public void Enumeration_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<int>("Id");
         table.AddRow();
         table.AddRow();
@@ -209,7 +209,7 @@ public class FrameTests
         colId.SetValue(2, 3);
 
         // Act
-        var rows = new List<FrameRow>();
+        var rows = new List<RecordRow>();
         foreach (var row in table)
         {
             rows.Add(row);
@@ -229,7 +229,7 @@ public class FrameTests
     public void DifferentDataTypes_WorkCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colBool = table.Columns.Add<Boolean>("Bool");
         var colByte = table.Columns.Add<Byte>("Byte");
         var colDateTime = table.Columns.Add<DateTime>("DateTime");
@@ -270,7 +270,7 @@ public class FrameTests
     public void RowImplicitConversion_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.AddRow();
         table.AddRow();
         var rows = table.ToArray();
@@ -287,7 +287,7 @@ public class FrameTests
     public void TypedSetAndGet_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colInt = table.Columns.Add<Int32>("Int");
         var colString = table.Columns.Add<String>("String");
         var colBool = table.Columns.Add<Boolean>("Bool");
@@ -308,7 +308,7 @@ public class FrameTests
     public void AddRow_MultipleRows_CountIncreases()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
 
         // Act & Assert
         Assert.AreEqual(0, table.Count);
@@ -327,7 +327,7 @@ public class FrameTests
     public void Columns_Find_ExistingColumn_ReturnsColumn()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var originalCol = table.Columns.Add<Int32>("TestColumn");
 
         // Act
@@ -342,7 +342,7 @@ public class FrameTests
     public void Columns_Find_NonExistentColumn_ReturnsNull()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.Columns.Add<Int32>("TestColumn");
 
         // Act
@@ -353,10 +353,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumn_Clear_DataIsEmpty()
+    public void RecordColumn_Clear_DataIsEmpty()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         var row = table.AddRow();
         col.SetValue(row.Row, "TestValue");
@@ -373,10 +373,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumn_SetValue_WithFrameRowIndex_WorksCorrectly()
+    public void RecordColumn_SetValue_WithRecordRowIndex_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Int32>("TestCol");
         var row1 = table.AddRow();
         var row2 = table.AddRow();
@@ -394,17 +394,17 @@ public class FrameTests
     public void Constructor_DefaultName_IsEmpty()
     {
         // Arrange & Act
-        var table = new Frame();
+        var table = new Record();
 
         // Assert
         Assert.AreEqual(string.Empty, table.Name);
     }
 
     [TestMethod]
-    public void FrameRow_AllTypedMethods_WorkCorrectly()
+    public void RecordRow_AllTypedMethods_WorkCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colChar = table.Columns.Add<Char>("Char");
         var colSByte = table.Columns.Add<SByte>("SByte");
         var colSingle = table.Columns.Add<Single>("Single");
@@ -435,10 +435,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumnCollection_IndexOf_ReturnsCorrectIndex()
+    public void RecordColumnCollection_IndexOf_ReturnsCorrectIndex()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.Columns.Add<String>("First");
         table.Columns.Add<Int32>("Second");
         table.Columns.Add<Boolean>("Third");
@@ -451,10 +451,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumnCollection_Remove_RemovesColumn()
+    public void RecordColumnCollection_Remove_RemovesColumn()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col1 = table.Columns.Add<String>("Col1");
         var col2 = table.Columns.Add<Int32>("Col2");
 
@@ -468,10 +468,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumnCollection_Clear_RemovesAllColumns()
+    public void RecordColumnCollection_Clear_RemovesAllColumns()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.Columns.Add<String>("Col1");
         table.Columns.Add<Int32>("Col2");
         table.Columns.Add<Boolean>("Col3");
@@ -487,7 +487,7 @@ public class FrameTests
     public void NullAndDbNullValues_HandledCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         var row = table.AddRow();
 
@@ -497,10 +497,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumn_Name_ReturnsCorrectName()
+    public void RecordColumn_Name_ReturnsCorrectName()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestColumnName");
 
         // Act & Assert
@@ -508,10 +508,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumn_Type_ReturnsCorrectType()
+    public void RecordColumn_Type_ReturnsCorrectType()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var stringCol = table.Columns.Add<String>("StringCol");
         var intCol = table.Columns.Add<Int32>("IntCol");
         var boolCol = table.Columns.Add<Boolean>("BoolCol");
@@ -523,10 +523,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void Frame_Name_CanBeSetAndRetrieved()
+    public void Record_Name_CanBeSetAndRetrieved()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
 
         // Act
         table.Name = "ModifiedName";
@@ -536,10 +536,10 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumnCollection_Indexer_ReturnsCorrectColumn()
+    public void RecordColumnCollection_Indexer_ReturnsCorrectColumn()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col1 = table.Columns.Add<String>("First");
         var col2 = table.Columns.Add<Int32>("Second");
 
@@ -549,12 +549,12 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void FrameColumnCollection_Capacity_InitializedCorrectly()
+    public void RecordColumnCollection_Capacity_InitializedCorrectly()
     {
         // Arrange & Act
-        var table1 = new Frame();
-        var table2 = new Frame("Test", 50);
-        var table3 = new Frame("Test", 5); // Should be set to minimum 20
+        var table1 = new Record();
+        var table2 = new Record("Test", 50);
+        var table3 = new Record("Test", 5); // Should be set to minimum 20
 
         // Assert
         Assert.AreEqual(20, table1.Capacity); // Default minimum
@@ -565,7 +565,7 @@ public class FrameTests
     [TestMethod]
     public void Delete_RowIndexLessThanZero_ReturnsFalse()
     {
-        var record = new Frame("Test", 2);
+        var record = new Record("Test", 2);
         var result = record.Delete(-1);
         Assert.IsFalse(result);
     }
@@ -573,7 +573,7 @@ public class FrameTests
     [TestMethod]
     public void Delete_RowIndexGreaterThanOrEqualCount_ReturnsFalse()
     {
-        var record = new Frame("Test", 2);
+        var record = new Record("Test", 2);
         record.AddRow();
         var result = record.Delete(1); // Only 1 row, index 1 is out of range
         Assert.IsFalse(result);
@@ -582,7 +582,7 @@ public class FrameTests
     [TestMethod]
     public void Delete_ValidRowIndex_RowIsDeleted()
     {
-        var record = new Frame("Test", 0);
+        var record = new Record("Test", 0);
         var idCol = record.Columns.Add<Int32>("Id");
         var nameCol = record.Columns.Add<String>("Name");
         record.AddRow();
@@ -603,7 +603,7 @@ public class FrameTests
     [TestMethod]
     public void Delete_LastRow_RowIsDeleted()
     {
-        var record = new Frame("Test", 0);
+        var record = new Record("Test", 0);
         var idCol = record.Columns.Add<Int32>("Id");
         record.AddRow();
         idCol.SetValue(0, 1);
@@ -618,9 +618,9 @@ public class FrameTests
     }
 
     [TestMethod]
-    public void ToString_EmptyFrame_ReturnsDefaultString()
+    public void ToString_EmptyRecord_ReturnsDefaultString()
     {
-        var record = new Frame();
+        var record = new Record();
         var result = record.ToString();
         Assert.IsTrue(result.Contains("None") || result.Contains("count 0"));
     }
@@ -628,7 +628,7 @@ public class FrameTests
     [TestMethod]
     public void ToString_OneRowMultipleColumns_ReturnsColumnValues()
     {
-        var record = new Frame("TestTable", 1);
+        var record = new Record("TestTable", 1);
         var nameCol = record.Columns.Add<String>("Name");
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
@@ -646,7 +646,7 @@ public class FrameTests
     [TestMethod]
     public void ToString_MultipleRowsMultipleColumns_ReturnsTableFormat()
     {
-        var record = new Frame("People", 2);
+        var record = new Record("People", 2);
         var nameCol = record.Columns.Add<String>("Name");
         var ageCol = record.Columns.Add<Int32>("Age");
         record.AddRow();
@@ -669,7 +669,7 @@ public class FrameTests
     [TestMethod]
     public void ToString_LongStringValue_TruncatesWithEllipsis()
     {
-        var record = new Frame("LongStringTest", 1);
+        var record = new Record("LongStringTest", 1);
         var nameCol = record.Columns.Add<String>("Name");
         var descCol = record.Columns.Add<String>("Description");
         record.AddRow();
@@ -687,7 +687,7 @@ public class FrameTests
     public void GetValue_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -700,7 +700,7 @@ public class FrameTests
     public void GetValue_RowIndexEqualToCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -713,7 +713,7 @@ public class FrameTests
     public void GetValue_RowIndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -726,7 +726,7 @@ public class FrameTests
     public void SetValue_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -739,7 +739,7 @@ public class FrameTests
     public void SetValue_RowIndexEqualToCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -752,7 +752,7 @@ public class FrameTests
     public void SetValue_RowIndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
 
@@ -765,7 +765,7 @@ public class FrameTests
     public void SetBoolean_NegativeIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Boolean>("BoolCol");
         table.AddRow();
 
@@ -778,7 +778,7 @@ public class FrameTests
     public void SetBoolean_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Boolean>("BoolCol");
         table.AddRow();
 
@@ -791,7 +791,7 @@ public class FrameTests
     public void SetInt32_IndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Int32>("IntCol");
         table.AddRow();
 
@@ -804,7 +804,7 @@ public class FrameTests
     public void ToBoolean_NegativeIndex_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Boolean>("BoolCol");
         table.AddRow();
 
@@ -817,7 +817,7 @@ public class FrameTests
     public void ToInt32_IndexEqualToCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<Int32>("IntCol");
         table.AddRow();
 
@@ -830,7 +830,7 @@ public class FrameTests
     public void ToString_IndexGreaterThanCount_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("StringCol");
         table.AddRow();
 
@@ -843,7 +843,7 @@ public class FrameTests
     public void BoundaryCheck_ValidIndex_WorksCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         table.AddRow();
         table.AddRow();
@@ -863,7 +863,7 @@ public class FrameTests
     public void BoundaryCheck_AfterCapacityExpansion_StillEnforcesBounds()
     {
         // Arrange
-        var table = new Frame("Test", 2); // Small initial capacity
+        var table = new Record("Test", 2); // Small initial capacity
         var col = table.Columns.Add<String>("TestCol");
 
         // Add rows to trigger capacity expansion
@@ -889,7 +889,7 @@ public class FrameTests
     public void AllTypedSetMethods_InvalidIndex_ThrowArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var boolCol = table.Columns.Add<Boolean>("Bool");
         var byteCol = table.Columns.Add<Byte>("Byte");
         var charCol = table.Columns.Add<Char>("Char");
@@ -930,7 +930,7 @@ public class FrameTests
     public void AllTypedToMethods_InvalidIndex_ThrowArgumentOutOfRangeException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var boolCol = table.Columns.Add<Boolean>("Bool");
         var byteCol = table.Columns.Add<Byte>("Byte");
         var charCol = table.Columns.Add<Char>("Char");
@@ -971,7 +971,7 @@ public class FrameTests
     public void BoundaryCheck_EmptyTable_AnyIndexThrowsException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         // No rows added, Count = 0
 
@@ -984,7 +984,7 @@ public class FrameTests
     public void BoundaryCheck_EmptyTable_NegativeIndexStillThrowsException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         // No rows added, Count = 0
 
@@ -997,7 +997,7 @@ public class FrameTests
     public void BoundaryCheck_EmptyTable_IndexGreaterThanZeroThrowsException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col = table.Columns.Add<String>("TestCol");
         // No rows added, Count = 0
 
@@ -1010,7 +1010,7 @@ public class FrameTests
     public void Columns_AddDuplicateName_ReturnsExisting()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var col1 = table.Columns.Add<String>("TestColumn");
 
         // Act
@@ -1025,7 +1025,7 @@ public class FrameTests
     public void Columns_AddDuplicateNameDifferentType_ThrowsInvalidOperationException()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         table.Columns.Add<String>("TestColumn");
 
         // Act & Assert - 同名不同类型应抛 InvalidOperationException（不再是 InvalidCastException）
@@ -1041,7 +1041,7 @@ public class FrameTests
     [TestMethod]
     public void Columns_SetObject_WorksCorrectly()
     {
-        var re = new Frame();
+        var re = new Record();
         var name = re.Columns.Add<string>("Name");
         var id = re.Columns.Add<Int32>("Id");
 
@@ -1058,7 +1058,7 @@ public class FrameTests
     public void Columns_SetObjectNotMatchType_ThrowsInvalidCastException()
     {
         // Arrange
-        var re = new Frame();
+        var re = new Record();
         var id = re.Columns.Add<Int32>("Id");
         var row = re.AddRow();
         // Act & Assert - DateTime cannot be converted to int via SetValue
@@ -1069,7 +1069,7 @@ public class FrameTests
     public void AddRowFromValues_ExactNumberOfValues_SetsAllColumns()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
         var colAge = table.Columns.Add<Int32>("Age");
@@ -1088,7 +1088,7 @@ public class FrameTests
     public void AddRowFromValues_FewerValuesThanColumns_SetsOnlyProvidedValues()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
         var colAge = table.Columns.Add<Int32>("Age");
@@ -1108,7 +1108,7 @@ public class FrameTests
     public void AddRowFromValues_MoreValuesThanColumns_IgnoresExtraValues()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
 
@@ -1126,7 +1126,7 @@ public class FrameTests
     public void AddRowFromValues_EmptyValuesArray_CreatesEmptyRow()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
 
@@ -1144,7 +1144,7 @@ public class FrameTests
     public void AddRowFromValues_NoColumns_CreatesRowWithoutErrors()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
 
         // Act
         var row = table.AddRowFromValues(1, "Test", 30);
@@ -1159,7 +1159,7 @@ public class FrameTests
     public void AddRowFromValues_DifferentDataTypes_SetsCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colBool = table.Columns.Add<Boolean>("Bool");
         var colByte = table.Columns.Add<Byte>("Byte");
         var colDateTime = table.Columns.Add<DateTime>("DateTime");
@@ -1183,7 +1183,7 @@ public class FrameTests
     public void AddRowFromValues_WithNullValues_SetsNullCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
         var colAge = table.Columns.Add<Int32>("Age");
@@ -1203,7 +1203,7 @@ public class FrameTests
     public void AddRowFromValues_MultipleRowsCalls_IncrementsCountCorrectly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
 
@@ -1229,7 +1229,7 @@ public class FrameTests
     public void AddRowFromValues_SingleValue_SetsFirstColumnOnly()
     {
         // Arrange
-        var table = new Frame();
+        var table = new Record();
         var colId = table.Columns.Add<Int32>("Id");
         var colName = table.Columns.Add<String>("Name");
         var colAge = table.Columns.Add<Int32>("Age");

--- a/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordToStringTests.cs
@@ -4,13 +4,13 @@ using System.Linq;
 namespace LuYao.Data;
 
 [TestClass]
-public class FrameToStringTests
+public class RecordToStringTests
 {
     [TestMethod]
-    public void WhenEmptyFrameThenContainsCountAndColumnInfo()
+    public void WhenEmptyRecordThenContainsCountAndColumnInfo()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
 
         // Act
         var result = record.ToString();
@@ -23,7 +23,7 @@ public class FrameToStringTests
     public void WhenNoNameThenShowsNone()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
 
         // Act
         var result = record.ToString();
@@ -36,7 +36,7 @@ public class FrameToStringTests
     public void WhenHasNameThenShowsName()
     {
         // Arrange
-        var record = new Frame("Users");
+        var record = new Record("Users");
 
         // Act
         var result = record.ToString();
@@ -49,7 +49,7 @@ public class FrameToStringTests
     public void WhenZeroColumnsAndZeroRowsThenDoesNotThrow()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
 
         // Act
         var result = record.ToString();
@@ -62,7 +62,7 @@ public class FrameToStringTests
     public void WhenColumnsButZeroRowsThenDoesNotThrow()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
 
@@ -77,7 +77,7 @@ public class FrameToStringTests
     public void WhenOneRowAndZeroColumnsThenDoesNotThrow()
     {
         // Arrange — 通过 DataTable 构造一个有行但无列的情况不可行，直接 AddRow
-        var record = new Frame();
+        var record = new Record();
         record.AddRow();
 
         // Act
@@ -91,7 +91,7 @@ public class FrameToStringTests
     public void WhenOneRowThenOutputsVerticalLayout()
     {
         // Arrange
-        var record = new Frame("Test");
+        var record = new Record("Test");
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
         var row = record.AddRow();
@@ -110,7 +110,7 @@ public class FrameToStringTests
     public void WhenMultipleRowsThenOutputsTableWithSeparator()
     {
         // Arrange
-        var record = new Frame("Test");
+        var record = new Record("Test");
         record.Columns.Add<int>("Id");
         record.Columns.Add<string>("Name");
         for (int i = 0; i < 2; i++)
@@ -133,7 +133,7 @@ public class FrameToStringTests
     public void WhenNullValueThenOutputsEmptyString()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<string>("Val");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
@@ -152,7 +152,7 @@ public class FrameToStringTests
     public void WhenSingleColumnThenNoSeparatorPrefix()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<int>("X");
         var r1 = record.AddRow();
         var r2 = record.AddRow();
@@ -174,7 +174,7 @@ public class FrameToStringTests
     public void WhenLongValueThenTruncatedWithDots()
     {
         // Arrange
-        var record = new Frame();
+        var record = new Record();
         record.Columns.Add<string>("Data");
         var r1 = record.AddRow();
         var r2 = record.AddRow();


### PR DESCRIPTION
本次提交完成以下主要内容：

- 将原有 Frame/FrameColumn/FrameRow 等类型体系系统性重命名为 Record/RecordColumn/RecordRow，涉及所有相关类型、方法、字段、枚举、注释及测试用例，确保命名一致性，二进制序列化头部同步调整。
- 新增 Record、RecordSet 及其相关类型的完整实现，支持高性能列式内存表结构、对象映射、分组、查询、分页、ADO.NET 互操作、二进制序列化等功能，并提供详细开发文档。
- RecordColumn/RecordColumn<T> 支持类型白名单与泛型高效存储，RecordRow 支持 struct 语义、索引器、dynamic 访问等，RecordColumnCollection 支持按名查找、批量建列等。
- 单元测试覆盖所有核心功能、边界条件和异常场景，新增 RecordToStringTests.cs，验证 Record.ToString 的多种输出格式和健壮性。
- 该实现为业务开发提供高性能、类型安全、易用的内存表结构，适用于对象与表结构互转、数据处理、服务端分页等场景。