### PR TITLE
feat: remove ArrayRank from RecordColumn, add Binary type for byte[]

### DIFF
--- a/src/LuYao.Common/Data/Helpers.cs
+++ b/src/LuYao.Common/Data/Helpers.cs
@@ -30,6 +30,7 @@ static class Helpers
         [typeof(DateTimeOffset)] = RecordColumnType.DateTimeOffset,
         [typeof(TimeSpan)] = RecordColumnType.TimeSpan,
         [typeof(Guid)] = RecordColumnType.Guid,
+        [typeof(byte[])] = RecordColumnType.Binary,
     };
 
     private static readonly Dictionary<RecordColumnType, Type> ColumnTypeToType;
@@ -44,20 +45,17 @@ static class Helpers
     }
 
     /// <summary>
-    /// 从 CLR <see cref="Type"/> 获取基础 <see cref="RecordColumnType"/>（不含 Nullable 信息和数组维度）。
+    /// From CLR <see cref="Type"/> get the base <see cref="RecordColumnType"/> (excluding Nullable and array info).
     /// </summary>
     internal static RecordColumnType GetColumnType(Type type)
     {
-        var lookup = NormalizeColumnLookupType(type);
-
-        // 剥离数组维度，只看元素类型
-        if (lookup.IsArray)
+        // byte[] maps directly to Binary
+        if (type == typeof(byte[]))
         {
-            lookup = lookup.GetElementType()!;
-            // 数组元素可能是可空类型（如 int?[]），需要再次规范化
-            lookup = Nullable.GetUnderlyingType(lookup) ?? lookup;
-            lookup = lookup.IsEnum ? Enum.GetUnderlyingType(lookup) : lookup;
+            return RecordColumnType.Binary;
         }
+
+        var lookup = NormalizeColumnLookupType(type);
 
         if (TypeToColumnType.TryGetValue(lookup, out var ct))
             return ct;
@@ -69,41 +67,19 @@ static class Helpers
     /// </summary>
     internal static bool IsNullableType(Type type)
     {
-        // 检查数组元素类型
-        if (type.IsArray)
-        {
-            var elementType = type.GetElementType();
-            if (elementType != null)
-            {
-                return Nullable.GetUnderlyingType(elementType) != null;
-            }
-        }
-
         return Nullable.GetUnderlyingType(type) != null;
     }
 
     /// <summary>
     /// 从基础 <see cref="RecordColumnType"/>、<paramref name="isNullable"/> 和 <paramref name="arrayRank"/> 还原 CLR <see cref="Type"/>。
     /// </summary>
-    internal static Type GetClrType(RecordColumnType columnType, bool isNullable, int arrayRank = 0)
+    internal static Type GetClrType(RecordColumnType columnType, bool isNullable)
     {
+        if (columnType == RecordColumnType.Binary)
+            return typeof(byte[]);
+
         if (!ColumnTypeToType.TryGetValue(columnType, out var baseType))
             throw new NotSupportedException($"未知列类型枚举值: {columnType}");
-
-        // 处理数组维度
-        if (arrayRank > 0)
-        {
-            // 如果数组元素是可空的值类型，需要先构造可空类型再构造数组
-            if (isNullable && baseType.IsValueType)
-            {
-                baseType = typeof(Nullable<>).MakeGenericType(baseType);
-            }
-
-            baseType = (arrayRank == 1) 
-                ? baseType.MakeArrayType() 
-                : baseType.MakeArrayType(arrayRank);
-            return baseType;
-        }
 
         if (isNullable && baseType.IsValueType)
             return typeof(Nullable<>).MakeGenericType(baseType);
@@ -115,17 +91,11 @@ static class Helpers
     internal static bool IsSupportedColumnType(Type type)
     {
         if (type == null) return false;
+
+        // byte[] is directly supported as Binary
+        if (type == typeof(byte[])) return true;
+
         var normalized = NormalizeColumnLookupType(type);
-
-        // 支持数组类型
-        if (normalized.IsArray)
-        {
-            var elementType = normalized.GetElementType()!;
-            // 递归展开数组元素类型（处理 int?[] 等情况）
-            elementType = Nullable.GetUnderlyingType(elementType) ?? elementType;
-            normalized = elementType.IsEnum ? Enum.GetUnderlyingType(elementType) : elementType;
-        }
-
         return TypeToColumnType.ContainsKey(normalized);
     }
 

--- a/src/LuYao.Common/Data/RecordColumn.T.cs
+++ b/src/LuYao.Common/Data/RecordColumn.T.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Globalization;
-using LuYao.Text.Json;
 
 namespace LuYao.Data;
 
@@ -67,15 +65,7 @@ public class RecordColumn<T> : RecordColumn
         }
         else
         {
-            // 数组类型特殊处理：尝试直接转换
-            if (typeof(T).IsArray && value is Array)
-            {
-                _data[row] = (T)value;
-            }
-            else
-            {
-                _data[row] = (T)Valid.To(value, this.Type);
-            }
+            _data[row] = (T)Valid.To(value, this.Type);
         }
     }
 
@@ -86,127 +76,15 @@ public class RecordColumn<T> : RecordColumn
         T value = _data[row];
         if (value is null) return string.Empty;
 
-        // 数组类型返回 JSON 格式
-        if (value is Array array)
+        // byte[] columns return Base64 string
+        if (value is byte[] bytes)
         {
-            return FormatArrayAsJson(array);
+            return Convert.ToBase64String(bytes);
         }
 
         return value.ToString() ?? string.Empty;
     }
 
-    /// <summary>
-    /// 将数组格式化为 JSON 字符串。
-    /// </summary>
-    private static string FormatArrayAsJson(Array array)
-    {
-        var sb = new System.Text.StringBuilder();
-        using var writer = new JsonWriter(sb, spaceAfterComma: true);
-
-        if (array.Rank == 1)
-        {
-            WriteOneDimensionalArray(writer, array);
-        }
-        else
-        {
-            WriteMultiDimensionalArray(writer, array, new int[array.Rank], 0);
-        }
-
-        writer.Flush();
-        return sb.ToString();
-    }
-
-    private static void WriteOneDimensionalArray(JsonWriter writer, Array array)
-    {
-        writer.WriteStartArray();
-        for (int i = 0; i < array.Length; i++)
-        {
-            var element = array.GetValue(i);
-            WriteJsonValue(writer, element);
-        }
-        writer.WriteEndArray();
-    }
-
-    private static void WriteMultiDimensionalArray(JsonWriter writer, Array array, int[] indices, int dimension)
-    {
-        writer.WriteStartArray();
-        int length = array.GetLength(dimension);
-        for (int i = 0; i < length; i++)
-        {
-            indices[dimension] = i;
-
-            if (dimension == array.Rank - 1)
-            {
-                var element = array.GetValue(indices);
-                WriteJsonValue(writer, element);
-            }
-            else
-            {
-                WriteMultiDimensionalArray(writer, array, indices, dimension + 1);
-            }
-        }
-        writer.WriteEndArray();
-    }
-
-    private static void WriteJsonValue(JsonWriter writer, object? value)
-    {
-        if (value is null)
-        {
-            writer.WriteNull();
-        }
-        else if (value is string str)
-        {
-            writer.WriteValue(str);
-        }
-        else if (value is char ch)
-        {
-            writer.WriteValue(ch.ToString());
-        }
-        else if (value is bool b)
-        {
-            writer.WriteValue(b);
-        }
-        else if (value is DateTime dt)
-        {
-            writer.WriteValue(dt.ToString("o", CultureInfo.InvariantCulture));
-        }
-        else if (value is DateTimeOffset dto)
-        {
-            writer.WriteValue(dto.ToString("o", CultureInfo.InvariantCulture));
-        }
-        else if (value is TimeSpan ts)
-        {
-            writer.WriteValue(ts.ToString("c", CultureInfo.InvariantCulture));
-        }
-        else if (value is Guid guid)
-        {
-            writer.WriteValue(guid.ToString());
-        }
-        else if (value is float f)
-        {
-            writer.WriteRaw(float.IsNaN(f) || float.IsInfinity(f) ? "null" : f.ToString("R", CultureInfo.InvariantCulture));
-        }
-        else if (value is double d)
-        {
-            writer.WriteRaw(double.IsNaN(d) || double.IsInfinity(d) ? "null" : d.ToString("R", CultureInfo.InvariantCulture));
-        }
-        else if (value is decimal dec)
-        {
-            writer.WriteRaw(dec.ToString(CultureInfo.InvariantCulture));
-        }
-        else if (value is sbyte or byte or short or ushort or int or uint or long or ulong)
-        {
-            writer.WriteRaw(Convert.ToString(value, CultureInfo.InvariantCulture)!);
-        }
-        else if (value is Enum)
-        {
-            writer.WriteValue(value.ToString());
-        }
-        else
-        {
-            writer.WriteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
-        }
-    }
 
     internal override void Extend(int length)
     {

--- a/src/LuYao.Common/Data/RecordColumn.cs
+++ b/src/LuYao.Common/Data/RecordColumn.cs
@@ -28,7 +28,6 @@ public abstract class RecordColumn : IXProp
         this.Table = table ?? throw new ArgumentNullException(nameof(table));
         this.Name = name ?? throw new ArgumentNullException(nameof(name));
         this._type = type ?? throw new ArgumentNullException(nameof(type));
-        this.ArrayRank = DetermineArrayRank(type);
         this.ColumnType = Helpers.GetColumnType(type);
         this.IsNullable = Helpers.IsNullableType(type);
     }
@@ -55,19 +54,6 @@ public abstract class RecordColumn : IXProp
     /// </summary>
     public bool IsNullable { get; }
 
-    /// <summary>
-    /// 获取数组维度。0 表示非数组，1 表示一维数组（如 int[]），2 表示二维数组（如 int[,]），依此类推。
-    /// </summary>
-    public int ArrayRank { get; }
-
-    /// <summary>
-    /// 确定类型的数组维度。
-    /// </summary>
-    private static int DetermineArrayRank(Type type)
-    {
-        var effectiveType = Nullable.GetUnderlyingType(type) ?? type;
-        return effectiveType.IsArray ? effectiveType.GetArrayRank() : 0;
-    }
 
     /// <summary>
     /// 在指定行设置列的值。
@@ -149,12 +135,6 @@ public abstract class RecordColumn : IXProp
         object? value = this.Get(row);
         if (value is null) return default;
         if (value is T direct) return direct;
-
-        // 数组类型无法通过 Convert.ChangeType 转换，但可能是兼容的数组类型
-        if (typeof(T).IsArray && value is Array)
-        {
-            return (T)value;
-        }
 
         return (T)Valid.To(value, typeof(T));
     }

--- a/src/LuYao.Common/Data/RecordColumnType.cs
+++ b/src/LuYao.Common/Data/RecordColumnType.cs
@@ -59,4 +59,7 @@ public enum RecordColumnType : byte
 
     /// <summary>全局唯一标识符 (<see cref="System.Guid"/>)。</summary>
     Guid = 18,
+
+    /// <summary>字节数组 (<see cref="T:byte[]"/>)。</summary>
+    Binary = 19,
 }

--- a/src/LuYao.Common/Data/RecordSchema.cs
+++ b/src/LuYao.Common/Data/RecordSchema.cs
@@ -41,21 +41,15 @@ public sealed class RecordSchema
         public bool IsNullable { get; }
 
         /// <summary>
-        /// 数组维度。0 表示非数组，1 表示一维数组，2 表示二维数组，依此类推。
-        /// </summary>
-        public int ArrayRank { get; }
-
-        /// <summary>
         /// 列的 CLR 数据类型。
         /// </summary>
-        public Type Type => Helpers.GetClrType(ColumnType, IsNullable, ArrayRank);
+        public Type Type => Helpers.GetClrType(ColumnType, IsNullable);
 
-        internal ColumnDef(string name, RecordColumnType columnType, bool isNullable, int arrayRank = 0)
+        internal ColumnDef(string name, RecordColumnType columnType, bool isNullable)
         {
             Name = name;
             ColumnType = columnType;
             IsNullable = isNullable;
-            ArrayRank = arrayRank;
         }
     }
 }

--- a/src/LuYao.Common/Data/RecordTable.cs
+++ b/src/LuYao.Common/Data/RecordTable.cs
@@ -529,7 +529,7 @@ public partial class RecordTable : IEnumerable<RecordRow>
         var columns = new List<RecordSchema.ColumnDef>(this.Columns.Count);
         foreach (RecordColumn col in this.Columns)
         {
-            columns.Add(new RecordSchema.ColumnDef(col.Name, col.ColumnType, col.IsNullable, col.ArrayRank));
+            columns.Add(new RecordSchema.ColumnDef(col.Name, col.ColumnType, col.IsNullable));
         }
         return new RecordSchema(columns);
     }

--- a/src/LuYao.Common/Data/RecordTable/Binary.cs
+++ b/src/LuYao.Common/Data/RecordTable/Binary.cs
@@ -7,7 +7,7 @@ namespace LuYao.Data;
 public partial class RecordTable
 {
     // 二进制格式版本号，用于未来兼容性检查
-    private const byte BinaryFormatVersion = 1;
+    private const byte BinaryFormatVersion = 2;
 
     /// <summary>
     /// 将当前 <see cref="RecordTable"/> 写入二进制流。
@@ -37,7 +37,7 @@ public partial class RecordTable
         writer.Write(this._pageSize);
         writer.Write(this._maxCount);
 
-        // Schema: column count + (name, type, isNullable, arrayRank) per column
+        // Schema: column count + (name, type, isNullable) per column
         writer.Write(this.Columns.Count);
         for (int c = 0; c < this.Columns.Count; c++)
         {
@@ -45,7 +45,6 @@ public partial class RecordTable
             writer.Write(col.Name);
             writer.Write((byte)col.ColumnType);
             writer.Write(col.IsNullable);
-            writer.Write((byte)col.ArrayRank);
         }
 
         // Row count
@@ -97,8 +96,7 @@ public partial class RecordTable
             string name = reader.ReadString();
             var columnType = (RecordColumnType)reader.ReadByte();
             bool isNullable = reader.ReadBoolean();
-            int arrayRank = reader.ReadByte();
-            Type clrType = Helpers.GetClrType(columnType, isNullable, arrayRank);
+            Type clrType = Helpers.GetClrType(columnType, isNullable);
             this.Columns.Add(name, clrType);
         }
 
@@ -169,7 +167,8 @@ public partial class RecordTable
 
     private static void WriteColumnData(BinaryWriter writer, RecordColumn col, int rowCount)
     {
-        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || col.ArrayRank > 0;
+        bool isBinary = col.ColumnType == RecordColumnType.Binary;
+        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || isBinary;
 
         for (int r = 0; r < rowCount; r++)
         {
@@ -184,9 +183,11 @@ public partial class RecordTable
                 writer.Write(true);
             }
 
-            if (col.ArrayRank > 0)
+            if (isBinary)
             {
-                WriteArrayValue(writer, (Array)val!, col.ColumnType);
+                var bytes = (byte[])val!;
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
             }
             else
             {
@@ -197,7 +198,8 @@ public partial class RecordTable
 
     private static void ReadColumnData(BinaryReader reader, RecordColumn col, int rowCount)
     {
-        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || col.ArrayRank > 0;
+        bool isBinary = col.ColumnType == RecordColumnType.Binary;
+        bool needsNullCheck = col.IsNullable || col.ColumnType == RecordColumnType.String || isBinary;
 
         for (int r = 0; r < rowCount; r++)
         {
@@ -208,9 +210,10 @@ public partial class RecordTable
             }
 
             object val;
-            if (col.ArrayRank > 0)
+            if (isBinary)
             {
-                val = ReadArrayValue(reader, col.ColumnType, col.ArrayRank, col.IsNullable);
+                int len = reader.ReadInt32();
+                val = reader.ReadBytes(len);
             }
             else
             {
@@ -220,89 +223,6 @@ public partial class RecordTable
         }
     }
 
-    private static void WriteArrayValue(BinaryWriter writer, Array array, RecordColumnType elementType)
-    {
-        int rank = array.Rank;
-        writer.Write((byte)rank);
-
-        // 写入各维度长度
-        for (int i = 0; i < rank; i++)
-        {
-            writer.Write(array.GetLength(i));
-        }
-
-        // 写入元素（扁平化遍历）
-        int totalElements = array.Length;
-        int[] indices = new int[rank];
-
-        for (int flatIndex = 0; flatIndex < totalElements; flatIndex++)
-        {
-            GetMultiDimensionalIndices(flatIndex, array, indices);
-            var element = array.GetValue(indices);
-
-            // 元素可能为 null（如 int?[] 或 string[]）
-            if (element == null)
-            {
-                writer.Write(false);
-                continue;
-            }
-
-            writer.Write(true);
-            WritePrimitiveValue(writer, element, elementType);
-        }
-    }
-
-    private static Array ReadArrayValue(BinaryReader reader, RecordColumnType elementType, int expectedRank, bool isElementNullable)
-    {
-        int rank = reader.ReadByte();
-        if (rank != expectedRank)
-        {
-            throw new InvalidOperationException($"数组维度不匹配：期望 {expectedRank}，实际 {rank}");
-        }
-
-        // 读取各维度长度
-        int[] lengths = new int[rank];
-        int totalElements = 1;
-        for (int i = 0; i < rank; i++)
-        {
-            lengths[i] = reader.ReadInt32();
-            totalElements *= lengths[i];
-        }
-
-        // 创建数组（考虑元素是否可空）
-        Type clrType = Helpers.GetClrType(elementType, isNullable: isElementNullable, arrayRank: 0);
-        Array array = rank == 1 
-            ? Array.CreateInstance(clrType, lengths[0])
-            : Array.CreateInstance(clrType, lengths);
-
-        // 读取元素
-        int[] indices = new int[rank];
-        for (int flatIndex = 0; flatIndex < totalElements; flatIndex++)
-        {
-            GetMultiDimensionalIndices(flatIndex, array, indices);
-
-            bool hasValue = reader.ReadBoolean();
-            if (!hasValue) continue;
-
-            var element = ReadPrimitiveValue(reader, elementType);
-            array.SetValue(element, indices);
-        }
-
-        return array;
-    }
-
-    private static void GetMultiDimensionalIndices(int flatIndex, Array array, int[] indices)
-    {
-        int rank = array.Rank;
-        int remaining = flatIndex;
-
-        for (int i = rank - 1; i >= 0; i--)
-        {
-            int length = array.GetLength(i);
-            indices[i] = remaining % length;
-            remaining /= length;
-        }
-    }
 
     private static void WritePrimitiveValue(BinaryWriter writer, object value, RecordColumnType columnType)
     {

--- a/tests/LuYao.Common.UnitTests/Data/RecordArrayTypeTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordArrayTypeTests.cs
@@ -1,696 +1,277 @@
-using System;
-using System.Globalization;
-using System.Linq;
+﻿using System;
 
 namespace LuYao.Data;
 
 /// <summary>
-/// 测试 RecordTable 对数组类型的支持。
+/// Tests for RecordTable Binary (byte[]) column type support.
 /// </summary>
 [TestClass]
 public class RecordArrayTypeTests
 {
-    #region 基础功能测试
+    #region Basic Binary column tests
 
     [TestMethod]
-    public void WhenAddOneDimensionalArrayColumnThenArrayRankIsOne()
+    public void WhenAddBinaryColumnThenColumnTypeIsBinary()
     {
         var table = new RecordTable("Test");
-        var col = table.Columns.Add<int[]>("Scores");
+        var col = table.Columns.Add<byte[]>("Data");
 
-        Assert.AreEqual(1, col.ArrayRank);
-        Assert.AreEqual(typeof(int[]), col.Type);
-        Assert.AreEqual(RecordColumnType.Int32, col.ColumnType);
+        Assert.AreEqual(RecordColumnType.Binary, col.ColumnType);
+        Assert.AreEqual(typeof(byte[]), col.Type);
     }
 
     [TestMethod]
-    public void WhenAddTwoDimensionalArrayColumnThenArrayRankIsTwo()
-    {
-        var table = new RecordTable("Test");
-        var col = table.Columns.Add<int[,]>("Matrix");
-
-        Assert.AreEqual(2, col.ArrayRank);
-        Assert.AreEqual(typeof(int[,]), col.Type);
-        Assert.AreEqual(RecordColumnType.Int32, col.ColumnType);
-    }
-
-    [TestMethod]
-    public void WhenAddThreeDimensionalArrayColumnThenArrayRankIsThree()
-    {
-        var table = new RecordTable("Test");
-        var col = table.Columns.Add<int[,,]>("Cube");
-
-        Assert.AreEqual(3, col.ArrayRank);
-        Assert.AreEqual(typeof(int[,,]), col.Type);
-        Assert.AreEqual(RecordColumnType.Int32, col.ColumnType);
-    }
-
-    [TestMethod]
-    public void WhenAddNonArrayColumnThenArrayRankIsZero()
+    public void WhenAddNonArrayColumnThenColumnTypeIsCorrect()
     {
         var table = new RecordTable("Test");
         var col = table.Columns.Add<int>("Value");
 
-        Assert.AreEqual(0, col.ArrayRank);
+        Assert.AreEqual(RecordColumnType.Int32, col.ColumnType);
         Assert.AreEqual(typeof(int), col.Type);
     }
 
     #endregion
 
-    #region 一维数组数据操作
+    #region Binary data operations
 
     [TestMethod]
-    public void WhenSetAndGetIntArrayThenValuesPreserved()
+    public void WhenSetAndGetByteArrayThenValuesPreserved()
     {
         var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
+        table.Columns.Add<byte[]>("Data");
 
         var row = table.AddRow();
-        row["Scores"] = new[] { 85, 90, 88, 92 };
+        row["Data"] = new byte[] { 1, 2, 3, 4, 5 };
 
-        var retrieved = row.To<int[]>("Scores");
+        var retrieved = row.To<byte[]>("Data");
         Assert.IsNotNull(retrieved);
-        Assert.AreEqual(4, retrieved.Length);
-        Assert.AreEqual(85, retrieved[0]);
-        Assert.AreEqual(90, retrieved[1]);
-        Assert.AreEqual(88, retrieved[2]);
-        Assert.AreEqual(92, retrieved[3]);
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, retrieved);
     }
 
     [TestMethod]
-    public void WhenSetAndGetStringArrayThenValuesPreserved()
+    public void WhenSetNullByteArrayThenGetReturnsNull()
     {
         var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Tags");
+        table.Columns.Add<byte[]>("Data");
 
         var row = table.AddRow();
-        row["Tags"] = new[] { "VIP", "Premium", "Active" };
+        row["Data"] = null;
 
-        var retrieved = row.To<string[]>("Tags");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(3, retrieved.Length);
-        Assert.AreEqual("VIP", retrieved[0]);
-        Assert.AreEqual("Premium", retrieved[1]);
-        Assert.AreEqual("Active", retrieved[2]);
-    }
-
-    [TestMethod]
-    public void WhenSetNullArrayThenGetReturnsNull()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
-
-        var row = table.AddRow();
-        row["Scores"] = null;
-
-        var retrieved = row.To<int[]>("Scores");
+        var retrieved = row.To<byte[]>("Data");
         Assert.IsNull(retrieved);
     }
 
     [TestMethod]
-    public void WhenSetEmptyArrayThenGetReturnsEmptyArray()
+    public void WhenSetEmptyByteArrayThenGetReturnsEmptyArray()
     {
         var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
+        table.Columns.Add<byte[]>("Data");
 
         var row = table.AddRow();
-        row["Scores"] = new int[0];
+        row["Data"] = new byte[0];
 
-        var retrieved = row.To<int[]>("Scores");
+        var retrieved = row.To<byte[]>("Data");
         Assert.IsNotNull(retrieved);
         Assert.AreEqual(0, retrieved.Length);
     }
 
     #endregion
 
-    #region 多维数组数据操作
+    #region Binary serialization tests
 
     [TestMethod]
-    public void WhenSetAndGetTwoDimensionalArrayThenValuesPreserved()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<decimal[,]>("PriceMatrix");
-
-        var row = table.AddRow();
-        var matrix = new decimal[,] { { 1.1m, 2.2m }, { 3.3m, 4.4m } };
-        row["PriceMatrix"] = matrix;
-
-        var retrieved = row.To<decimal[,]>("PriceMatrix");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(2, retrieved.GetLength(0));
-        Assert.AreEqual(2, retrieved.GetLength(1));
-        Assert.AreEqual(1.1m, retrieved[0, 0]);
-        Assert.AreEqual(2.2m, retrieved[0, 1]);
-        Assert.AreEqual(3.3m, retrieved[1, 0]);
-        Assert.AreEqual(4.4m, retrieved[1, 1]);
-    }
-
-    [TestMethod]
-    public void WhenSetAndGetThreeDimensionalArrayThenValuesPreserved()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int[,,]>("Cube");
-
-        var row = table.AddRow();
-        var cube = new int[2, 2, 2]
-        {
-            { { 1, 2 }, { 3, 4 } },
-            { { 5, 6 }, { 7, 8 } }
-        };
-        row["Cube"] = cube;
-
-        var retrieved = row.To<int[,,]>("Cube");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(2, retrieved.GetLength(0));
-        Assert.AreEqual(2, retrieved.GetLength(1));
-        Assert.AreEqual(2, retrieved.GetLength(2));
-        Assert.AreEqual(1, retrieved[0, 0, 0]);
-        Assert.AreEqual(8, retrieved[1, 1, 1]);
-    }
-
-    #endregion
-
-    #region 数组元素可空性
-
-    [TestMethod]
-    public void WhenSetNullableIntArrayWithNullElementsThenPreserved()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int?[]>("NullableScores");
-
-        var row = table.AddRow();
-        row["NullableScores"] = new int?[] { 85, null, 88, null, 92 };
-
-        var retrieved = row.To<int?[]>("NullableScores");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(5, retrieved.Length);
-        Assert.AreEqual(85, retrieved[0]);
-        Assert.IsNull(retrieved[1]);
-        Assert.AreEqual(88, retrieved[2]);
-        Assert.IsNull(retrieved[3]);
-        Assert.AreEqual(92, retrieved[4]);
-    }
-
-    [TestMethod]
-    public void WhenSetStringArrayWithNullElementsThenPreserved()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Tags");
-
-        var row = table.AddRow();
-        row["Tags"] = new string[] { "VIP", null, "Active" };
-
-        var retrieved = row.To<string[]>("Tags");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(3, retrieved.Length);
-        Assert.AreEqual("VIP", retrieved[0]);
-        Assert.IsNull(retrieved[1]);
-        Assert.AreEqual("Active", retrieved[2]);
-    }
-
-    #endregion
-
-    #region 二进制序列化测试
-
-    [TestMethod]
-    public void WhenSerializeOneDimensionalArrayThenRoundTripSucceeds()
+    public void WhenSerializeByteArrayThenRoundTripSucceeds()
     {
         var original = new RecordTable("Test");
-        original.Columns.Add<int[]>("Scores");
-        original.Columns.Add<string[]>("Tags");
+        original.Columns.Add<byte[]>("Data");
 
         var row = original.AddRow();
-        row["Scores"] = new[] { 85, 90, 88, 92 };
-        row["Tags"] = new[] { "VIP", "Premium" };
+        row["Data"] = new byte[] { 10, 20, 30, 40 };
 
         var bytes = original.ToBytes();
         var deserialized = RecordTable.FromBytes(bytes);
 
         Assert.AreEqual(1, deserialized.Count);
-        Assert.AreEqual(2, deserialized.Columns.Count);
-
-        var scoresCol = deserialized.Columns.Find<int[]>("Scores");
-        Assert.IsNotNull(scoresCol);
-        Assert.AreEqual(1, scoresCol.ArrayRank);
-
-        var scores = deserialized[0].To<int[]>("Scores");
-        Assert.IsNotNull(scores);
-        CollectionAssert.AreEqual(new[] { 85, 90, 88, 92 }, scores);
-
-        var tags = deserialized[0].To<string[]>("Tags");
-        Assert.IsNotNull(tags);
-        CollectionAssert.AreEqual(new[] { "VIP", "Premium" }, tags);
+        var data = deserialized[0].To<byte[]>("Data");
+        CollectionAssert.AreEqual(new byte[] { 10, 20, 30, 40 }, data);
     }
 
     [TestMethod]
-    public void WhenSerializeTwoDimensionalArrayThenRoundTripSucceeds()
+    public void WhenSerializeNullByteArrayThenRoundTripSucceeds()
     {
         var original = new RecordTable("Test");
-        original.Columns.Add<int[,]>("Matrix");
+        original.Columns.Add<byte[]>("Data");
 
         var row = original.AddRow();
-        var matrix = new int[,] { { 1, 2, 3 }, { 4, 5, 6 } };
-        row["Matrix"] = matrix;
+        row["Data"] = null;
 
         var bytes = original.ToBytes();
         var deserialized = RecordTable.FromBytes(bytes);
 
-        var retrieved = deserialized[0].To<int[,]>("Matrix");
-        Assert.IsNotNull(retrieved);
-        Assert.AreEqual(2, retrieved.GetLength(0));
-        Assert.AreEqual(3, retrieved.GetLength(1));
-        Assert.AreEqual(1, retrieved[0, 0]);
-        Assert.AreEqual(6, retrieved[1, 2]);
+        Assert.IsNull(deserialized[0].To<byte[]>("Data"));
     }
 
     [TestMethod]
-    public void WhenSerializeArrayWithNullElementsThenRoundTripSucceeds()
+    public void WhenSerializeEmptyByteArrayThenRoundTripSucceeds()
     {
         var original = new RecordTable("Test");
-        original.Columns.Add<int?[]>("NullableScores");
-        original.Columns.Add<string[]>("Tags");
+        original.Columns.Add<byte[]>("Data");
 
         var row = original.AddRow();
-        row["NullableScores"] = new int?[] { 85, null, 88 };
-        row["Tags"] = new string[] { "VIP", null, "Active" };
+        row["Data"] = new byte[0];
 
         var bytes = original.ToBytes();
         var deserialized = RecordTable.FromBytes(bytes);
 
-        // 验证可空元素数组
-        var scoresObj = deserialized[0]["NullableScores"];
-        Assert.IsNotNull(scoresObj);
-        Assert.IsInstanceOfType(scoresObj, typeof(int?[]));
-        var scores = (int?[])scoresObj;
-        Assert.AreEqual(3, scores.Length);
-        Assert.AreEqual(85, scores[0]);
-        Assert.IsNull(scores[1]);
-        Assert.AreEqual(88, scores[2]);
-
-        // 验证引用类型元素数组
-        var tags = deserialized[0].To<string[]>("Tags");
-        Assert.IsNotNull(tags);
-        Assert.AreEqual(3, tags.Length);
-        Assert.AreEqual("VIP", tags[0]);
-        Assert.IsNull(tags[1]);
-        Assert.AreEqual("Active", tags[2]);
+        var data = deserialized[0].To<byte[]>("Data");
+        Assert.IsNotNull(data);
+        Assert.AreEqual(0, data.Length);
     }
 
     [TestMethod]
-    public void WhenSerializeNullArrayThenRoundTripSucceeds()
-    {
-        var original = new RecordTable("Test");
-        original.Columns.Add<int[]>("Scores");
-
-        var row = original.AddRow();
-        row["Scores"] = null;
-
-        var bytes = original.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var scores = deserialized[0].To<int[]>("Scores");
-        Assert.IsNull(scores);
-    }
-
-    [TestMethod]
-    public void WhenSerializeEmptyArrayThenRoundTripSucceeds()
-    {
-        var original = new RecordTable("Test");
-        original.Columns.Add<int[]>("Scores");
-
-        var row = original.AddRow();
-        row["Scores"] = new int[0];
-
-        var bytes = original.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var scores = deserialized[0].To<int[]>("Scores");
-        Assert.IsNotNull(scores);
-        Assert.AreEqual(0, scores.Length);
-    }
-
-    [TestMethod]
-    public void WhenSerializeMultipleRowsWithArraysThenAllRowsPreserved()
+    public void WhenSerializeMultipleRowsWithByteArrayThenAllRowsPreserved()
     {
         var original = new RecordTable("Test");
         original.Columns.Add<int>("Id");
-        original.Columns.Add<int[]>("Scores");
+        original.Columns.Add<byte[]>("Data");
 
         for (int i = 1; i <= 3; i++)
         {
             var row = original.AddRow();
             row["Id"] = i;
-            row["Scores"] = new[] { i * 10, i * 20, i * 30 };
+            row["Data"] = new byte[] { (byte)i, (byte)(i * 2) };
         }
 
         var bytes = original.ToBytes();
         var deserialized = RecordTable.FromBytes(bytes);
 
         Assert.AreEqual(3, deserialized.Count);
-
         for (int i = 0; i < 3; i++)
         {
             var id = deserialized[i].To<int>("Id");
-            var scores = deserialized[i].To<int[]>("Scores");
-
+            var data = deserialized[i].To<byte[]>("Data");
             Assert.AreEqual(i + 1, id);
-            Assert.IsNotNull(scores);
-            Assert.AreEqual(3, scores.Length);
-            Assert.AreEqual((i + 1) * 10, scores[0]);
-            Assert.AreEqual((i + 1) * 20, scores[1]);
-            Assert.AreEqual((i + 1) * 30, scores[2]);
+            CollectionAssert.AreEqual(new byte[] { (byte)(i + 1), (byte)((i + 1) * 2) }, data);
         }
     }
 
     #endregion
 
-    #region ToString JSON 格式测试
+    #region ToString tests
 
     [TestMethod]
-    public void WhenToStringOnOneDimensionalIntArrayThenReturnsJsonFormat()
+    public void WhenToStringOnByteArrayThenReturnsBase64()
     {
         var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
+        table.Columns.Add<byte[]>("Data");
 
         var row = table.AddRow();
-        row["Scores"] = new[] { 85, 90, 88 };
+        row["Data"] = new byte[] { 1, 2, 3 };
 
-        var str = row.ToString("Scores");
-        Assert.AreEqual("[85, 90, 88]", str);
+        var str = row.ToString("Data");
+        Assert.AreEqual(Convert.ToBase64String(new byte[] { 1, 2, 3 }), str);
     }
 
     [TestMethod]
-    public void WhenToStringOnOneDimensionalStringArrayThenReturnsJsonFormat()
+    public void WhenToStringOnNullByteArrayThenReturnsEmptyString()
     {
         var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Tags");
+        table.Columns.Add<byte[]>("Data");
 
         var row = table.AddRow();
-        row["Tags"] = new[] { "VIP", "Premium" };
+        row["Data"] = null;
 
-        var str = row.ToString("Tags");
-        Assert.AreEqual("[\"VIP\", \"Premium\"]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnTwoDimensionalArrayThenReturnsJsonFormat()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int[,]>("Matrix");
-
-        var row = table.AddRow();
-        row["Matrix"] = new int[,] { { 1, 2 }, { 3, 4 } };
-
-        var str = row.ToString("Matrix");
-        Assert.AreEqual("[[1, 2], [3, 4]]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnEmptyArrayThenReturnsEmptyJsonArray()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
-
-        var row = table.AddRow();
-        row["Scores"] = new int[0];
-
-        var str = row.ToString("Scores");
-        Assert.AreEqual("[]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnNullArrayThenReturnsEmptyString()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<int[]>("Scores");
-
-        var row = table.AddRow();
-        row["Scores"] = null;
-
-        var str = row.ToString("Scores");
+        var str = row.ToString("Data");
         Assert.AreEqual("", str);
     }
 
-    [TestMethod]
-    public void WhenToStringOnArrayWithNullElementsThenReturnsJsonWithNull()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Tags");
-
-        var row = table.AddRow();
-        row["Tags"] = new string[] { "VIP", null, "Active" };
-
-        var str = row.ToString("Tags");
-        Assert.AreEqual("[\"VIP\", null, \"Active\"]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnStringArrayWithSpecialCharactersThenEscaped()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Messages");
-
-        var row = table.AddRow();
-        row["Messages"] = new[] { "Hello \"World\"", "Line1\nLine2", "Tab\tSeparated" };
-
-        var str = row.ToString("Messages");
-        Assert.AreEqual("[\"Hello \\\"World\\\"\", \"Line1\\nLine2\", \"Tab\\tSeparated\"]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnStringArrayWithControlCharactersThenEscaped()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<string[]>("Messages");
-
-        var row = table.AddRow();
-        row["Messages"] = new[] { "Back\bSpace", "Form\fFeed", "\u0001" };
-
-        var str = row.ToString("Messages");
-        Assert.AreEqual("[\"Back\\bSpace\", \"Form\\fFeed\", \"\\u0001\"]", str);
-    }
-
-    [TestMethod]
-    public void WhenToStringOnDecimalArrayWithDifferentCultureThenUsesInvariantCulture()
-    {
-        var originalCulture = CultureInfo.CurrentCulture;
-        try
-        {
-            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
-
-            var table = new RecordTable("Test");
-            table.Columns.Add<decimal[]>("Amounts");
-
-            var row = table.AddRow();
-            row["Amounts"] = new[] { 1.5m, 2.75m };
-
-            var str = row.ToString("Amounts");
-            Assert.AreEqual("[1.5, 2.75]", str);
-        }
-        finally
-        {
-            CultureInfo.CurrentCulture = originalCulture;
-        }
-    }
-
     #endregion
 
-    #region RecordSchema 测试
+    #region RecordSchema tests
 
     [TestMethod]
-    public void WhenGetSchemaWithArrayColumnsThenArrayRankIncluded()
+    public void WhenGetSchemaWithBinaryColumnThenColumnTypeIsBinary()
     {
         var table = new RecordTable("Test");
         table.Columns.Add<int>("Id");
-        table.Columns.Add<int[]>("Scores");
-        table.Columns.Add<string[,]>("Matrix");
+        table.Columns.Add<byte[]>("Data");
 
         var schema = table.GetSchema();
 
-        Assert.AreEqual(3, schema.Columns.Count);
+        Assert.AreEqual(2, schema.Columns.Count);
 
         var idCol = schema.Columns[0];
         Assert.AreEqual("Id", idCol.Name);
-        Assert.AreEqual(0, idCol.ArrayRank);
         Assert.AreEqual(typeof(int), idCol.Type);
 
-        var scoresCol = schema.Columns[1];
-        Assert.AreEqual("Scores", scoresCol.Name);
-        Assert.AreEqual(1, scoresCol.ArrayRank);
-        Assert.AreEqual(typeof(int[]), scoresCol.Type);
-
-        var matrixCol = schema.Columns[2];
-        Assert.AreEqual("Matrix", matrixCol.Name);
-        Assert.AreEqual(2, matrixCol.ArrayRank);
-        Assert.AreEqual(typeof(string[,]), matrixCol.Type);
+        var dataCol = schema.Columns[1];
+        Assert.AreEqual("Data", dataCol.Name);
+        Assert.AreEqual(RecordColumnType.Binary, dataCol.ColumnType);
+        Assert.AreEqual(typeof(byte[]), dataCol.Type);
     }
 
     #endregion
 
-    #region 各种元素类型测试
+    #region Delete operation tests
 
     [TestMethod]
-    public void WhenUseBoolArrayThenSerializationWorks()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<bool[]>("Flags");
-
-        var row = table.AddRow();
-        row["Flags"] = new[] { true, false, true };
-
-        var bytes = table.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var flags = deserialized[0].To<bool[]>("Flags");
-        CollectionAssert.AreEqual(new[] { true, false, true }, flags);
-    }
-
-    [TestMethod]
-    public void WhenUseLongArrayThenSerializationWorks()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<long[]>("Ids");
-
-        var row = table.AddRow();
-        row["Ids"] = new[] { 1000000000L, 2000000000L, 3000000000L };
-
-        var bytes = table.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var ids = deserialized[0].To<long[]>("Ids");
-        CollectionAssert.AreEqual(new[] { 1000000000L, 2000000000L, 3000000000L }, ids);
-    }
-
-    [TestMethod]
-    public void WhenUseDoubleArrayThenSerializationWorks()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<double[]>("Values");
-
-        var row = table.AddRow();
-        row["Values"] = new[] { 1.1, 2.2, 3.3 };
-
-        var bytes = table.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var values = deserialized[0].To<double[]>("Values");
-        Assert.AreEqual(3, values.Length);
-        Assert.AreEqual(1.1, values[0], 0.0001);
-        Assert.AreEqual(2.2, values[1], 0.0001);
-        Assert.AreEqual(3.3, values[2], 0.0001);
-    }
-
-    [TestMethod]
-    public void WhenUseDateTimeArrayThenSerializationWorks()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<DateTime[]>("Dates");
-
-        var row = table.AddRow();
-        var dates = new[] { new DateTime(2024, 1, 1), new DateTime(2024, 6, 15), new DateTime(2024, 12, 31) };
-        row["Dates"] = dates;
-
-        var bytes = table.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var retrievedDates = deserialized[0].To<DateTime[]>("Dates");
-        Assert.AreEqual(3, retrievedDates.Length);
-        Assert.AreEqual(new DateTime(2024, 1, 1), retrievedDates[0]);
-        Assert.AreEqual(new DateTime(2024, 6, 15), retrievedDates[1]);
-        Assert.AreEqual(new DateTime(2024, 12, 31), retrievedDates[2]);
-    }
-
-    [TestMethod]
-    public void WhenUseGuidArrayThenSerializationWorks()
-    {
-        var table = new RecordTable("Test");
-        table.Columns.Add<Guid[]>("Ids");
-
-        var row = table.AddRow();
-        var guids = new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-        row["Ids"] = guids;
-
-        var bytes = table.ToBytes();
-        var deserialized = RecordTable.FromBytes(bytes);
-
-        var retrievedGuids = deserialized[0].To<Guid[]>("Ids");
-        CollectionAssert.AreEqual(guids, retrievedGuids);
-    }
-
-    #endregion
-
-    #region 删除操作测试
-
-    [TestMethod]
-    public void WhenDeleteRowWithArrayColumnThenDataShiftsCorrectly()
+    public void WhenDeleteRowWithBinaryColumnThenDataShiftsCorrectly()
     {
         var table = new RecordTable("Test");
         table.Columns.Add<int>("Id");
-        table.Columns.Add<int[]>("Scores");
+        table.Columns.Add<byte[]>("Data");
 
         for (int i = 1; i <= 3; i++)
         {
             var row = table.AddRow();
             row["Id"] = i;
-            row["Scores"] = new[] { i * 10, i * 20 };
+            row["Data"] = new byte[] { (byte)i };
         }
 
-        table.Delete(1); // 删除第二行
+        table.Delete(1);
 
         Assert.AreEqual(2, table.Count);
         Assert.AreEqual(1, table[0].To<int>("Id"));
-        CollectionAssert.AreEqual(new[] { 10, 20 }, table[0].To<int[]>("Scores"));
+        CollectionAssert.AreEqual(new byte[] { 1 }, table[0].To<byte[]>("Data"));
         Assert.AreEqual(3, table[1].To<int>("Id"));
-        CollectionAssert.AreEqual(new[] { 30, 60 }, table[1].To<int[]>("Scores"));
+        CollectionAssert.AreEqual(new byte[] { 3 }, table[1].To<byte[]>("Data"));
     }
 
     #endregion
 
-    #region Clone 操作测试
+    #region Clone operation tests
 
     [TestMethod]
-    public void WhenCloneRecordWithArrayColumnsThenDataCopied()
+    public void WhenCloneRecordWithBinaryColumnThenDataCopied()
     {
         var original = new RecordTable("Test");
         original.Columns.Add<int>("Id");
-        original.Columns.Add<int[]>("Scores");
+        original.Columns.Add<byte[]>("Data");
 
         var row = original.AddRow();
         row["Id"] = 1;
-        row["Scores"] = new[] { 85, 90, 88 };
+        row["Data"] = new byte[] { 1, 2, 3 };
 
         var clone = original.Clone();
 
         Assert.AreEqual(1, clone.Count);
         Assert.AreEqual(2, clone.Columns.Count);
-        Assert.AreEqual(1, clone.Columns.Find<int[]>("Scores")!.ArrayRank);
-
-        var scores = clone[0].To<int[]>("Scores");
-        CollectionAssert.AreEqual(new[] { 85, 90, 88 }, scores);
-
-        // 修改克隆不影响原始
-        var cloneRow = clone[0];
-        cloneRow["Scores"] = new[] { 100, 100 };
-        var originalScores = original[0].To<int[]>("Scores");
-        CollectionAssert.AreEqual(new[] { 85, 90, 88 }, originalScores);
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, clone[0].To<byte[]>("Data"));
     }
 
     [TestMethod]
-    public void WhenCloneSchemaWithArrayColumnsThenStructureCopied()
+    public void WhenCloneSchemaWithBinaryColumnThenStructureCopied()
     {
         var original = new RecordTable("Test");
         original.Columns.Add<int>("Id");
-        original.Columns.Add<int[]>("Scores");
-        original.Columns.Add<string[,]>("Matrix");
+        original.Columns.Add<byte[]>("Data");
 
         var clone = original.CloneSchema();
 
         Assert.AreEqual(0, clone.Count);
-        Assert.AreEqual(3, clone.Columns.Count);
-
-        Assert.AreEqual(0, clone.Columns[0].ArrayRank);
-        Assert.AreEqual(1, clone.Columns[1].ArrayRank);
-        Assert.AreEqual(2, clone.Columns[2].ArrayRank);
+        Assert.AreEqual(2, clone.Columns.Count);
+        Assert.AreEqual(RecordColumnType.Int32, clone.Columns[0].ColumnType);
+        Assert.AreEqual(RecordColumnType.Binary, clone.Columns[1].ColumnType);
     }
 
     #endregion

--- a/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
+++ b/tests/LuYao.Common.UnitTests/Data/RecordSerializationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 
 namespace LuYao.Data;
@@ -94,9 +94,8 @@ public class RecordSerializationTests
         var table = new RecordTable("Binary", 1);
         var col = table.Columns.Add<byte[]>("Data");
 
-        // byte[] 现在作为一维数组处理
-        Assert.AreEqual(1, col.ArrayRank);
-        Assert.AreEqual(RecordColumnType.Byte, col.ColumnType);
+        Assert.AreEqual(RecordColumnType.Binary, col.ColumnType);
+        Assert.AreEqual(typeof(byte[]), col.Type);
 
         var row = table.AddRow();
         col.SetValue(row.Row, new byte[] { 1, 2, 3, 4, 5 });
@@ -105,7 +104,7 @@ public class RecordSerializationTests
         var deserialized = RecordTable.FromBytes(bytes);
 
         var deserializedCol = deserialized.Columns.Find<byte[]>("Data")!;
-        Assert.AreEqual(1, deserializedCol.ArrayRank);
+        Assert.AreEqual(RecordColumnType.Binary, deserializedCol.ColumnType);
 
         var data = deserializedCol.GetValue(0);
         CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4, 5 }, data);


### PR DESCRIPTION
- Add RecordColumnType.Binary (= 19) to represent byte[]
- Remove ArrayRank property and DetermineArrayRank from RecordColumn
- Update Helpers: map byte[] to Binary, simplify GetClrType/IsNullableType
- Bump binary format version to 2 (schema no longer stores arrayRank byte)
- Replace array serialization helpers with direct Binary read/write
- Remove multi-dimensional array support from RecordColumn.T.cs
- ToString for Binary columns returns Base64 string
- Update RecordSchema.ColumnDef: remove ArrayRank
- Rewrite RecordArrayTypeTests for Binary/byte[] column type
- Fix RecordSerializationTests assertions for byte[] column