### PR TITLE
fix(data): harden Record binary JSON converters against malicious pay…

### DIFF
--- a/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
+++ b/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
@@ -7,13 +7,36 @@ namespace LuYao.Data;
 /// <summary>
 /// Record 二进制负载压缩辅助类。
 /// </summary>
+/// <remarks>
+/// 使用 5 字节 magic 头 (<c>0xFE 'L' 'Y' 'Z' &lt;algo&gt;</c>) 区分压缩负载与遗留无压缩负载，
+/// 避免与 <see cref="BinaryPayloadHeader"/> 的 marker (0xFF) 以及无头部遗留格式的版本号字节产生歧义。
+/// </remarks>
 internal static class RecordBinaryPayloadHelper
 {
-    private const int MaxDecompressedBytes = 64 * 1024 * 1024;
+    /// <summary>解压后允许的最大字节数，用于防御 zip bomb 等 DoS 攻击。</summary>
+    public const int MaxDecompressedBytes = 64 * 1024 * 1024;
+
+    /// <summary>压缩负载允许的最大字节数（解码 Base64 后），用于防御过大压缩输入。</summary>
+    public const int MaxCompressedBytes = 16 * 1024 * 1024;
+
+    /// <summary>
+    /// JSON 字符串中 Base64 文本允许的最大字符数；用于在解码前阻止过大输入。
+    /// 取 <see cref="MaxCompressedBytes"/> 对应的 Base64 长度上限并向上取整。
+    /// </summary>
+    public const int MaxBase64Length = ((MaxCompressedBytes + 2) / 3) * 4;
+
     private const int DecodeBufferSize = 16 * 1024;
-    private const byte CompressionGZip = 1;
-    private const byte GZipSignatureFirst = 0x1F;
-    private const byte GZipSignatureSecond = 0x8B;
+    private const int InitialOutputCapacity = 4 * 1024;
+
+    // Magic: 0xFE 'L' 'Y' 'Z' + 算法 ID。0xFE 与 BinaryPayloadHeader.Marker (0xFF) 及 BinaryFormatVersion (1) 都不冲突。
+    private const byte MagicByte0 = 0xFE;
+    private const byte MagicByte1 = (byte)'L';
+    private const byte MagicByte2 = (byte)'Y';
+    private const byte MagicByte3 = (byte)'Z';
+    private const int MagicLength = 4;
+    private const int HeaderLength = MagicLength + 1; // magic + algorithm id
+
+    private const byte AlgorithmGZip = 1;
 
     /// <summary>
     /// 压缩并写入头部。
@@ -39,8 +62,12 @@ internal static class RecordBinaryPayloadHelper
         if (offset < 0 || offset > payload.Length) throw new ArgumentOutOfRangeException(nameof(offset));
         if (count < 0 || payload.Length - offset < count) throw new ArgumentOutOfRangeException(nameof(count));
 
-        using var output = new MemoryStream(count + 16);
-        output.WriteByte(CompressionGZip);
+        using var output = new MemoryStream(count + HeaderLength + 16);
+        output.WriteByte(MagicByte0);
+        output.WriteByte(MagicByte1);
+        output.WriteByte(MagicByte2);
+        output.WriteByte(MagicByte3);
+        output.WriteByte(AlgorithmGZip);
         using (var gzip = new GZipStream(output, CompressionLevel.Fastest, leaveOpen: true))
         {
             gzip.Write(payload, offset, count);
@@ -49,23 +76,44 @@ internal static class RecordBinaryPayloadHelper
     }
 
     /// <summary>
-    /// 读取负载并按头部解压。
+    /// 读取负载并按头部解压；若负载不带本类型的压缩头则原样返回（向后兼容遗留无压缩格式）。
     /// </summary>
     /// <param name="payload">Base64 解码后的负载。</param>
     /// <returns>解压后的原始负载。</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="payload"/> 为 null。</exception>
+    /// <exception cref="InvalidDataException">压缩输入过大、解压结果超出限制、迭代次数异常或算法不支持。</exception>
     public static byte[] Decode(byte[] payload)
     {
         if (payload == null) throw new ArgumentNullException(nameof(payload));
-        if (!IsGZipPayload(payload)) return payload;
 
-        using var input = new MemoryStream(payload, 1, payload.Length - 1, writable: false);
+        // 入口长度硬上限：阻止解码后的超大压缩负载进入解压流程。
+        if (payload.Length > MaxCompressedBytes)
+            throw new InvalidDataException($"压缩负载超过限制：{MaxCompressedBytes} bytes.");
+
+        if (!HasCompressedHeader(payload)) return payload;
+
+        byte algorithm = payload[MagicLength];
+        if (algorithm != AlgorithmGZip)
+            throw new InvalidDataException($"不支持的压缩算法标识：0x{algorithm:X2}。");
+
+        int dataOffset = HeaderLength;
+        int dataLength = payload.Length - HeaderLength;
+
+        using var input = new MemoryStream(payload, dataOffset, dataLength, writable: false);
         using var gzip = new GZipStream(input, CompressionMode.Decompress, leaveOpen: false);
-        using var output = new MemoryStream(Math.Min(payload.Length * 4, MaxDecompressedBytes));
+        // 不信任攻击者控制的长度作为容量提示；固定小初始容量，让 MemoryStream 按需扩容。
+        using var output = new MemoryStream(InitialOutputCapacity);
         var buffer = new byte[DecodeBufferSize];
-        var total = 0;
+        long total = 0;
+        // 限制迭代次数，防御构造慢速 / 高迭代次数的负载。
+        const int maxIterations = (MaxDecompressedBytes / DecodeBufferSize) + 16;
+        int iterations = 0;
         while (true)
         {
-            var read = gzip.Read(buffer, 0, buffer.Length);
+            if (++iterations > maxIterations)
+                throw new InvalidDataException("解压迭代次数超过限制。");
+
+            int read = gzip.Read(buffer, 0, buffer.Length);
             if (read <= 0) break;
 
             if (total + read > MaxDecompressedBytes)
@@ -78,9 +126,10 @@ internal static class RecordBinaryPayloadHelper
         return output.ToArray();
     }
 
-    private static bool IsGZipPayload(byte[] payload) =>
-        payload.Length >= 3
-        && payload[0] == CompressionGZip
-        && payload[1] == GZipSignatureFirst
-        && payload[2] == GZipSignatureSecond;
+    private static bool HasCompressedHeader(byte[] payload) =>
+        payload.Length >= HeaderLength
+        && payload[0] == MagicByte0
+        && payload[1] == MagicByte1
+        && payload[2] == MagicByte2
+        && payload[3] == MagicByte3;
 }

--- a/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
+++ b/src/LuYao.Common/Data/RecordBinaryPayloadHelper.cs
@@ -86,11 +86,13 @@ internal static class RecordBinaryPayloadHelper
     {
         if (payload == null) throw new ArgumentNullException(nameof(payload));
 
-        // 入口长度硬上限：阻止解码后的超大压缩负载进入解压流程。
+        // 不带本类型压缩头的负载（含遗留无压缩格式）原样透传，不做 16MB 限制：
+        // Converter 层的 Base64 长度守卫已经是入口总闸门。
+        if (!HasCompressedHeader(payload)) return payload;
+
+        // 仅对带压缩头、即将进入解压流程的负载施加输入上限，防止过大压缩输入引发的内存压力。
         if (payload.Length > MaxCompressedBytes)
             throw new InvalidDataException($"压缩负载超过限制：{MaxCompressedBytes} bytes.");
-
-        if (!HasCompressedHeader(payload)) return payload;
 
         byte algorithm = payload[MagicLength];
         if (algorithm != AlgorithmGZip)
@@ -105,14 +107,10 @@ internal static class RecordBinaryPayloadHelper
         using var output = new MemoryStream(InitialOutputCapacity);
         var buffer = new byte[DecodeBufferSize];
         long total = 0;
-        // 限制迭代次数，防御构造慢速 / 高迭代次数的负载。
-        const int maxIterations = (MaxDecompressedBytes / DecodeBufferSize) + 16;
-        int iterations = 0;
         while (true)
         {
-            if (++iterations > maxIterations)
-                throw new InvalidDataException("解压迭代次数超过限制。");
-
+            // 注意：Stream.Read 允许返回少于 count 的字节数，因此不能基于"调用次数"做迭代上限，
+            // 否则可能误杀合法但分块较小的解压流。退出条件以 read <= 0 为准。
             int read = gzip.Read(buffer, 0, buffer.Length);
             if (read <= 0) break;
 

--- a/src/LuYao.Common/Data/RecordSetJsonConverter.cs
+++ b/src/LuYao.Common/Data/RecordSetJsonConverter.cs
@@ -17,6 +17,11 @@ public class RecordSetJsonConverter : JsonConverter<RecordSet>
         if (reader.TokenType == JsonTokenType.Null) return null;
         if (reader.TokenType == JsonTokenType.String)
         {
+            // 在分配字符串/字节数组前先检查 Base64 长度上限，防御超大输入引发的 OOM。
+            long base64Length = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+            if (base64Length > RecordBinaryPayloadHelper.MaxBase64Length)
+                throw new JsonException($"RecordSet Base64 payload exceeds maximum allowed length {RecordBinaryPayloadHelper.MaxBase64Length}.");
+
             var base64 = reader.GetString()!;
             try
             {

--- a/src/LuYao.Common/Data/RecordTableJsonConverter.cs
+++ b/src/LuYao.Common/Data/RecordTableJsonConverter.cs
@@ -18,6 +18,11 @@ public class RecordTableJsonConverter : JsonConverter<RecordTable>
         if (reader.TokenType == JsonTokenType.Null) return null;
         if (reader.TokenType == JsonTokenType.String)
         {
+            // 在分配字符串/字节数组前先检查 Base64 长度上限，防御超大输入引发的 OOM。
+            long base64Length = reader.HasValueSequence ? reader.ValueSequence.Length : reader.ValueSpan.Length;
+            if (base64Length > RecordBinaryPayloadHelper.MaxBase64Length)
+                throw new JsonException($"RecordTable Base64 payload exceeds maximum allowed length {RecordBinaryPayloadHelper.MaxBase64Length}.");
+
             var base64 = reader.GetString()!;
             try
             {

--- a/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
 using System.Text.Json;
 
 namespace LuYao.Data;
@@ -187,6 +190,134 @@ public class RecordJsonConverterTests
 
         Assert.IsNotNull(deserialized);
         Assert.AreEqual(0, deserialized.Count);
+    }
+
+    #endregion
+
+    #region Security / Compatibility Tests
+
+    // 与 RecordBinaryPayloadHelper 内部头部保持一致：0xFE 'L' 'Y' 'Z' + 算法 ID。
+    private static readonly byte[] CompressedHeader = { 0xFE, (byte)'L', (byte)'Y', (byte)'Z', 0x01 };
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDeserializeUncompressedLegacyPayloadThenSucceeds()
+    {
+        // 旧的无压缩 RecordSet.ToBytes() 直接 Base64，应当走 passthrough 分支。
+        var original = CreateTestRecordSet();
+        var rawBytes = original.ToBytes();
+        var json = "\"" + Convert.ToBase64String(rawBytes) + "\"";
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        var deserialized = JsonSerializer.Deserialize<RecordSet>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual(2, deserialized.Count);
+        Assert.IsTrue(deserialized.Contains("Orders"));
+        Assert.IsTrue(deserialized.Contains("Products"));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenDeserializeUncompressedLegacyPayloadThenSucceeds()
+    {
+        // 旧的无压缩 RecordTable 二进制（直接 WriteTo），应当走 passthrough 分支。
+        var original = CreateTestRecordTable();
+        byte[] rawBytes;
+        using (var ms = new MemoryStream())
+        using (var bw = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+        {
+            original.WriteTo(bw);
+            bw.Flush();
+            rawBytes = ms.ToArray();
+        }
+        var json = "\"" + Convert.ToBase64String(rawBytes) + "\"";
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        var deserialized = JsonSerializer.Deserialize<RecordTable>(json, options);
+
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual("Orders", deserialized.Name);
+        Assert.AreEqual(2, deserialized.Count);
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenPayloadHasCompressionMarkerButInvalidGZipThenThrowsJsonException()
+    {
+        // 头部正确，但 gzip 主体为乱码，应当被包装为 JsonException。
+        var bad = new byte[CompressedHeader.Length + 16];
+        Buffer.BlockCopy(CompressedHeader, 0, bad, 0, CompressedHeader.Length);
+        for (int i = CompressedHeader.Length; i < bad.Length; i++) bad[i] = 0xAB;
+        var json = "\"" + Convert.ToBase64String(bad) + "\"";
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>(json, options));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenPayloadHasCompressionMarkerButInvalidGZipThenThrowsJsonException()
+    {
+        var bad = new byte[CompressedHeader.Length + 16];
+        Buffer.BlockCopy(CompressedHeader, 0, bad, 0, CompressedHeader.Length);
+        for (int i = CompressedHeader.Length; i < bad.Length; i++) bad[i] = 0xAB;
+        var json = "\"" + Convert.ToBase64String(bad) + "\"";
+
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordTable>(json, options));
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenDecompressedSizeExceedsLimitThenThrowsJsonException()
+    {
+        // 构造 zip bomb：极小压缩输入，解压后远超 64MB 上限。
+        byte[] compressed;
+        using (var ms = new MemoryStream())
+        {
+            ms.Write(CompressedHeader, 0, CompressedHeader.Length);
+            using (var gz = new GZipStream(ms, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                var chunk = new byte[64 * 1024]; // 全零块，压缩比极高
+                // 写入 ~80MB，超过 64MB 上限
+                for (int i = 0; i < 1280; i++) gz.Write(chunk, 0, chunk.Length);
+            }
+            compressed = ms.ToArray();
+        }
+
+        var json = "\"" + Convert.ToBase64String(compressed) + "\"";
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>(json, options));
+    }
+
+    [TestMethod]
+    public void RecordSetJsonConverter_WhenBase64PayloadTooLargeThenThrowsJsonException()
+    {
+        // 构造一个超过 MaxBase64Length 的字符串（内容无所谓，长度用 'A' 填充）。
+        // MaxBase64Length 来自 16MB 压缩上限，约 22.4MB Base64 字符。
+        const int oversize = 25 * 1024 * 1024;
+        var sb = new StringBuilder(oversize + 2);
+        sb.Append('"');
+        sb.Append('A', oversize);
+        sb.Append('"');
+        var json = sb.ToString();
+
+        var options = new JsonSerializerOptions { MaxDepth = 64 };
+        options.Converters.Add(new RecordSetJsonConverter());
+
+        // System.Text.Json 默认对单个 token 的字符串长度也有上限，但这里我们关心的是
+        // 在分配 byte[] 之前就被守卫拦截。无论命中守卫还是底层读取限制，都应是 JsonException。
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordSet>(json, options));
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordJsonConverterTests.cs
@@ -302,14 +302,7 @@ public class RecordJsonConverterTests
     [TestMethod]
     public void RecordSetJsonConverter_WhenBase64PayloadTooLargeThenThrowsJsonException()
     {
-        // 构造一个超过 MaxBase64Length 的字符串（内容无所谓，长度用 'A' 填充）。
-        // MaxBase64Length 来自 16MB 压缩上限，约 22.4MB Base64 字符。
-        const int oversize = 25 * 1024 * 1024;
-        var sb = new StringBuilder(oversize + 2);
-        sb.Append('"');
-        sb.Append('A', oversize);
-        sb.Append('"');
-        var json = sb.ToString();
+        var json = BuildOversizeBase64Json();
 
         var options = new JsonSerializerOptions { MaxDepth = 64 };
         options.Converters.Add(new RecordSetJsonConverter());
@@ -318,6 +311,30 @@ public class RecordJsonConverterTests
         // 在分配 byte[] 之前就被守卫拦截。无论命中守卫还是底层读取限制，都应是 JsonException。
         Assert.Throws<JsonException>(() =>
             JsonSerializer.Deserialize<RecordSet>(json, options));
+    }
+
+    [TestMethod]
+    public void RecordTableJsonConverter_WhenBase64PayloadTooLargeThenThrowsJsonException()
+    {
+        var json = BuildOversizeBase64Json();
+
+        var options = new JsonSerializerOptions { MaxDepth = 64 };
+        options.Converters.Add(new RecordTableJsonConverter());
+
+        Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<RecordTable>(json, options));
+    }
+
+    private static string BuildOversizeBase64Json()
+    {
+        // 构造一个超过 MaxBase64Length 的字符串（内容无所谓，长度用 'A' 填充）。
+        // MaxBase64Length 来自 16MB 压缩上限，约 22.4MB Base64 字符。
+        const int oversize = 25 * 1024 * 1024;
+        var sb = new StringBuilder(oversize + 2);
+        sb.Append('"');
+        sb.Append('A', oversize);
+        sb.Append('"');
+        return sb.ToString();
     }
 
     #endregion


### PR DESCRIPTION
…loads

- Replace ambiguous 1-byte compression marker with 5-byte magic (0xFE 'L' 'Y' 'Z' <algo>) to avoid collision with legacy headerless payloads and BinaryPayloadHeader marker.
- Fix int overflow in Decode initial capacity (payload.Length * 4); use fixed small initial capacity instead of attacker-controlled hint.
- Add MaxCompressedBytes (16MB) entry guard and decode iteration cap.
- Add MaxBase64Length guard in RecordSet/RecordTable JsonConverters to reject oversize JSON strings before allocation (OOM defense).
- Add tests: legacy passthrough, invalid gzip, zip bomb, oversize Base64.