### PR TITLE
Feature/record to dictionary

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -574,6 +574,7 @@ var groups = record.Group<int, int>("Year", "Month");
 - `record.AddRowsFromList<T>(IEnumerable<T> items)`
 - `record.ToList<T>()`
 - `record.To<T>()`
+- `record.ToDictionary<TKey, T>()`
 
 示例：
 
@@ -586,7 +587,10 @@ var record = Record.From(new OrderDto
 
 List<OrderDto> list = record.ToList<OrderDto>();
 OrderDto first = record.To<OrderDto>();
+Dictionary<int, OrderDto> dict = record.ToDictionary<int, OrderDto>();
 ```
+
+`ToDictionary<TKey, T>` 使用第一列的值作为字典键；若存在重复键，则后者覆盖前者。若无行或无列，返回空字典。
 
 ### 6.2 `RecordRow` 级别映射
 

--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -97,7 +97,9 @@ partial class Record
     /// <typeparam name="TKey">键类型，对应第一列的值类型。</typeparam>
     /// <typeparam name="T">值类型，必须有无参构造函数。</typeparam>
     /// <returns>以第一列值为键、行对象为值的字典。</returns>
-    public Dictionary<TKey, T> ToDictionary<TKey, T>() where T : class, new()
+    public Dictionary<TKey, T> ToDictionary<TKey, T>()
+        where TKey : notnull
+        where T : class, new()
     {
         var dict = new Dictionary<TKey, T>();
         if (this.Count == 0 || this.Columns.Count == 0) return dict;

--- a/src/LuYao.Common/Data/Record.Mapping.cs
+++ b/src/LuYao.Common/Data/Record.Mapping.cs
@@ -21,6 +21,22 @@ partial class Record
     }
 
     /// <summary>
+    /// 将当前 <see cref="Record"/> 的第一行转换为 <typeparamref name="T"/> 对象。
+    /// 如果 <see cref="Record"/> 没有任何行，则返回一个使用无参构造函数创建的默认实例。
+    /// </summary>
+    /// <typeparam name="T">目标对象类型，必须有无参构造函数。</typeparam>
+    /// <returns>转换后的对象实例。</returns>
+    public T To<T>() where T : class, new()
+    {
+        var ret = new T();
+        if (this.Count > 0)
+        {
+            XCopy<T>.CopyFrom(ret, this[0]);
+        }
+        return ret;
+    }
+
+    /// <summary>
     /// 根据对象集合创建一个 <see cref="Record"/>，自动推断列结构并将每个对象写入一行。
     /// </summary>
     /// <typeparam name="T">集合元素的对象类型。</typeparam>
@@ -75,18 +91,22 @@ partial class Record
     }
 
     /// <summary>
-    /// 将当前 <see cref="Record"/> 的第一行转换为 <typeparamref name="T"/> 对象。
-    /// 如果 <see cref="Record"/> 没有任何行，则返回一个使用无参构造函数创建的默认实例。
+    /// 将当前 <see cref="Record"/> 转换为以第一列为键的字典。
+    /// 如果没有行或没有列，则返回空字典；键重复时后者覆盖前者。
     /// </summary>
-    /// <typeparam name="T">目标对象类型，必须有无参构造函数。</typeparam>
-    /// <returns>转换后的对象实例。</returns>
-    public T To<T>() where T : class, new()
+    /// <typeparam name="TKey">键类型，对应第一列的值类型。</typeparam>
+    /// <typeparam name="T">值类型，必须有无参构造函数。</typeparam>
+    /// <returns>以第一列值为键、行对象为值的字典。</returns>
+    public Dictionary<TKey, T> ToDictionary<TKey, T>() where T : class, new()
     {
-        var ret = new T();
-        if (this.Count > 0)
+        var dict = new Dictionary<TKey, T>();
+        if (this.Count == 0 || this.Columns.Count == 0) return dict;
+        var keyColumn = this.Columns[0];
+        foreach (var row in this)
         {
-            XCopy<T>.CopyFrom(ret, this[0]);
+            var key = keyColumn.To<TKey>(row.Row)!;
+            dict[key] = row.To<T>();
         }
-        return ret;
+        return dict;
     }
 }

--- a/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordMappingTests.cs
@@ -142,4 +142,60 @@ public class RecordMappingTests
 
         Assert.AreEqual(0, result.Count);
     }
+
+    // ── ToDictionary<TKey, T> ─────────────────────────────────────────────────
+
+    [TestMethod]
+    public void ToDictionary_ShouldMapFirstColumnAsKey()
+    {
+        var list = new List<TestModel>
+        {
+            new TestModel { Id = 1, Name = "Alice" },
+            new TestModel { Id = 2, Name = "Bob" }
+        };
+        var record = Record.FromList(list);
+
+        var dict = record.ToDictionary<int, TestModel>();
+
+        Assert.AreEqual(2,       dict.Count);
+        Assert.AreEqual("Alice", dict[1].Name);
+        Assert.AreEqual("Bob",   dict[2].Name);
+    }
+
+    [TestMethod]
+    public void ToDictionary_WithDuplicateKeys_ShouldUseLastValue()
+    {
+        var list = new List<TestModel>
+        {
+            new TestModel { Id = 1, Name = "First" },
+            new TestModel { Id = 1, Name = "Second" }
+        };
+        var record = Record.FromList(list);
+
+        var dict = record.ToDictionary<int, TestModel>();
+
+        Assert.AreEqual(1,        dict.Count);
+        Assert.AreEqual("Second", dict[1].Name);
+    }
+
+    [TestMethod]
+    public void ToDictionary_WithNoRows_ShouldReturnEmptyDictionary()
+    {
+        var record = new Record();
+        record.Columns.AddFrom<TestModel>();
+
+        var dict = record.ToDictionary<int, TestModel>();
+
+        Assert.AreEqual(0, dict.Count);
+    }
+
+    [TestMethod]
+    public void ToDictionary_WithNoColumns_ShouldReturnEmptyDictionary()
+    {
+        var record = new Record();
+
+        var dict = record.ToDictionary<int, TestModel>();
+
+        Assert.AreEqual(0, dict.Count);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new method for converting a `Record` to a dictionary, using the first column as the key, and updates the documentation and tests accordingly. The main changes are the addition of the `ToDictionary<TKey, T>` method, improved documentation, and comprehensive unit tests to ensure correct behavior.

### New features

* Added `ToDictionary<TKey, T>()` method to the `Record` class, allowing conversion of records to a dictionary using the first column as the key. If there are duplicate keys, the last value is used; if there are no rows or columns, an empty dictionary is returned.

### Documentation updates

* Updated `docs/Record.md` to document the new `ToDictionary<TKey, T>()` method, including usage examples and behavior notes. [[1]](diffhunk://#diff-264146e3f872515677daf054bda745e001b702006cb9055a2db6437702a478daR577) [[2]](diffhunk://#diff-264146e3f872515677daf054bda745e001b702006cb9055a2db6437702a478daR590-R594)

### Testing improvements

* Added unit tests for `ToDictionary<TKey, T>()` in `RecordMappingTests.cs` to cover mapping, duplicate keys, and empty records/columns scenarios.