### PR TITLE
feat: add Find/FindAll object overloads and unit tests

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -318,6 +318,8 @@ record.AddRowFromValues(2, "B", "Ignored");
 
 - `Find<T>(string name, T value)`
 - `FindAll<T>(string name, T value)`
+- `Find(string name, object? value)`
+- `FindAll(string name, object? value)`
 - `Find(Func<RecordRow, bool> filter)`
 - `FindAll(Func<RecordRow, bool> filter)`
 - `FindByDynamic(Func<dynamic, bool> filter)`
@@ -330,12 +332,17 @@ record.AddRowFromValues(2, "B", "Ignored");
 - `FindAll*` 使用 `yield return`，属于延迟执行枚举
 - `Find<T>(name, value)` 中列不存在时直接返回 `null`
 - `FindAll<T>(name, value)` 中列不存在时直接返回空序列
+- `Find(string, object?)` / `FindAll(string, object?)` 使用 `object.Equals` 进行匹配，支持 `null` 值比较；列不存在时分别返回 `null` 或空序列
 - 以委托过滤的 `Find` / `FindAll` 在 `filter == null` 时抛 `ArgumentNullException`
 
 示例：
 
 ```csharp
 var first = record.Find<int>("Id", 100);
+
+// 使用 object 重载（支持运行时类型与 null）
+var row = record.Find("Name", (object?)"Bob");
+var nullRows = record.FindAll("Name", (object?)null);
 
 var largeOrders = record.FindAll(r => r.To<decimal>("Amount") > 1000m);
 

--- a/src/LuYao.Common/Data/Record.Query.cs
+++ b/src/LuYao.Common/Data/Record.Query.cs
@@ -46,6 +46,42 @@ public partial class Record
     }
 
     /// <summary>
+    /// 在当前记录的所有数据行中，查找指定列与目标值（object 类型）匹配的第一行数据。
+    /// 如果指定的列名不存在，或者未找到匹配项，则直接返回 null。
+    /// </summary>
+    /// <param name="name">要查找的列名称。</param>
+    /// <param name="value">要匹配的目标值。</param>
+    /// <returns>符合条件的第一条 <see cref="RecordRow"/>，未找到则返回 null。</returns>
+    public RecordRow? Find(string name, object? value)
+    {
+        var col = this.Columns.Find(name);
+        if (col == null) return null;
+        for (int i = 0; i < this.Count; i++)
+        {
+            var val = col.Get(i);
+            if (Equals(val, value)) return new RecordRow(this, i);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 在当前记录的所有数据行中，查找指定列与目标值（object 类型）匹配的所有行数据，并以可枚举的序列返回。
+    /// </summary>
+    /// <param name="name">要查找的列名称。</param>
+    /// <param name="value">要匹配的目标值。</param>
+    /// <returns>一个包含所有符合条件 <see cref="RecordRow"/> 的枚举器序列。</returns>
+    public IEnumerable<RecordRow> FindAll(string name, object? value)
+    {
+        var col = this.Columns.Find(name);
+        if (col == null) yield break;
+        for (int i = 0; i < this.Count; i++)
+        {
+            var val = col.Get(i);
+            if (Equals(val, value)) yield return new RecordRow(this, i);
+        }
+    }
+
+    /// <summary>
     /// 使用指定的条件筛选器，查找符合要求的第一条行数据。
     /// </summary>
     /// <param name="filter">用于筛选 <see cref="RecordRow"/> 数据行的条件委托。</param>

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -170,4 +170,104 @@ public class RecordQueryTests
         Assert.AreEqual(1, results[0].To<int>("Id"));
         Assert.AreEqual(3, results[1].To<int>("Id"));
     }
+
+    [TestMethod]
+    public void Find_ObjectOverload_ReturnsFirstMatchingRow()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var result = record.Find("Name", (object)"Bob");
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(2, result.Value.To<int>("Id"));
+    }
+
+    [TestMethod]
+    public void Find_ObjectOverload_ReturnsNullWhenColumnNotFound()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var result = record.Find("NotExist", (object)1);
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Find_ObjectOverload_ReturnsNullWhenNoMatch()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var result = record.Find("Id", (object)99);
+
+        // Assert
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void Find_ObjectOverload_SupportsNullValue()
+    {
+        // Arrange
+        var record = new Record();
+        var colName = record.Columns.Add<string>("Name");
+        var r1 = record.AddRow();
+        colName.SetValue(r1.Row, "Alice");
+        var r2 = record.AddRow();
+        colName.SetValue(r2.Row, null);
+
+        // Act
+        var result = record.Find("Name", (object?)null);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.IsNull(result.Value.To<string>("Name"));
+    }
+
+    [TestMethod]
+    public void FindAll_ObjectOverload_ReturnsAllMatchingRows()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var results = record.FindAll("IsActive", (object)true).ToList();
+
+        // Assert
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual(1, results[0].To<int>("Id"));
+        Assert.AreEqual(3, results[1].To<int>("Id"));
+    }
+
+    [TestMethod]
+    public void FindAll_ObjectOverload_ReturnsEmptyWhenColumnNotFound()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var results = record.FindAll("NotExist", (object)1).ToList();
+
+        // Assert
+        Assert.AreEqual(0, results.Count);
+    }
+
+    [TestMethod]
+    public void FindAll_ObjectOverload_ReturnsEmptyWhenNoMatch()
+    {
+        // Arrange
+        var record = CreateTestRecord();
+
+        // Act
+        var results = record.FindAll("Id", (object)99).ToList();
+
+        // Assert
+        Assert.AreEqual(0, results.Count);
+    }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordQueryTests.cs
@@ -270,4 +270,26 @@ public class RecordQueryTests
         // Assert
         Assert.AreEqual(0, results.Count);
     }
+
+    [TestMethod]
+    public void FindAll_ObjectOverload_SupportsNullValue()
+    {
+        // Arrange
+        var record = new Record();
+        var colName = record.Columns.Add<string>("Name");
+        var r1 = record.AddRow();
+        colName.SetValue(r1.Row, "Alice");
+        var r2 = record.AddRow();
+        colName.SetValue(r2.Row, null);
+        var r3 = record.AddRow();
+        colName.SetValue(r3.Row, null);
+
+        // Act
+        var results = record.FindAll("Name", (object?)null).ToList();
+
+        // Assert
+        Assert.AreEqual(2, results.Count);
+        Assert.IsNull(results[0].To<string>("Name"));
+        Assert.IsNull(results[1].To<string>("Name"));
+    }
 }


### PR DESCRIPTION
This pull request adds new overloads to the `Find` and `FindAll` methods in the `Record` class to support searching by column name and value using the general `object` type, increasing the flexibility of record querying. Comprehensive unit tests are also added to ensure correct behavior for these new overloads, including handling of nulls and missing columns.

**Enhancements to record querying:**

* Added `Find(string name, object? value)` and `FindAll(string name, object? value)` methods to allow searching for rows by column name and value using the `object` type, supporting more flexible and dynamic queries.

**Testing improvements:**

* Added unit tests for the new `Find` and `FindAll` object overloads, covering scenarios such as finding the first match, handling missing columns, no matches, and support for null values.