### PR TITLE
RecordRow对象映射增强：XCopy支持运行时类型

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -154,7 +154,8 @@ XCopy<MyClass>.CopyFrom(obj, row);
 
 **规则：**
 - 仅处理类型受支持（见 `Helpers.IsSupportedForReading` / `IsSupportedForWriting`）的公共实例属性
-- 列不存在时静默跳过，**不自动建列**
+- `CopyTo` / `CopyFrom` 在列不存在时静默跳过，**不自动建列**
+- `WriteTo` 在目标列不存在时会自动创建列并写入
 - `data` 为 `null` 时抛 `ArgumentNullException`
 
 ---

--- a/docs/Record.md
+++ b/docs/Record.md
@@ -1,0 +1,194 @@
+# Record 体系文档
+
+## 概述
+
+Record 体系是一套**列存储**的轻量数据容器，位于 `LuYao.Data` 命名空间。其核心组件为：
+
+| 类型 | 说明 |
+|---|---|
+| `RecordTable` | 列存储数据表，持有列集合与行数据 |
+| `RecordRow` | 对某一行的引用（`struct`），通过列索引访问数据 |
+| `RecordColumn` / `RecordColumn<T>` | 单列定义，携带类型信息与读写能力 |
+| `RecordColumnCollection` | 列集合，维护列名到列对象的映射 |
+| `RecordSet` | 命名 `RecordTable` 集合，以表名为键 |
+
+---
+
+## 核心类型
+
+### RecordTable
+
+列存储数据表，实现 `IEnumerable<RecordRow>`。
+
+```csharp
+var table = new RecordTable("Orders");
+table.Columns.Add<int>("Id");
+table.Columns.Add<string>("Name");
+
+var row = table.AddRow();
+table.Columns.Get("Id").Set(row, 1);
+```
+
+**从对象创建：**
+
+```csharp
+var table = RecordTable.From(myObj);               // 单对象，推断列结构
+var table = RecordTable.FromList(myList);           // 集合，推断列结构
+```
+
+**转换回对象：**
+
+```csharp
+var obj  = table.To<MyClass>();                    // 取第一行
+var list = table.ToList<MyClass>();                // 全部行
+var dict = table.ToDictionary<int, MyClass>();     // 以第一列为键
+```
+
+---
+
+### RecordRow
+
+`struct`，是对 `RecordTable` 中某一行的轻量引用，不独立持有数据。
+
+```csharp
+RecordRow row = table[0];
+
+// 动态访问（支持 dynamic）
+dynamic d = row;
+string name = d.Name;
+
+// 与对象互转
+row.CopyTo(myObj);          // 行 → 对象（填充已有实例）
+var obj = row.To<MyClass>(); // 行 → 对象（新建实例）
+row.CopyFrom(myObj);         // 对象 → 行
+```
+
+---
+
+### RecordColumn / RecordColumnCollection
+
+`RecordColumn` 持有列名、列类型及对行数据的读写能力。
+
+```csharp
+var col = table.Columns.Add<int>("Age");   // 同名同类型幂等，同名不同类型抛异常
+var col = table.Columns.Find("Age");       // 不存在返回 null
+var col = table.Columns.Get("Age");        // 不存在抛 KeyNotFoundException
+
+col.Set(row, 18);
+var val = col.Get(row);
+```
+
+支持从对象类型批量推断列：
+
+```csharp
+table.Columns.AddFrom<MyClass>();          // 按属性批量建列
+```
+
+---
+
+### RecordSet
+
+命名 `RecordTable` 的容器，以 `RecordTable.Name` 为键，默认大小写敏感。
+
+```csharp
+var set = new RecordSet();
+set.Add(table);
+var t = set["Orders"];
+set.Remove("Orders");
+```
+
+---
+
+## Meta 工具层
+
+位于 `LuYao.Data.Meta` 命名空间，为 Record 体系提供反射加速与对象映射支持。
+
+### XProp
+
+封装单个公共实例属性，通过编译委托（`Expression.Lambda`）实现接近直接调用性能的读写访问。属性列表按类型缓存，全局唯一。
+
+```csharp
+var props = XProp.GetAll(typeof(MyClass));
+foreach (var p in props)
+{
+    object? val = p.GetValue(obj);
+    p.SetValue(obj, val);
+}
+```
+
+---
+
+### XData\<T\>
+
+按属性名对强类型对象进行读写，底层使用 `XProp`。
+
+```csharp
+XData<MyClass>.Set(obj, "Name", "Alice");
+var val = XData<MyClass>.Get(obj, "Name");
+```
+
+> 属性名不存在时抛 `ArgumentException`，属性不可读/写时抛 `InvalidOperationException`。
+
+---
+
+### XCopy
+
+在**对象**与 **`RecordRow`** 之间进行属性双向复制的核心工具类。
+
+以运行时实际类型（`data.GetType()`）为缓存键，**天然支持派生类**——无论对象声明类型是基类还是派生类，派生类新增的属性均能被正确处理。
+
+```csharp
+// 非泛型版本（推荐直接使用，无需指定类型参数）
+XCopy.CopyTo(obj, row);    // 对象 → 行
+XCopy.CopyFrom(obj, row);  // 行 → 对象
+```
+
+**泛型薄封装（`XCopy<T>`）** 提供编译期类型约束，逻辑完全委托给非泛型 `XCopy`：
+
+```csharp
+XCopy<MyClass>.CopyTo(obj, row);
+XCopy<MyClass>.CopyFrom(obj, row);
+```
+
+两者使用**全局唯一**的 `ConcurrentDictionary<Type, IReadOnlyList<XProp>>` 缓存，不同泛型闭合类型（`XCopy<Base>`、`XCopy<Derived>`）共享同一份缓存，不会重复构建。
+
+**规则：**
+- 仅处理类型受支持（见 `Helpers.IsSupportedForReading` / `IsSupportedForWriting`）的公共实例属性
+- 列不存在时静默跳过，**不自动建列**
+- `data` 为 `null` 时抛 `ArgumentNullException`
+
+---
+
+### XCopy\<TSource, TTarget\>
+
+在两个强类型对象之间按属性名进行浅拷贝。仅映射同名、类型完全一致且均受支持的可读/可写属性对。映射关系在首次访问时按 `(TSource, TTarget)` 组合构建并缓存。
+
+```csharp
+// 新建目标实例并填充
+TargetDto dto = XCopy<MyClass, TargetDto>.Copy(source);
+
+// 填充已有实例
+XCopy<MyClass, TargetDto>.CopyTo(source, target);
+```
+
+---
+
+## 序列化
+
+### JSON
+
+通过 `System.Text.Json` 的自定义转换器支持，分别注册 `RecordTableJsonConverter` 和 `RecordSetJsonConverter`。
+
+### 二进制
+
+通过 `RecordBinaryPayloadCodec` 提供高效的二进制序列化/反序列化，支持压缩（`RecordPayloadCompression`）。
+
+```csharp
+// RecordTable
+var bytes = RecordTable.ToBinary(table);
+var table = RecordTable.FromBinary(bytes);
+
+// RecordSet
+var bytes = RecordSet.ToBinary(set);
+var set   = RecordSet.FromBinary(bytes);
+```

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -1,72 +1,133 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace LuYao.Data.Meta;
 
 /// <summary>
+/// 提供在对象与 <see cref="RecordRow"/> 之间进行属性双向复制的静态工具类。
+/// 以运行时实际类型为键缓存属性列表，天然支持派生类的新增属性。
+/// </summary>
+public static class XCopy
+{
+    private static readonly ConcurrentDictionary<Type, IReadOnlyList<XProp>> _readableCache
+        = new ConcurrentDictionary<Type, IReadOnlyList<XProp>>();
+    private static readonly ConcurrentDictionary<Type, IReadOnlyList<XProp>> _writableCache
+        = new ConcurrentDictionary<Type, IReadOnlyList<XProp>>();
+
+    internal static IReadOnlyList<XProp> GetReadableProps(Type runtimeType)
+        => _readableCache.GetOrAdd(runtimeType, t =>
+        {
+            var all = XProp.GetAll(t);
+            var list = new List<XProp>(all.Count);
+            foreach (var p in all)
+            {
+                if (Helpers.IsSupportedForReading(p)) list.Add(p);
+            }
+            return list.AsReadOnly();
+        });
+
+    internal static IReadOnlyList<XProp> GetWritableProps(Type runtimeType)
+        => _writableCache.GetOrAdd(runtimeType, t =>
+        {
+            var all = XProp.GetAll(t);
+            var list = new List<XProp>(all.Count);
+            foreach (var p in all)
+            {
+                if (Helpers.IsSupportedForWriting(p)) list.Add(p);
+            }
+            return list.AsReadOnly();
+        });
+
+    #region RecordRow
+    /// <summary>
+    /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 使用运行时实际类型扫描属性，派生类新增属性会被正确处理。
+    /// </summary>
+    /// <param name="data">数据来源对象，不可为 null。</param>
+    /// <param name="target">目标行；若列不存在则静默跳过，<b>不会自动建列</b>。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void CopyTo(object data, RecordRow target)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        var cols = target.Table.Columns;
+        foreach (var prop in GetReadableProps(data.GetType()))
+        {
+            var col = cols.Find(prop.Name);
+            if (col == null) continue;
+            col.Set(target, prop.GetValue(data));
+        }
+    }
+
+    /// <summary>
+    /// 将 <paramref name="source"/> 中与对象属性同名的列值写回对象 <paramref name="data"/>。
+    /// 使用运行时实际类型扫描属性，派生类新增属性会被正确处理。
+    /// </summary>
+    /// <param name="data">目标对象，不可为 null。</param>
+    /// <param name="source">数据来源行。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void CopyFrom(object data, RecordRow source)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        var cols = source.Table.Columns;
+        foreach (var prop in GetWritableProps(data.GetType()))
+        {
+            var col = cols.Find(prop.Name);
+            if (col == null) continue;
+            prop.SetValue(data, col.Get(source));
+        }
+    }
+
+    /// <summary>
+    /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 若目标行所在表中不存在对应列，则<b>自动创建列</b>后再写入。
+    /// 使用运行时实际类型扫描属性，派生类新增属性会被正确处理。
+    /// </summary>
+    /// <param name="data">数据来源对象，不可为 null。</param>
+    /// <param name="target">目标行。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void WriteTo(object data, RecordRow target)
+    {
+        if (data == null) throw new ArgumentNullException(nameof(data));
+        var cols = target.Table.Columns;
+        foreach (var prop in GetReadableProps(data.GetType()))
+        {
+            var col = cols.Find(prop.Name) ?? cols.Add(prop.Name, prop.Type);
+            col.Set(target, prop.GetValue(data));
+        }
+    }
+    #endregion
+}
+
+/// <summary>
 /// 提供在强类型对象与 <see cref="RecordRow"/> 之间进行属性双向复制的静态工具类。
+/// 为 <see cref="XCopy"/> 的泛型薄封装，提供编译期类型约束，逻辑委托给 <see cref="XCopy"/>。
 /// </summary>
 /// <typeparam name="T">要映射的对象类型，必须为引用类型。</typeparam>
 public static class XCopy<T> where T : class
 {
-    // 预先过滤，避免每次调用重复遍历和判断
-    private static readonly IReadOnlyList<XProp> _readableProps = BuildReadableProps();
-    private static readonly IReadOnlyList<XProp> _writableProps = BuildWritableProps();
-
-    private static IReadOnlyList<XProp> BuildReadableProps()
-    {
-        var all = XProp.GetAll(typeof(T));
-        var list = new List<XProp>(all.Count);
-        foreach (var p in all)
-        {
-            if (Helpers.IsSupportedForReading(p)) list.Add(p);
-        }
-        return list.AsReadOnly();
-    }
-
-    private static IReadOnlyList<XProp> BuildWritableProps()
-    {
-        var all = XProp.GetAll(typeof(T));
-        var list = new List<XProp>(all.Count);
-        foreach (var p in all)
-        {
-            if (Helpers.IsSupportedForWriting(p)) list.Add(p);
-        }
-        return list.AsReadOnly();
-    }
-
     #region RecordRow
     /// <summary>
-    /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="row"/> 对应的列。
+    /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
     /// </summary>
     /// <param name="data">数据来源对象。</param>
-    /// <param name="row">目标行；仅写入类型受支持的可读属性。Mapping 路径下若列不存在则静默跳过，<b>不会自动建列</b>。</param>
-    public static void CopyTo(T data, RecordRow row)
-    {
-        var cols = row.Table.Columns;
-        foreach (var prop in _readableProps)
-        {
-            var col = cols.Find(prop.Name);
-            if (col == null) continue;
-            col.Set(row, prop.GetValue(data));
-        }
-    }
+    /// <param name="target">目标行；若列不存在则静默跳过，<b>不会自动建列</b>。</param>
+    public static void CopyTo(T data, RecordRow target) => XCopy.CopyTo(data, target);
 
     /// <summary>
-    /// 将 <paramref name="row"/> 中与对象属性同名的列值写回对象 <paramref name="data"/>。
+    /// 将 <paramref name="source"/> 中与对象属性同名的列值写回对象 <paramref name="data"/>。
     /// </summary>
-    /// <param name="data">目标对象；仅更新类型受支持且行中存在对应列的可写属性。</param>
-    /// <param name="row">数据来源行。</param>
-    public static void CopyFrom(T data, RecordRow row)
-    {
-        var cols = row.Table.Columns;
-        foreach (var prop in _writableProps)
-        {
-            var col = cols.Find(prop.Name);
-            if (col == null) continue;
-            prop.SetValue(data, col.Get(row));
-        }
-    }
+    /// <param name="data">目标对象。</param>
+    /// <param name="source">数据来源行。</param>
+    public static void CopyFrom(T data, RecordRow source) => XCopy.CopyFrom(data, source);
+
+    /// <summary>
+    /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 若目标行所在表中不存在对应列，则<b>自动创建列</b>后再写入。
+    /// </summary>
+    /// <param name="data">数据来源对象。</param>
+    /// <param name="target">目标行。</param>
+    public static void WriteTo(T data, RecordRow target) => XCopy.WriteTo(data, target);
     #endregion
 }
 

--- a/src/LuYao.Common/Data/RecordRow/Mapping.cs
+++ b/src/LuYao.Common/Data/RecordRow/Mapping.cs
@@ -6,6 +6,17 @@ partial struct RecordRow
 {
     /// <summary>
     /// 将当前行的列值填充到已有对象 <paramref name="data"/> 的对应属性中。
+    /// 使用运行时实际类型，派生类新增属性会被正确处理。
+    /// </summary>
+    /// <param name="data">要被填充的对象实例，不可为 null。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="data"/> 为 null 时抛出。</exception>
+    public void CopyTo(object data)
+    {
+        XCopy.CopyFrom(data, this);
+    }
+
+    /// <summary>
+    /// 将当前行的列值填充到已有对象 <paramref name="data"/> 的对应属性中。
     /// </summary>
     /// <typeparam name="T">目标对象类型。</typeparam>
     /// <param name="data">要被填充的对象实例。</param>

--- a/tests/LuYao.Common.UnitTests/Data/Meta/XCopyTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/Meta/XCopyTests.cs
@@ -1,0 +1,297 @@
+using LuYao.Data;
+using LuYao.Data.Meta;
+
+namespace LuYao.Data.Meta
+{
+    [TestClass]
+    public class XCopyTests
+    {
+        #region 测试用类型
+
+        private class Base
+        {
+            public int Id { get; set; }
+            public string? Name { get; set; }
+            // 不支持的类型，应被跳过
+            public object? Ignored { get; set; }
+        }
+
+        private class Derived : Base
+        {
+            public double Score { get; set; }
+        }
+
+        private static RecordTable BuildTable()
+        {
+            var t = new RecordTable();
+            t.Columns.Add<int>("Id");
+            t.Columns.Add<string>("Name");
+            t.Columns.Add<double>("Score");
+            return t;
+        }
+
+        #endregion
+
+        // ── CopyTo ──────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CopyTo_Base_WritesBaseProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            var obj = new Base { Id = 1, Name = "Alice" };
+
+            XCopy.CopyTo(obj, row);
+
+            Assert.AreEqual(1, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Alice", table.Columns.Get("Name").Get(row));
+        }
+
+        [TestMethod]
+        public void CopyTo_Derived_WritesBaseAndDerivedProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 2, Name = "Bob", Score = 9.5 };
+
+            XCopy.CopyTo(obj, row);
+
+            Assert.AreEqual(2, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Bob", table.Columns.Get("Name").Get(row));
+            Assert.AreEqual(9.5, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void CopyTo_DerivedViaBaseRef_WritesDerivedProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            Base obj = new Derived { Id = 3, Name = "Carol", Score = 8.0 };
+
+            // 以基类引用传入，运行时类型仍是 Derived
+            XCopy.CopyTo(obj, row);
+
+            Assert.AreEqual(3, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual(8.0, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void CopyTo_MissingColumn_SilentlySkips()
+        {
+            var table = new RecordTable();
+            table.Columns.Add<int>("Id");
+            var row = table.AddRow();
+            var obj = new Base { Id = 7, Name = "X" };
+
+            // Name 列不存在，不应抛异常
+            XCopy.CopyTo(obj, row);
+
+            Assert.AreEqual(7, table.Columns.Get("Id").Get(row));
+        }
+
+        [TestMethod]
+        public void CopyTo_NullData_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try
+            {
+                XCopy.CopyTo(null!, row);
+                Assert.Fail("Expected ArgumentNullException");
+            }
+            catch (ArgumentNullException) { }
+        }
+
+        // ── CopyFrom ─────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CopyFrom_Base_ReadsBaseProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 10);
+            table.Columns.Get("Name").Set(row, "Dave");
+
+            var obj = new Base();
+            XCopy.CopyFrom(obj, row);
+
+            Assert.AreEqual(10, obj.Id);
+            Assert.AreEqual("Dave", obj.Name);
+        }
+
+        [TestMethod]
+        public void CopyFrom_Derived_ReadsBaseAndDerivedProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 20);
+            table.Columns.Get("Name").Set(row, "Eve");
+            table.Columns.Get("Score").Set(row, 7.5);
+
+            var obj = new Derived();
+            XCopy.CopyFrom(obj, row);
+
+            Assert.AreEqual(20, obj.Id);
+            Assert.AreEqual("Eve", obj.Name);
+            Assert.AreEqual(7.5, obj.Score);
+        }
+
+        [TestMethod]
+        public void CopyFrom_DerivedViaBaseRef_SetsDerivedProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 30);
+            table.Columns.Get("Score").Set(row, 6.0);
+
+            Base obj = new Derived();
+            XCopy.CopyFrom(obj, row);
+
+            Assert.AreEqual(30, ((Derived)obj).Id);
+            Assert.AreEqual(6.0, ((Derived)obj).Score);
+        }
+
+        [TestMethod]
+        public void CopyFrom_NullData_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try
+            {
+                XCopy.CopyFrom(null!, row);
+                Assert.Fail("Expected ArgumentNullException");
+            }
+            catch (ArgumentNullException) { }
+        }
+
+        // ── XCopy<T> 薄封装 ──────────────────────────────────────────────────
+
+        [TestMethod]
+        public void Generic_CopyTo_DelegatesToNonGeneric()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 5, Name = "Frank", Score = 3.14 };
+
+            XCopy<Base>.CopyTo(obj, row);
+
+            Assert.AreEqual(5, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual(3.14, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void Generic_CopyFrom_DelegatesToNonGeneric()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 99);
+            table.Columns.Get("Score").Set(row, 1.23);
+
+            var obj = new Derived();
+            XCopy<Base>.CopyFrom(obj, row);
+
+            Assert.AreEqual(99, obj.Id);
+            Assert.AreEqual(1.23, obj.Score);
+        }
+
+        // ── WriteTo ──────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void WriteTo_Base_CreatesColumnsAndWritesValues()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            var obj = new Base { Id = 1, Name = "Alice" };
+
+            XCopy.WriteTo(obj, row);
+
+            Assert.AreEqual(1, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Alice", table.Columns.Get("Name").Get(row));
+        }
+
+        [TestMethod]
+        public void WriteTo_Derived_CreatesAllColumnsIncludingDerivedProps()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 2, Name = "Bob", Score = 9.5 };
+
+            XCopy.WriteTo(obj, row);
+
+            Assert.AreEqual(2, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Bob", table.Columns.Get("Name").Get(row));
+            Assert.AreEqual(9.5, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void WriteTo_DerivedViaBaseRef_CreatesDerivedColumns()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            Base obj = new Derived { Id = 3, Name = "Carol", Score = 8.0 };
+
+            XCopy.WriteTo(obj, row);
+
+            // Score 列应被自动创建
+            Assert.IsNotNull(table.Columns.Find("Score"));
+            Assert.AreEqual(8.0, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void WriteTo_ExistingColumns_OverwritesValues()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 99);
+
+            var obj = new Base { Id = 42, Name = "New" };
+            XCopy.WriteTo(obj, row);
+
+            Assert.AreEqual(42, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("New", table.Columns.Get("Name").Get(row));
+        }
+
+        [TestMethod]
+        public void WriteTo_UnsupportedTypeProperty_IsSkipped()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            var obj = new Base { Id = 5, Name = "Eve", Ignored = new object() };
+
+            // Ignored 属性类型 object 不受支持，不应建列也不应抛异常
+            XCopy.WriteTo(obj, row);
+
+            Assert.IsNull(table.Columns.Find("Ignored"));
+            Assert.AreEqual(5, table.Columns.Get("Id").Get(row));
+        }
+
+        [TestMethod]
+        public void WriteTo_NullData_ThrowsArgumentNullException()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+
+            try
+            {
+                XCopy.WriteTo(null!, row);
+                Assert.Fail("Expected ArgumentNullException");
+            }
+            catch (ArgumentNullException) { }
+        }
+
+        [TestMethod]
+        public void Generic_WriteTo_DelegatesToNonGeneric()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 7, Name = "Frank", Score = 3.14 };
+
+            XCopy<Base>.WriteTo(obj, row);
+
+            Assert.IsNotNull(table.Columns.Find("Score"));
+            Assert.AreEqual(3.14, table.Columns.Get("Score").Get(row));
+        }
+    }
+}

--- a/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordRowSemanticsTests.cs
@@ -106,6 +106,83 @@ public class RecordRowSemanticsTests
         Assert.AreEqual(7, table[0].To<int>("Id"));
     }
 
+    // ── CopyTo(object) 非泛型重载 ────────────────────────────────────────────
+
+    private class CopyToBase
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    private class CopyToDerived : CopyToBase
+    {
+        public double Score { get; set; }
+    }
+
+    [TestMethod]
+    public void CopyTo_NonGeneric_FillsBaseProps()
+    {
+        var table = new RecordTable();
+        table.Columns.Add<int>("Id");
+        table.Columns.Add<string>("Name");
+        var row = table.AddRow();
+        table.Columns.Get("Id").Set(row, 10);
+        table.Columns.Get("Name").Set(row, "Alice");
+
+        var obj = new CopyToBase();
+        row.CopyTo((object)obj);
+
+        Assert.AreEqual(10, obj.Id);
+        Assert.AreEqual("Alice", obj.Name);
+    }
+
+    [TestMethod]
+    public void CopyTo_NonGeneric_FillsDerivedPropsViaBaseRef()
+    {
+        var table = new RecordTable();
+        table.Columns.Add<int>("Id");
+        table.Columns.Add<double>("Score");
+        var row = table.AddRow();
+        table.Columns.Get("Id").Set(row, 20);
+        table.Columns.Get("Score").Set(row, 9.9);
+
+        // 以基类引用持有派生类实例，运行时类型应被正确识别
+        CopyToBase obj = new CopyToDerived();
+        row.CopyTo((object)obj);
+
+        Assert.AreEqual(20, obj.Id);
+        Assert.AreEqual(9.9, ((CopyToDerived)obj).Score);
+    }
+
+    [TestMethod]
+    public void CopyTo_NonGeneric_MissingColumn_SilentlySkips()
+    {
+        var table = new RecordTable();
+        table.Columns.Add<int>("Id");
+        var row = table.AddRow();
+        table.Columns.Get("Id").Set(row, 5);
+
+        var obj = new CopyToBase { Name = "original" };
+        row.CopyTo((object)obj);
+
+        Assert.AreEqual(5, obj.Id);
+        Assert.AreEqual("original", obj.Name); // Name 列不存在，保持原值
+    }
+
+    [TestMethod]
+    public void CopyTo_NonGeneric_NullData_ThrowsArgumentNullException()
+    {
+        var table = new RecordTable();
+        var row = table.AddRow();
+
+        try
+        {
+            row.CopyTo((object)null!);
+            Assert.Fail("Expected ArgumentNullException");
+        }
+        catch (ArgumentNullException) { }
+    }
+
     [TestMethod]
     public void Mapping_CopyFromObject_DoesNotAutoCreateColumns()
     {


### PR DESCRIPTION
重构XCopy为非泛型静态类，支持object参数并按运行时类型缓存属性，自动处理派生类属性。新增CopyTo/CopyFrom/WriteTo非泛型重载，RecordRow支持CopyTo(object)。保留XCopy<T>薄封装。完善单元测试，文档同步更新。