### PR TITLE
feat: 添加 RecordTable/RecordSet 的 JSON 转换器支持

### DIFF
--- a/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
+++ b/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace LuYao.Data;
+
+/// <summary>
+/// Record 二进制负载压缩辅助类。
+/// </summary>
+internal static class RecordBinaryPayloadHelper
+{
+    private const int MaxDecompressedBytes = 64 * 1024 * 1024;
+    private const int DecodeBufferSize = 16 * 1024;
+    private const byte CompressionGZip = 1;
+    private const byte GZipSignatureFirst = 0x1F;
+    private const byte GZipSignatureSecond = 0x8B;
+
+    /// <summary>
+    /// 压缩并写入头部。
+    /// </summary>
+    /// <param name="payload">原始负载。</param>
+    /// <returns>带头部的压缩负载。</returns>
+    public static byte[] Encode(byte[] payload)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        return Encode(payload, 0, payload.Length);
+    }
+
+    /// <summary>
+    /// 压缩并写入头部。
+    /// </summary>
+    /// <param name="payload">原始负载。</param>
+    /// <param name="offset">起始偏移。</param>
+    /// <param name="count">长度。</param>
+    /// <returns>带头部的压缩负载。</returns>
+    public static byte[] Encode(byte[] payload, int offset, int count)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        if (offset < 0 || offset > payload.Length) throw new ArgumentOutOfRangeException(nameof(offset));
+        if (count < 0 || payload.Length - offset < count) throw new ArgumentOutOfRangeException(nameof(count));
+
+        using var output = new MemoryStream(count + 16);
+        output.WriteByte(CompressionGZip);
+        using (var gzip = new GZipStream(output, CompressionLevel.Fastest, leaveOpen: true))
+        {
+            gzip.Write(payload, offset, count);
+        }
+        return output.ToArray();
+    }
+
+    /// <summary>
+    /// 读取负载并按头部解压。
+    /// </summary>
+    /// <param name="payload">Base64 解码后的负载。</param>
+    /// <returns>解压后的原始负载。</returns>
+    public static byte[] Decode(byte[] payload)
+    {
+        if (payload == null) throw new ArgumentNullException(nameof(payload));
+        if (!IsGZipPayload(payload)) return payload;
+
+        using var input = new MemoryStream(payload, 1, payload.Length - 1, writable: false);
+        using var gzip = new GZipStream(input, CompressionMode.Decompress, leaveOpen: false);
+        using var output = new MemoryStream(Math.Min(payload.Length * 4, MaxDecompressedBytes));
+        var buffer = new byte[DecodeBufferSize];
+        var total = 0;
+        while (true)
+        {
+            var read = gzip.Read(buffer, 0, buffer.Length);
+            if (read <= 0) break;
+
+            if (total + read > MaxDecompressedBytes)
+                throw new InvalidDataException($"解压后数据超过限制：{MaxDecompressedBytes} bytes.");
+
+            total += read;
+            output.Write(buffer, 0, read);
+        }
+
+        return output.ToArray();
+    }
+
+    private static bool IsGZipPayload(byte[] payload) =>
+        payload.Length >= 3
+        && payload[0] == CompressionGZip
+        && payload[1] == GZipSignatureFirst
+        && payload[2] == GZipSignatureSecond;
+}

--- a/src/LuYao.Common/Data/RecordSetJsonConverter.cs
+++ b/src/LuYao.Common/Data/RecordSetJsonConverter.cs
@@ -1,0 +1,59 @@
+#if !NET45 && !NET461
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LuYao.Data;
+
+/// <summary>
+/// 将 <see cref="RecordSet"/> 以 Base64 二进制格式进行 JSON 序列化/反序列化。
+/// </summary>
+public class RecordSetJsonConverter : JsonConverter<RecordSet>
+{
+    /// <inheritdoc/>
+    public override RecordSet? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return null;
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var base64 = reader.GetString()!;
+            try
+            {
+                var bytes = Convert.FromBase64String(base64);
+                bytes = RecordBinaryPayloadHelper.Decode(bytes);
+                return RecordSet.FromBytes(bytes);
+            }
+            catch (FormatException ex)
+            {
+                throw new JsonException($"Failed to read RecordSet from Base64 JSON string. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (EndOfStreamException ex)
+            {
+                throw new JsonException($"Failed to read RecordSet from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (InvalidDataException ex)
+            {
+                throw new JsonException($"Failed to read RecordSet from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new JsonException($"Failed to read RecordSet from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+        }
+        throw new JsonException($"Unexpected token type {reader.TokenType} for RecordSet.");
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, RecordSet value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+        var bytes = RecordBinaryPayloadHelper.Encode(value.ToBytes());
+        writer.WriteStringValue(Convert.ToBase64String(bytes));
+    }
+}
+#endif

--- a/src/LuYao.Common/Data/RecordTableJsonConverter.cs
+++ b/src/LuYao.Common/Data/RecordTableJsonConverter.cs
@@ -1,0 +1,73 @@
+#if !NET45 && !NET461
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LuYao.Data;
+
+/// <summary>
+/// 将 <see cref="RecordTable"/> 以 Base64 二进制格式进行 JSON 序列化/反序列化。
+/// </summary>
+public class RecordTableJsonConverter : JsonConverter<RecordTable>
+{
+    /// <inheritdoc/>
+    public override RecordTable? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return null;
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var base64 = reader.GetString()!;
+            try
+            {
+                var bytes = Convert.FromBase64String(base64);
+                bytes = RecordBinaryPayloadHelper.Decode(bytes);
+                using var ms = new MemoryStream(bytes, writable: false);
+                using var br = new BinaryReader(ms, Encoding.UTF8, leaveOpen: true);
+                var record = new RecordTable();
+                record.ReadFrom(br);
+                return record;
+            }
+            catch (FormatException ex)
+            {
+                throw new JsonException($"Failed to read RecordTable from Base64 JSON string. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (EndOfStreamException ex)
+            {
+                throw new JsonException($"Failed to read RecordTable from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (InvalidDataException ex)
+            {
+                throw new JsonException($"Failed to read RecordTable from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new JsonException($"Failed to read RecordTable from binary payload. TokenType={reader.TokenType}, Base64Length={base64.Length}.", ex);
+            }
+        }
+        throw new JsonException($"Unexpected token type {reader.TokenType} for RecordTable.");
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, RecordTable value, JsonSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+        using var ms = new MemoryStream();
+        using var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true);
+        value.WriteTo(bw);
+        bw.Flush();
+
+        string base64;
+        if (ms.TryGetBuffer(out ArraySegment<byte> buffer) && buffer.Array != null)
+            base64 = Convert.ToBase64String(RecordBinaryPayloadHelper.Encode(buffer.Array, buffer.Offset, (int)ms.Length));
+        else
+            base64 = Convert.ToBase64String(RecordBinaryPayloadHelper.Encode(ms.ToArray()));
+        writer.WriteStringValue(base64);
+    }
+}
+#endif

--- a/src/LuYao.Common/LuYao.Common.csproj
+++ b/src/LuYao.Common/LuYao.Common.csproj
@@ -20,10 +20,14 @@
 		<Compile Include="..\Assembly.cs" Link="Assembly.cs" />
 	</ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+	</ItemGroup>
+
 	<ItemGroup>
 	  <PackageReference Update="ConfigureAwait.Fody" Version="3.4.0" />
 	  <PackageReference Update="Fody" Version="6.9.3">
-	    <PrivateAssets>all</PrivateAssets>
+		<PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
 	</ItemGroup>
 </Project>

--- a/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Text.Json;
+
+namespace LuYao.Data;
+
+[TestClass]
+public class RecordJsonConverterTests
+{
+    #region RecordTableJsonConverter Tests
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenSerializeAndDeserializeThenDataPreserved()
+    {
+        var original = CreateTestRecordTable();
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        var json = JsonSerializer.Serialize(original, options);
+        var deserialized = JsonSerializer.Deserialize<RecordTable>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual("Orders", deserialized.Name);
+        Assert.AreEqual(2, deserialized.Count);
+        Assert.AreEqual(2, deserialized.Columns.Count);
+        Assert.AreEqual(2, deserialized.Page);
+        Assert.AreEqual(10, deserialized.PageSize);
+        Assert.AreEqual(50, deserialized.MaxCount);
+
+        var idCol = deserialized.Columns["Id"] as RecordColumn<int>;
+        var nameCol = deserialized.Columns["Name"] as RecordColumn<string>;
+        Assert.IsNotNull(idCol);
+        Assert.IsNotNull(nameCol);
+
+        Assert.AreEqual(1, idCol.GetValue(0));
+        Assert.AreEqual("Order-1", nameCol.GetValue(0));
+        Assert.AreEqual(2, idCol.GetValue(1));
+        Assert.AreEqual("Order-2", nameCol.GetValue(1));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenSerializeNullThenReturnsNull()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        var json = JsonSerializer.Serialize<RecordTable>(null, options);
+        Assert.AreEqual("null", json);
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenDeserializeNullThenReturnsNull()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        var deserialized = JsonSerializer.Deserialize<RecordTable>("null", options);
+        Assert.IsNull(deserialized);
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenDeserializeInvalidBase64ThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordTable>("\"invalid-base64!!!\"", options));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenDeserializeInvalidTokenTypeThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordTable>("123", options));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenDeserializeInvalidBinaryPayloadThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        var invalidBytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+        var base64 = Convert.ToBase64String(invalidBytes);
+        var json = $"\"{base64}\"";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordTable>(json, options));
+    }
+
+    #endregion
+
+    #region RecordSetJsonConverter Tests
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenSerializeAndDeserializeThenDataPreserved()
+    {
+        var original = CreateTestRecordSet();
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var json = JsonSerializer.Serialize(original, options);
+        var deserialized = JsonSerializer.Deserialize<RecordSet>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(2, deserialized.Count);
+        Assert.IsTrue(deserialized.Contains("Orders"));
+        Assert.IsTrue(deserialized.Contains("Products"));
+
+        var orders = deserialized["Orders"];
+        Assert.IsNotNull(orders);
+        Assert.AreEqual("Orders", orders.Name);
+        Assert.AreEqual(1, orders.Count);
+
+        var products = deserialized["Products"];
+        Assert.IsNotNull(products);
+        Assert.AreEqual("Products", products.Name);
+        Assert.AreEqual(1, products.Count);
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenSerializeNullThenReturnsNull()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var json = JsonSerializer.Serialize<RecordSet>(null, options);
+        Assert.AreEqual("null", json);
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDeserializeNullThenReturnsNull()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var deserialized = JsonSerializer.Deserialize<RecordSet>("null", options);
+        Assert.IsNull(deserialized);
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDeserializeInvalidBase64ThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>("\"invalid-base64!!!\"", options));
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDeserializeInvalidTokenTypeThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>("123", options));
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDeserializeInvalidBinaryPayloadThenThrowsJsonException()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var invalidBytes = new byte[] { 0x00, 0x01, 0x02, 0x03 };
+        var base64 = Convert.ToBase64String(invalidBytes);
+        var json = $"\"{base64}\"";
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>(json, options));
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenRoundTripWithEmptySetThenSucceeds()
+    {
+        var original = new RecordSet();
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var json = JsonSerializer.Serialize(original, options);
+        var deserialized = JsonSerializer.Deserialize<RecordSet>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(0, deserialized.Count);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static RecordTable CreateTestRecordTable()
+    {
+        var table = new RecordTable("Orders", 2);
+        var idCol = table.Columns.Add<int>("Id");
+        var nameCol = table.Columns.Add<string>("Name");
+        table.Page = 2;
+        table.PageSize = 10;
+        table.MaxCount = 50;
+
+        var row1 = table.AddRow();
+        idCol.SetValue(row1.Row, 1);
+        nameCol.SetValue(row1.Row, "Order-1");
+
+        var row2 = table.AddRow();
+        idCol.SetValue(row2.Row, 2);
+        nameCol.SetValue(row2.Row, "Order-2");
+
+        return table;
+    }
+
+    private static RecordSet CreateTestRecordSet()
+    {
+        var set = new RecordSet();
+
+        var orders = new RecordTable("Orders", 1);
+        var orderId = orders.Columns.Add<int>("Id");
+        var orderRow = orders.AddRow();
+        orderId.SetValue(orderRow.Row, 1);
+        set.Add("Orders", orders);
+
+        var products = new RecordTable("Products", 1);
+        var productId = products.Columns.Add<int>("Id");
+        var productRow = products.AddRow();
+        productId.SetValue(productRow.Row, 100);
+        set.Add("Products", products);
+
+        return set;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
This pull request introduces support for efficient JSON serialization and deserialization of `RecordSet` and `RecordTable` objects using a custom Base64-encoded, compressed binary format. It also adds comprehensive unit tests for these converters and includes a new helper for handling the binary payload compression. Additionally, the necessary package reference for `System.Text.Json` is added for relevant target frameworks.

**Serialization/Deserialization Enhancements:**

* Added `RecordSetJsonConverter` and `RecordTableJsonConverter` classes, enabling JSON serialization and deserialization of `RecordSet` and `RecordTable` objects using Base64-encoded, GZip-compressed binary payloads. These converters include robust error handling for invalid data and token types. (`src/LuYao.Common/Data/RecordSetJsonConverter.cs` [[1]](diffhunk://#diff-1799f28f658b64af1c698e2298af669fae16f562f511c493aa0a025c02559881R1-R59) `src/LuYao.Common/Data/RecordTableJsonConverter.cs` [[2]](diffhunk://#diff-682b14c6de60a4c2e9535524dab097e453c62304688c9eed7906248585ed3bf4R1-R73)
* Introduced `RecordBinaryPayloadHelper`, a utility class for compressing and decompressing record binary payloads using GZip, with safeguards for data size and format. (`src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs` [src/LuYao.Common/Data/RecordBinaryPayloadHelper.csR1-R86](diffhunk://#diff-fccedfe9325db6f53a4878e2ca190ac7b45fd5ff11021caa8d7248f06d0de61fR1-R86))

**Testing:**

* Added `RecordJsonConverterTests` to verify the correct serialization/deserialization behavior, null handling, and error cases for both converters, ensuring data integrity and reliability. (`tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs` [tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.csR1-R236](diffhunk://#diff-f00b101a69203f0d2ff03552feb7bb2076bad8b57bddd1e044097a4c2c792a41R1-R236))

**Project Configuration:**

* Added a conditional package reference for `System.Text.Json` version 8.0.5 for `netstandard2.0` and `netstandard2.1` target frameworks to support the new converters. (`src/LuYao.Common/LuYao.Common.csproj` [src/LuYao.Common/LuYao.Common.csprojR23-R26](diffhunk://#diff-7d7104edeb0471fc011708b0ed9a5a92a0b856a5bdddce0dbcd87d699444c8a6R23-R26))- 新增 RecordBinaryPayloadHelper 提供压缩/解压功能

- 新增 RecordTableJsonConverter 支持 RecordTable 的 JSON 序列化

- 新增 RecordSetJsonConverter 支持 RecordSet 的 JSON 序列化

- 使用 Base64 + GZip 压缩的二进制格式

- 添加完整的单元测试覆盖（13 个测试全部通过）

- 使用条件编译排除不支持 System.Text.Json 的框架（net45/net461）