### PR TITLE
feat: add RecordColumn.ToList<T>() and Record.GetList<T>(colName)

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -325,7 +325,7 @@ record.AddRowFromValues(2, "B", "Ignored");
 - `FindAll(Func<RecordRow, bool> filter)`
 - `FindByDynamic(Func<dynamic, bool> filter)`
 - `FindAllByDynamic(Func<dynamic, bool> filter)`
-- `GetList<T>(string colName)`：将指定列的所有值提取为 `List<T?>`，长度等于 `Count`；列不存在时抛 `KeyNotFoundException`，列名为空时抛 `ArgumentException`
+- `GetList<T>(string colName)`：将指定列的所有值提取为 `List<T?>`，长度等于 `Count`；列不存在时抛 `KeyNotFoundException`，列名为空时抛 `ArgumentException`，列值无法转换为目标类型时抛 `InvalidCastException`
 
 行为说明：
 

--- a/docs/Record.md
+++ b/docs/Record.md
@@ -136,6 +136,7 @@
 - `Capacity`
 - `Get(int row)` / `Set(int row, object? value)`
 - `To<T>(int row)`
+- `ToList<T>()`：将整列数据转为 `List<T?>`，长度等于 `Record.Count`；`null` 值对应 `default(T)`
 - `ToString(int row)`：获取指定行列值的字符串表示；`null` 值返回空字符串
 - `Delete(int row)` / `Clear()`
 - `GetValue(int row)` / `SetValue(int row, T value)`（泛型列）
@@ -324,6 +325,7 @@ record.AddRowFromValues(2, "B", "Ignored");
 - `FindAll(Func<RecordRow, bool> filter)`
 - `FindByDynamic(Func<dynamic, bool> filter)`
 - `FindAllByDynamic(Func<dynamic, bool> filter)`
+- `GetList<T>(string colName)`：将指定列的所有值提取为 `List<T?>`，长度等于 `Count`；列不存在时抛 `KeyNotFoundException`，列名为空时抛 `ArgumentException`
 
 行为说明：
 

--- a/src/LuYao.Common/Data/Record.Query.cs
+++ b/src/LuYao.Common/Data/Record.Query.cs
@@ -147,4 +147,20 @@ public partial class Record
             if (filter(row)) yield return row;
         }
     }
+
+    /// <summary>
+    /// 将指定列的所有数据转换为 <see cref="List{T}"/>，顺序与行索引一致。
+    /// 原值为 null 时对应元素为 <typeparamref name="T"/> 的默认值。
+    /// </summary>
+    /// <typeparam name="T">目标类型。</typeparam>
+    /// <param name="colName">列名称。</param>
+    /// <returns>包含整列数据的列表，长度等于 <see cref="Count"/>。</returns>
+    /// <exception cref="ArgumentException">当 <paramref name="colName"/> 为 null 或空白时抛出。</exception>
+    /// <exception cref="KeyNotFoundException">当指定列名不存在时抛出。</exception>
+    /// <exception cref="InvalidCastException">当某行值无法转换为目标类型时抛出。</exception>
+    public List<T?> GetList<T>(string colName)
+    {
+        if (string.IsNullOrWhiteSpace(colName)) throw new ArgumentException("列名不能为空。", nameof(colName));
+        return this.Columns.Get(colName).ToList<T>();
+    }
 }

--- a/src/LuYao.Common/Data/Record.Query.cs
+++ b/src/LuYao.Common/Data/Record.Query.cs
@@ -160,7 +160,7 @@ public partial class Record
     /// <exception cref="InvalidCastException">当某行值无法转换为目标类型时抛出。</exception>
     public List<T?> GetList<T>(string colName)
     {
-        if (string.IsNullOrWhiteSpace(colName)) throw new ArgumentException("列名不能为空。", nameof(colName));
+        if (string.IsNullOrWhiteSpace(colName)) throw new ArgumentException("列名不能为空", nameof(colName));
         return this.Columns.Get(colName).ToList<T>();
     }
 }

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using LuYao.Data.Meta;
 
 namespace LuYao.Data;
@@ -143,6 +144,22 @@ public abstract class RecordColumn : IXProp
     /// <returns>列值的字符串表示。</returns>
     /// <exception cref="ArgumentOutOfRangeException">当 <paramref name="row"/> 超出有效范围时抛出。</exception>
     public abstract String ToString(int row);
+
+    /// <summary>
+    /// 将整列数据转换为 <see cref="List{T}"/>，顺序与行索引一致。
+    /// 原值为 null 时对应元素为 <typeparamref name="T"/> 的默认值。
+    /// </summary>
+    /// <typeparam name="T">目标类型。</typeparam>
+    /// <returns>包含整列数据的列表，长度等于 <see cref="Record.Count"/>。</returns>
+    /// <exception cref="InvalidCastException">当某行值无法转换为目标类型时抛出。</exception>
+    public List<T?> ToList<T>()
+    {
+        int count = this.Record.Count;
+        var list = new List<T?>(count);
+        for (int i = 0; i < count; i++)
+            list.Add(To<T>(i));
+        return list;
+    }
     #endregion
 
     #region IXProp 实现

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -1341,4 +1341,16 @@ public class RecordTests
         Assert.Throws<ArgumentException>(() => table.GetList<int>(null!));
         Assert.Throws<ArgumentException>(() => table.GetList<int>("   "));
     }
+
+    [TestMethod]
+    public void RecordColumn_ToList_TypeMismatch_ThrowsInvalidCastException()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add<DateTime>("Value");
+        table.AddRow(); col.SetValue(0, DateTime.Now);
+
+        // Act & Assert
+        Assert.Throws<InvalidCastException>(() => col.ToList<int>());
+    }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordTests.cs
@@ -1244,4 +1244,101 @@ public class RecordTests
         Assert.IsNull(colName.Get(row.Row));
         Assert.AreEqual(0, colAge.To<Int32>(row.Row));
     }
+
+    [TestMethod]
+    public void RecordColumn_ToList_ReturnsAllValues()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add<Int32>("Id");
+        table.AddRow(); col.SetValue(0, 1);
+        table.AddRow(); col.SetValue(1, 2);
+        table.AddRow(); col.SetValue(2, 3);
+
+        // Act
+        var list = col.ToList<int>();
+
+        // Assert
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual(1, list[0]);
+        Assert.AreEqual(2, list[1]);
+        Assert.AreEqual(3, list[2]);
+    }
+
+    [TestMethod]
+    public void RecordColumn_ToList_EmptyRecord_ReturnsEmptyList()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add<String>("Name");
+
+        // Act
+        var list = col.ToList<string>();
+
+        // Assert
+        Assert.AreEqual(0, list.Count);
+    }
+
+    [TestMethod]
+    public void RecordColumn_ToList_NullValues_ReturnsDefaultForNulls()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add<String>("Name");
+        table.AddRow(); col.SetValue(0, "Alice");
+        table.AddRow(); // null
+        table.AddRow(); col.SetValue(2, "Bob");
+
+        // Act
+        var list = col.ToList<string>();
+
+        // Assert
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual("Alice", list[0]);
+        Assert.IsNull(list[1]);
+        Assert.AreEqual("Bob", list[2]);
+    }
+
+    [TestMethod]
+    public void Record_GetList_ByColName_ReturnsCorrectValues()
+    {
+        // Arrange
+        var table = new Record();
+        var col = table.Columns.Add<String>("Name");
+        table.AddRow(); col.SetValue(0, "Alice");
+        table.AddRow(); col.SetValue(1, "Bob");
+        table.AddRow(); col.SetValue(2, "Carol");
+
+        // Act
+        var list = table.GetList<string>("Name");
+
+        // Assert
+        Assert.AreEqual(3, list.Count);
+        Assert.AreEqual("Alice", list[0]);
+        Assert.AreEqual("Bob", list[1]);
+        Assert.AreEqual("Carol", list[2]);
+    }
+
+    [TestMethod]
+    public void Record_GetList_ColNotFound_ThrowsKeyNotFoundException()
+    {
+        // Arrange
+        var table = new Record();
+        table.Columns.Add<Int32>("Id");
+        table.AddRow();
+
+        // Act & Assert
+        Assert.Throws<KeyNotFoundException>(() => table.GetList<int>("Missing"));
+    }
+
+    [TestMethod]
+    public void Record_GetList_NullOrWhitespaceColName_ThrowsArgumentException()
+    {
+        // Arrange
+        var table = new Record();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => table.GetList<int>(null!));
+        Assert.Throws<ArgumentException>(() => table.GetList<int>("   "));
+    }
 }


### PR DESCRIPTION
This pull request introduces new methods to efficiently extract entire columns of data as lists from the `Record` and `RecordColumn` classes, along with comprehensive documentation and unit tests. These enhancements improve usability for bulk data retrieval and ensure robust error handling.

**API Enhancements for Column Extraction:**

* Added `ToList<T>()` method to `RecordColumn` to convert an entire column to a `List<T?>`, mapping `null` values to `default(T)` and preserving row order.
* Added `GetList<T>(string colName)` method to `Record` to extract all values from a specified column as a `List<T?>`, with clear exceptions for missing or invalid column names.

**Documentation Updates:**

* Documented the new `ToList<T>()` and `GetList<T>(string colName)` methods in `docs/Record.md`, including usage details and exception behavior. [[1]](diffhunk://#diff-264146e3f872515677daf054bda745e001b702006cb9055a2db6437702a478daR139) [[2]](diffhunk://#diff-264146e3f872515677daf054bda745e001b702006cb9055a2db6437702a478daR328)

**Testing Improvements:**

* Added unit tests for `RecordColumn.ToList<T>()` and `Record.GetList<T>(string colName)` covering normal operation, empty records, null values, and error cases for invalid column names.

**Codebase Maintenance:**

* Added necessary `using System.Collections.Generic;` directive to support new list functionality.