### PR TITLE
支持 XCopy 基于声明类型的属性拷贝重载

### DIFF
--- a/docs/Record.md
+++ b/docs/Record.md
@@ -135,28 +135,34 @@ var val = XData<MyClass>.Get(obj, "Name");
 
 在**对象**与 **`RecordRow`** 之间进行属性双向复制的核心工具类。
 
-以运行时实际类型（`data.GetType()`）为缓存键，**天然支持派生类**——无论对象声明类型是基类还是派生类，派生类新增的属性均能被正确处理。
+默认重载按运行时实际类型（`data.GetType()`）扫描属性，派生类新增属性会被一并处理；显式 `Type` 重载按指定声明类型扫描属性，可只处理基类属性。
 
 ```csharp
-// 非泛型版本（推荐直接使用，无需指定类型参数）
+// 非泛型版本：默认按运行时类型扫描
 XCopy.CopyTo(obj, row);    // 对象 → 行
 XCopy.CopyFrom(obj, row);  // 行 → 对象
+
+// 显式指定属性扫描类型
+XCopy.CopyTo(typeof(Base), obj, row);
+XCopy.CopyFrom(typeof(Base), obj, row);
+XCopy.WriteTo(typeof(Base), obj, row);
 ```
 
-**泛型薄封装（`XCopy<T>`）** 提供编译期类型约束，逻辑完全委托给非泛型 `XCopy`：
+**泛型薄封装（`XCopy<T>`）** 固定按编译期类型 `typeof(T)` 扫描属性；当传入派生类实例时，仅处理 `T` 声明的属性：
 
 ```csharp
 XCopy<MyClass>.CopyTo(obj, row);
 XCopy<MyClass>.CopyFrom(obj, row);
 ```
 
-两者使用**全局唯一**的 `ConcurrentDictionary<Type, IReadOnlyList<XProp>>` 缓存，不同泛型闭合类型（`XCopy<Base>`、`XCopy<Derived>`）共享同一份缓存，不会重复构建。
+相关重载共享按扫描类型缓存的 `ConcurrentDictionary<Type, IReadOnlyList<XProp>>`，同一类型的属性列表只构建一次。
 
 **规则：**
 - 仅处理类型受支持（见 `Helpers.IsSupportedForReading` / `IsSupportedForWriting`）的公共实例属性
 - `CopyTo` / `CopyFrom` 在列不存在时静默跳过，**不自动建列**
 - `WriteTo` 在目标列不存在时会自动创建列并写入
-- `data` 为 `null` 时抛 `ArgumentNullException`
+- 显式 `Type` 重载在 `type` 或 `data` 为 `null` 时抛 `ArgumentNullException`
+- 泛型 `XCopy<T>` 等价于调用对应的 `XCopy.CopyTo(typeof(T), ...)` / `CopyFrom(typeof(T), ...)` / `WriteTo(typeof(T), ...)`
 
 ---
 

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -50,8 +50,24 @@ public static class XCopy
     public static void CopyTo(object data, RecordRow target)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
+        CopyTo(data.GetType(), data, target);
+    }
+
+    /// <summary>
+    /// 将 <paramref name="data"/> 中由 <paramref name="type"/> 指定类型的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 适用于需要按声明类型（而非运行时类型）扫描属性的场景。
+    /// 若目标行所在表中不存在对应列，则静默跳过，<b>不会自动建列</b>。
+    /// </summary>
+    /// <param name="type">用于扫描属性的声明类型，不可为 null。</param>
+    /// <param name="data">数据来源对象，不可为 null。</param>
+    /// <param name="target">目标行。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="type"/> 或 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void CopyTo(Type type, object data, RecordRow target)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        if (data == null) throw new ArgumentNullException(nameof(data));
         var cols = target.Table.Columns;
-        foreach (var prop in GetReadableProps(data.GetType()))
+        foreach (var prop in GetReadableProps(type))
         {
             var col = cols.Find(prop.Name);
             if (col == null) continue;
@@ -69,8 +85,22 @@ public static class XCopy
     public static void CopyFrom(object data, RecordRow source)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
+        CopyFrom(data.GetType(), data, source);
+    }
+    /// <summary>
+    /// 将 <paramref name="source"/> 中与由 <paramref name="type"/> 指定类型属性同名的列值写回对象 <paramref name="data"/>。
+    /// 适用于需要按声明类型（而非运行时类型）扫描属性的场景。
+    /// </summary>
+    /// <param name="type">用于扫描属性的声明类型，不可为 null。</param>
+    /// <param name="data">目标对象，不可为 null。</param>
+    /// <param name="source">数据来源行。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="type"/> 或 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void CopyFrom(Type type, object data, RecordRow source)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        if (data == null) throw new ArgumentNullException(nameof(data));
         var cols = source.Table.Columns;
-        foreach (var prop in GetWritableProps(data.GetType()))
+        foreach (var prop in GetWritableProps(type))
         {
             var col = cols.Find(prop.Name);
             if (col == null) continue;
@@ -89,8 +119,23 @@ public static class XCopy
     public static void WriteTo(object data, RecordRow target)
     {
         if (data == null) throw new ArgumentNullException(nameof(data));
+        WriteTo(data.GetType(), data, target);
+    }
+    /// <summary>
+    /// 将 <paramref name="data"/> 中由 <paramref name="type"/> 指定类型的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 若目标行所在表中不存在对应列，则<b>自动创建列</b>后再写入。
+    /// 适用于需要按声明类型（而非运行时类型）扫描属性的场景。
+    /// </summary>
+    /// <param name="type">用于扫描属性的声明类型，不可为 null。</param>
+    /// <param name="data">数据来源对象，不可为 null。</param>
+    /// <param name="target">目标行。</param>
+    /// <exception cref="ArgumentNullException">当 <paramref name="type"/> 或 <paramref name="data"/> 为 null 时抛出。</exception>
+    public static void WriteTo(Type type, object data, RecordRow target)
+    {
+        if (type == null) throw new ArgumentNullException(nameof(type));
+        if (data == null) throw new ArgumentNullException(nameof(data));
         var cols = target.Table.Columns;
-        foreach (var prop in GetReadableProps(data.GetType()))
+        foreach (var prop in GetReadableProps(type))
         {
             var col = cols.Find(prop.Name) ?? cols.Add(prop.Name, prop.Type);
             col.Set(target, prop.GetValue(data));
@@ -112,14 +157,14 @@ public static class XCopy<T> where T : class
     /// </summary>
     /// <param name="data">数据来源对象。</param>
     /// <param name="target">目标行；若列不存在则静默跳过，<b>不会自动建列</b>。</param>
-    public static void CopyTo(T data, RecordRow target) => XCopy.CopyTo(data, target);
+    public static void CopyTo(T data, RecordRow target) => XCopy.CopyTo(typeof(T), data, target);
 
     /// <summary>
     /// 将 <paramref name="source"/> 中与对象属性同名的列值写回对象 <paramref name="data"/>。
     /// </summary>
     /// <param name="data">目标对象。</param>
     /// <param name="source">数据来源行。</param>
-    public static void CopyFrom(T data, RecordRow source) => XCopy.CopyFrom(data, source);
+    public static void CopyFrom(T data, RecordRow source) => XCopy.CopyFrom(typeof(T), data, source);
 
     /// <summary>
     /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
@@ -127,7 +172,7 @@ public static class XCopy<T> where T : class
     /// </summary>
     /// <param name="data">数据来源对象。</param>
     /// <param name="target">目标行。</param>
-    public static void WriteTo(T data, RecordRow target) => XCopy.WriteTo(data, target);
+    public static void WriteTo(T data, RecordRow target) => XCopy.WriteTo(typeof(T), data, target);
     #endregion
 }
 

--- a/src/LuYao.Common/Data/Meta/XCopy.cs
+++ b/src/LuYao.Common/Data/Meta/XCopy.cs
@@ -146,7 +146,8 @@ public static class XCopy
 
 /// <summary>
 /// 提供在强类型对象与 <see cref="RecordRow"/> 之间进行属性双向复制的静态工具类。
-/// 为 <see cref="XCopy"/> 的泛型薄封装，提供编译期类型约束，逻辑委托给 <see cref="XCopy"/>。
+/// 为 <see cref="XCopy"/> 的泛型薄封装，固定按编译期类型 <typeparamref name="T"/> 扫描属性，
+/// 逻辑委托给 <see cref="XCopy"/> 的显式 <see cref="Type"/> 重载。
 /// </summary>
 /// <typeparam name="T">要映射的对象类型，必须为引用类型。</typeparam>
 public static class XCopy<T> where T : class
@@ -154,6 +155,8 @@ public static class XCopy<T> where T : class
     #region RecordRow
     /// <summary>
     /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
+    /// 固定按编译期类型 <typeparamref name="T"/> 扫描属性，
+    /// 即使 <paramref name="data"/> 的运行时类型为派生类，也不会处理派生类新增属性。
     /// </summary>
     /// <param name="data">数据来源对象。</param>
     /// <param name="target">目标行；若列不存在则静默跳过，<b>不会自动建列</b>。</param>
@@ -161,6 +164,8 @@ public static class XCopy<T> where T : class
 
     /// <summary>
     /// 将 <paramref name="source"/> 中与对象属性同名的列值写回对象 <paramref name="data"/>。
+    /// 固定按编译期类型 <typeparamref name="T"/> 扫描属性，
+    /// 即使 <paramref name="data"/> 的运行时类型为派生类，也不会处理派生类新增属性。
     /// </summary>
     /// <param name="data">目标对象。</param>
     /// <param name="source">数据来源行。</param>
@@ -169,6 +174,8 @@ public static class XCopy<T> where T : class
     /// <summary>
     /// 将对象 <paramref name="data"/> 的可读属性值写入 <paramref name="target"/> 对应的列。
     /// 若目标行所在表中不存在对应列，则<b>自动创建列</b>后再写入。
+    /// 固定按编译期类型 <typeparamref name="T"/> 扫描属性，
+    /// 即使 <paramref name="data"/> 的运行时类型为派生类，也不会处理派生类新增属性。
     /// </summary>
     /// <param name="data">数据来源对象。</param>
     /// <param name="target">目标行。</param>

--- a/tests/LuYao.Common.UnitTests/Data/Meta/XCopyTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/Meta/XCopyTests.cs
@@ -175,10 +175,13 @@ namespace LuYao.Data.Meta
             var row = table.AddRow();
             var obj = new Derived { Id = 5, Name = "Frank", Score = 3.14 };
 
+            // XCopy<Base> 使用编译期类型 typeof(Base)，仅复制 Base 的属性
             XCopy<Base>.CopyTo(obj, row);
 
             Assert.AreEqual(5, table.Columns.Get("Id").Get(row));
-            Assert.AreEqual(3.14, table.Columns.Get("Score").Get(row));
+            Assert.AreEqual("Frank", table.Columns.Get("Name").Get(row));
+            // Score 属于 Derived，不在 typeof(Base) 范围内，保持默认值
+            Assert.AreEqual(0.0, table.Columns.Get("Score").Get(row));
         }
 
         [TestMethod]
@@ -190,10 +193,12 @@ namespace LuYao.Data.Meta
             table.Columns.Get("Score").Set(row, 1.23);
 
             var obj = new Derived();
+            // XCopy<Base> 使用编译期类型 typeof(Base)，仅写回 Base 的属性
             XCopy<Base>.CopyFrom(obj, row);
 
             Assert.AreEqual(99, obj.Id);
-            Assert.AreEqual(1.23, obj.Score);
+            // Score 属于 Derived，不在 typeof(Base) 范围内，保持默认值
+            Assert.AreEqual(0.0, obj.Score);
         }
 
         // ── WriteTo ──────────────────────────────────────────────────────────
@@ -288,10 +293,144 @@ namespace LuYao.Data.Meta
             var row = table.AddRow();
             var obj = new Derived { Id = 7, Name = "Frank", Score = 3.14 };
 
+            // XCopy<Base> 使用编译期类型 typeof(Base)，仅创建 Base 的属性列
             XCopy<Base>.WriteTo(obj, row);
 
-            Assert.IsNotNull(table.Columns.Find("Score"));
-            Assert.AreEqual(3.14, table.Columns.Get("Score").Get(row));
+            Assert.AreEqual(7, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Frank", table.Columns.Get("Name").Get(row));
+            // Score 属于 Derived，不在 typeof(Base) 范围内，不应创建该列
+            Assert.IsNull(table.Columns.Find("Score"));
+        }
+
+        // ── CopyTo(Type, ...) 显式类型重载 ───────────────────────────────────
+
+        [TestMethod]
+        public void CopyTo_ExplicitBaseType_OnlyWritesBaseProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 10, Name = "Grace", Score = 5.0 };
+
+            // 显式指定 Base 类型，Score 属性不应被写入
+            XCopy.CopyTo(typeof(Base), obj, row);
+
+            Assert.AreEqual(10, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Grace", table.Columns.Get("Name").Get(row));
+            Assert.AreEqual(0.0, table.Columns.Get("Score").Get(row));
+        }
+
+        [TestMethod]
+        public void CopyTo_NullType_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try { XCopy.CopyTo(null!, new Base(), row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        [TestMethod]
+        public void CopyTo_ExplicitType_NullData_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try { XCopy.CopyTo(typeof(Base), null!, row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        // ── CopyFrom(Type, ...) 显式类型重载 ─────────────────────────────────
+
+        [TestMethod]
+        public void CopyFrom_ExplicitBaseType_OnlyReadsBaseProps()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+            table.Columns.Get("Id").Set(row, 20);
+            table.Columns.Get("Name").Set(row, "Hank");
+            table.Columns.Get("Score").Set(row, 4.5);
+
+            var obj = new Derived();
+            // 显式指定 Base 类型，Score 属性不应被写回
+            XCopy.CopyFrom(typeof(Base), obj, row);
+
+            Assert.AreEqual(20, obj.Id);
+            Assert.AreEqual("Hank", obj.Name);
+            Assert.AreEqual(0.0, obj.Score);
+        }
+
+        [TestMethod]
+        public void CopyFrom_NullType_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try { XCopy.CopyFrom(null!, new Base(), row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        [TestMethod]
+        public void CopyFrom_ExplicitType_NullData_ThrowsArgumentNullException()
+        {
+            var table = BuildTable();
+            var row = table.AddRow();
+
+            try { XCopy.CopyFrom(typeof(Base), null!, row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        // ── WriteTo(Type, ...) 显式类型重载 ──────────────────────────────────
+
+        [TestMethod]
+        public void WriteTo_ExplicitBaseType_OnlyCreatesBaseColumns()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+            var obj = new Derived { Id = 30, Name = "Ivy", Score = 2.0 };
+
+            // 显式指定 Base 类型，Score 列不应被创建
+            XCopy.WriteTo(typeof(Base), obj, row);
+
+            Assert.AreEqual(30, table.Columns.Get("Id").Get(row));
+            Assert.AreEqual("Ivy", table.Columns.Get("Name").Get(row));
+            Assert.IsNull(table.Columns.Find("Score"));
+        }
+
+        [TestMethod]
+        public void WriteTo_NullType_ThrowsArgumentNullException()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+
+            try { XCopy.WriteTo(null!, new Base(), row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        [TestMethod]
+        public void WriteTo_ExplicitType_NullData_ThrowsArgumentNullException()
+        {
+            var table = new RecordTable();
+            var row = table.AddRow();
+
+            try { XCopy.WriteTo(typeof(Base), null!, row); Assert.Fail("Expected ArgumentNullException"); }
+            catch (ArgumentNullException) { }
+        }
+
+        // ── 缓存一致性 ────────────────────────────────────────────────────────
+
+        [TestMethod]
+        public void CopyTo_CalledTwice_ProducesConsistentResults()
+        {
+            var table = BuildTable();
+            var row1 = table.AddRow();
+            var row2 = table.AddRow();
+            var obj = new Base { Id = 40, Name = "Jack" };
+
+            XCopy.CopyTo(obj, row1);
+            XCopy.CopyTo(obj, row2);
+
+            Assert.AreEqual(40, table.Columns.Get("Id").Get(row1));
+            Assert.AreEqual(40, table.Columns.Get("Id").Get(row2));
         }
     }
 }


### PR DESCRIPTION
新增 CopyTo/CopyFrom/WriteTo(Type, ...) 重载，允许显式指定属性扫描类型，仅处理基类属性。泛型实现同步调整，参数校验更严格。完善相关测试，覆盖类型限定与异常分支，提升类型安全与灵活性。