### PR TITLE
Fix/format array as json

### DIFF
--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -100,74 +100,55 @@ public class RecordColumn<T> : RecordColumn
     /// </summary>
     private static string FormatArrayAsJson(Array array)
     {
-        if (array.Length == 0)
-        {
-            return array.Rank == 1 ? "[]" : FormatMultiDimensionalArray(array);
-        }
+        var sb = new System.Text.StringBuilder();
+        using var writer = new JsonWriter(sb, spaceAfterComma: true);
 
         if (array.Rank == 1)
         {
-            return FormatOneDimensionalArray(array);
+            WriteOneDimensionalArray(writer, array);
+        }
+        else
+        {
+            WriteMultiDimensionalArray(writer, array, new int[array.Rank], 0);
         }
 
-        return FormatMultiDimensionalArray(array);
+        writer.Flush();
+        return sb.ToString();
     }
 
-    private static string FormatOneDimensionalArray(Array array)
+    private static void WriteOneDimensionalArray(JsonWriter writer, Array array)
     {
-        var sb = new System.Text.StringBuilder("[");
-        using var writer = new JsonWriter(sb);
+        writer.WriteStartArray();
         for (int i = 0; i < array.Length; i++)
         {
-            if (i > 0)
-            {
-                writer.Flush();
-                sb.Append(", ");
-            }
             var element = array.GetValue(i);
-            AppendJsonValue(writer, element);
+            WriteJsonValue(writer, element);
         }
-        writer.Flush();
-        sb.Append("]");
-        return sb.ToString();
+        writer.WriteEndArray();
     }
 
-    private static string FormatMultiDimensionalArray(Array array)
+    private static void WriteMultiDimensionalArray(JsonWriter writer, Array array, int[] indices, int dimension)
     {
-        var sb = new System.Text.StringBuilder();
-        using var writer = new JsonWriter(sb);
-        FormatMultiDimensionalArrayRecursive(sb, writer, array, new int[array.Rank], 0);
-        return sb.ToString();
-    }
-
-    private static void FormatMultiDimensionalArrayRecursive(System.Text.StringBuilder sb, JsonWriter writer, Array array, int[] indices, int dimension)
-    {
-        sb.Append('[');
+        writer.WriteStartArray();
         int length = array.GetLength(dimension);
         for (int i = 0; i < length; i++)
         {
-            if (i > 0)
-            {
-                writer.Flush();
-                sb.Append(", ");
-            }
             indices[dimension] = i;
 
             if (dimension == array.Rank - 1)
             {
                 var element = array.GetValue(indices);
-                AppendJsonValue(writer, element);
+                WriteJsonValue(writer, element);
             }
             else
             {
-                FormatMultiDimensionalArrayRecursive(sb, writer, array, indices, dimension + 1);
+                WriteMultiDimensionalArray(writer, array, indices, dimension + 1);
             }
         }
-        writer.Flush();
-        sb.Append(']');
+        writer.WriteEndArray();
     }
 
-    private static void AppendJsonValue(JsonWriter writer, object? value)
+    private static void WriteJsonValue(JsonWriter writer, object? value)
     {
         if (value is null)
         {

--- a/src/LuYao.Common/Text/Json/JsonReader.cs
+++ b/src/LuYao.Common/Text/Json/JsonReader.cs
@@ -23,6 +23,12 @@ public sealed class JsonReader : IDisposable
 
     private const int DefaultBufferSize = 4096;
 
+    /// <summary>
+    /// 初始化 JsonReader 实例
+    /// </summary>
+    /// <param name="reader">要读取的 TextReader</param>
+    /// <param name="ownsReader">是否拥有并释放 TextReader</param>
+    /// <param name="bufferSize">缓冲区大小</param>
     public JsonReader(TextReader reader, bool ownsReader = false, int bufferSize = DefaultBufferSize)
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
@@ -30,6 +36,10 @@ public sealed class JsonReader : IDisposable
         _buffer = new char[Math.Max(bufferSize, 64)];
     }
 
+    /// <summary>
+    /// 使用 JSON 字符串初始化 JsonReader 实例
+    /// </summary>
+    /// <param name="json">要解析的 JSON 字符串</param>
     public JsonReader(string json) : this(new StringReader(json), true)
     {
     }
@@ -393,6 +403,9 @@ public sealed class JsonReader : IDisposable
         (c >= 'A' && c <= 'F') ||
         (c >= 'a' && c <= 'f');
 
+    /// <summary>
+    /// 释放资源
+    /// </summary>
     public void Dispose()
     {
         if (!_disposed)
@@ -414,6 +427,16 @@ public sealed class JsonReader : IDisposable
 /// </summary>
 public class JsonException : Exception
 {
+    /// <summary>
+    /// 使用错误消息初始化 JsonException 实例
+    /// </summary>
+    /// <param name="message">错误消息</param>
     public JsonException(string message) : base(message) { }
+
+    /// <summary>
+    /// 使用错误消息和内部异常初始化 JsonException 实例
+    /// </summary>
+    /// <param name="message">错误消息</param>
+    /// <param name="innerException">内部异常</param>
     public JsonException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/src/LuYao.Common/Text/Json/JsonToken.cs
+++ b/src/LuYao.Common/Text/Json/JsonToken.cs
@@ -71,6 +71,13 @@ public enum JsonTokenType
 /// </summary>
 public readonly struct JsonToken
 {
+    /// <summary>
+    /// 初始化 JsonToken 实例
+    /// </summary>
+    /// <param name="type">标记类型</param>
+    /// <param name="value">标记值</param>
+    /// <param name="startIndex">在源字符串中的起始位置</param>
+    /// <param name="length">标记长度</param>
     public JsonToken(JsonTokenType type, object? value = null, int startIndex = 0, int length = 0)
     {
         Type = type;

--- a/src/LuYao.Common/Text/Json/JsonWriter.cs
+++ b/src/LuYao.Common/Text/Json/JsonWriter.cs
@@ -228,6 +228,9 @@ public sealed class JsonWriter : IDisposable
     /// </summary>
     public void Flush()
     {
+        if (_disposed || _buffer is null)
+            return;
+
         if (_bufferPosition > 0)
         {
             _writer.Write(_buffer, 0, _bufferPosition);

--- a/src/LuYao.Common/Text/Json/JsonWriter.cs
+++ b/src/LuYao.Common/Text/Json/JsonWriter.cs
@@ -26,6 +26,7 @@ public sealed class JsonWriter : IDisposable
     // 格式化选项
     private readonly bool _indented;
     private readonly string _indentString;
+    private readonly bool _spaceAfterComma;
     private int _currentIndentLevel;
 
     /// <summary>
@@ -35,14 +36,16 @@ public sealed class JsonWriter : IDisposable
     /// <param name="ownsWriter">是否拥有并释放 TextWriter</param>
     /// <param name="indented">是否启用缩进格式化</param>
     /// <param name="indentString">缩进字符串</param>
+    /// <param name="spaceAfterComma">是否在逗号后添加空格(仅在非缩进模式下)</param>
     /// <param name="bufferSize">缓冲区大小</param>
     public JsonWriter(TextWriter writer, bool ownsWriter = false, bool indented = false,
-                     string indentString = "  ", int bufferSize = DefaultBufferSize)
+                     string indentString = "  ", bool spaceAfterComma = false, int bufferSize = DefaultBufferSize)
     {
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
         _ownsWriter = ownsWriter;
         _indented = indented;
         _indentString = indentString ?? "  ";
+        _spaceAfterComma = spaceAfterComma && !indented; // 缩进模式下忽略此选项
         _buffer = new char[Math.Max(bufferSize, 64)];
         _stateStack = new JsonWriteState[8]; // 初始栈大小
     }
@@ -53,8 +56,9 @@ public sealed class JsonWriter : IDisposable
     /// <param name="sb">要写入的 StringBuilder</param>
     /// <param name="indented">是否启用缩进格式化</param>
     /// <param name="indentString">缩进字符串</param>
-    public JsonWriter(StringBuilder sb, bool indented = false, string indentString = "  ")
-        : this(new StringWriter(sb), true, indented, indentString)
+    /// <param name="spaceAfterComma">是否在逗号后添加空格(仅在非缩进模式下)</param>
+    public JsonWriter(StringBuilder sb, bool indented = false, string indentString = "  ", bool spaceAfterComma = false)
+        : this(new StringWriter(sb), true, indented, indentString, spaceAfterComma)
     {
     }
 
@@ -324,7 +328,14 @@ public sealed class JsonWriter : IDisposable
             else if (currentState == JsonWriteState.Value)
             {
                 WriteChar(',');
-                if (_indented) WriteNewLine();
+                if (_indented)
+                {
+                    WriteNewLine();
+                }
+                else if (_spaceAfterComma)
+                {
+                    WriteChar(' ');
+                }
             }
             // Property 状态不需要逗号，只需要设置为 Value
             else if (currentState == JsonWriteState.Property)


### PR DESCRIPTION
This pull request refactors and enhances the JSON serialization logic and improves code documentation throughout the JSON utilities. The most significant change is the refactoring of array-to-JSON formatting in `RecordColumn.T.cs` to use streaming with `JsonWriter`, which improves performance and maintainability. Additionally, the `JsonWriter` class now supports an option to add a space after commas for better readability in non-indented mode. Numerous constructors and exception classes now include XML documentation comments for improved code clarity.

**Array Serialization Refactor:**
- Refactored array-to-JSON formatting in `RecordColumn.T.cs` to use streaming with `JsonWriter` instead of building strings manually. This change applies to both one-dimensional and multi-dimensional arrays, improving performance and consistency.

**JSON Writer Enhancements:**
- Added a `spaceAfterComma` option to the `JsonWriter` class, allowing a space after commas in non-indented mode for improved readability. Updated constructors and internal logic to support this feature. [[1]](diffhunk://#diff-39205055d20fd9192ac169671011b796873816c0aa0f07d454fe51d8a5e0677cR29) [[2]](diffhunk://#diff-39205055d20fd9192ac169671011b796873816c0aa0f07d454fe51d8a5e0677cR39-R48) [[3]](diffhunk://#diff-39205055d20fd9192ac169671011b796873816c0aa0f07d454fe51d8a5e0677cL56-R61) [[4]](diffhunk://#diff-39205055d20fd9192ac169671011b796873816c0aa0f07d454fe51d8a5e0677cL327-R341)
- Modified the `Flush` method in `JsonWriter` to safely handle cases where the writer has already been disposed or the buffer is null.

**Documentation Improvements:**
- Added XML documentation comments to constructors and methods in `JsonReader`, `JsonWriter`, `JsonToken`, and `JsonException` for better code clarity and maintainability. [[1]](diffhunk://#diff-7c537b46d8959beb1deaf6307ea564dd6f9745bb86e749ae9053f59e28a6442aR26-R42) [[2]](diffhunk://#diff-7c537b46d8959beb1deaf6307ea564dd6f9745bb86e749ae9053f59e28a6442aR406-R408) [[3]](diffhunk://#diff-7c537b46d8959beb1deaf6307ea564dd6f9745bb86e749ae9053f59e28a6442aR430-R440) [[4]](diffhunk://#diff-8fe5b1107f647436e52708fcfb4830890b533c61ff7a959985350fc82522cccbR74-R80)